### PR TITLE
Fix appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,9 @@
 version: 1.0.{build}
 pull_requests:
   do_not_increment_build_number: true
-image:
-- Visual Studio 2017
-- Visual Studio 2017 Preview
-- Visual Studio 2015
+image: Visual Studio 2017
 configuration: Release
 platform: x86
-before_build:
-- cmd: '"%VS140COMNTOOLS%\..\IDE\devenv.exe" /Upgrade Diablo.dsw & exit 0'
 build:
   project: Diablo.sln
   verbosity: minimal


### PR DESCRIPTION
The AppVeyor script was broken by https://github.com/diasurgical/devilution/commit/0c01fc41ad17db59603b19acaa807db185fcff8f. I had to remove the before_build command because it causes the build to hang if the solution and project files already exist in the location it's trying to upgrade. I also had to remove the VS2017 Preview and VS2015 images because they don't succeed with the VS2017 solution and project files.

You may need to go cancel a few builds in AppVeyor manually. I notice that there aren't any pass/fail results on any of the most recent commits.