### PR TITLE
gendung_418D91 refactor

### DIFF
--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -163,8 +163,21 @@ void __cdecl gendung_418D91()
 	char level_cel_index;
 	unsigned char frame_num;
 
+	//fourth block
+	int total_level_frame_size;
+	int level_frame_size_index;
+	int frame_multiplier;
+
+	//fifth block
+	int ligthing_flag_enable;
+	int level_frame_total_size;
+	int lighting_flag_index;
+	int speed_light_index;
+	char* light_table_ptr;
+	int level_frame_size_val;
 	//
 	char* speed_cel_ptr;
+	char level_cel_val;
 
 	//v0 = 0;
 	memset(level_frame_types, 0, sizeof(level_frame_types));
@@ -413,14 +426,13 @@ LABEL_36:
 	*/
 	//////////////////////////
 	gendung_4191BF(2047);
-	int total_level_frame_size = 0;
-	int level_frame_size_index = 0;
-	const int frame_multiplier = light4flag ? 2 : 14;
-	do
+	total_level_frame_size = 0;
+	level_frame_size_index = 0;
+	frame_multiplier = light4flag ? 2 : 14;
+	while (total_level_frame_size < 0x100000)
 	{
 		total_level_frame_size += frame_multiplier * level_frame_sizes[level_frame_size_index++];
 	}
-	while (total_level_frame_size < 0x100000);
 	//////////////////////////
 	/*v22 = v20 - 1;
 	v58 = v22;
@@ -542,35 +554,33 @@ LABEL_66:
 	* eax only can be 0 or -1...
 	*/
 	
-	if (--level_frame_size_index > 128)// limit the counter to 128
+	if (--level_frame_size_index > 128)// limit the index to 128
 	{
 		level_frame_size_index = 128;
 	}
-	int ligthing_flag_enable = -(light4flag != 0); // 0 if 0 else -1
-	int level_frame_total_size = 0;
-	int lighting_flag_index = (ligthing_flag_enable & 0xF4) + 0xF;
+	ligthing_flag_enable = -(light4flag != 0); // 0 if 0 else -1
+	level_frame_total_size = 0;
+	lighting_flag_index = (ligthing_flag_enable & 0xF4) + 0xF;
 	level_frame_types_index = 0;
 	if (level_frame_size_index > 0)
 	{
 		int speed_light_multiplier_index = 0;
 		int (*speed_cel_frame_num_from_light_index_frame_num_ptr)[128] = speed_cel_frame_num_from_light_index_frame_num;
-		do
+		for(level_frame_types_index = 0; level_frame_types_index < level_frame_size_index; level_frame_types_index++)
 		{
 			//Tile tile_defs_ = tile_defs[level_frame_types_index2];
 			int tile_defs_val = *((_DWORD *)&tile_defs[0].top + level_frame_types_index);
 			(*speed_cel_frame_num_from_light_index_frame_num_ptr)[0] = tile_defs_val;
 			if (level_frame_types[level_frame_types_index] == 4096)
 			{
-				int speed_light_index = 1;
-				do
+				for(speed_light_index = 1; speed_light_index < lighting_flag_index; speed_light_index++)
 				{
 					speed_cel_frame_num_from_light_index_frame_num[0][speed_light_index + speed_light_multiplier_index] = level_frame_total_size;
-					char* dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[tile_defs_val];
+					dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[tile_defs_val];
 					speed_cel_ptr  = (char *)pSpeedCels + level_frame_total_size;
-					char* light_table_ptr = (char *)pLightTbl + 0x100 * speed_light_index;
+					light_table_ptr = (char *)pLightTbl + 0x100 * speed_light_index;
 					for (i = 0; i < 32; i++)
 					{
-						char level_cel_val;
 						for(j = 32; j != 0; j-= level_cel_val)
 						{
 							while (1)
@@ -598,30 +608,27 @@ LABEL_66:
 						}
 					}
 					level_frame_total_size += level_frame_sizes[level_frame_types_index];
-					++speed_light_index;
-				} while (speed_light_index < lighting_flag_index);
+				}
 			}
 			else
 			{
-				int level_frame_size_val = level_frame_sizes[level_frame_types_index];
-				int speed_light_index = 1;
+				level_frame_size_val = level_frame_sizes[level_frame_types_index];
 				for(speed_light_index = 1; speed_light_index < lighting_flag_index; speed_light_index++)
 				{
 					speed_cel_frame_num_from_light_index_frame_num[0][speed_light_index + speed_light_multiplier_index] = level_frame_total_size;
-					char* level_cel_ptr4 = (char *)dungeon_cel + *((_DWORD *)dungeon_cel + tile_defs_val);
-					char* light_table_ptr = (char *)pLightTbl + 0x100 * speed_light_index;
+					dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[tile_defs_val];
+					light_table_ptr = (char *)pLightTbl + 0x100 * speed_light_index;
 					speed_cel_ptr = (char *)pSpeedCels + level_frame_total_size;
 					for (i = 0; i < level_frame_size_val; i++)
 					{
-						*speed_cel_ptr++ = light_table_ptr[*level_cel_ptr4++];
+						*speed_cel_ptr++ = light_table_ptr[*dungeon_cel_ptr++];
 					}
 					level_frame_total_size += level_frame_size_val;
 				}
 			}
-			++level_frame_types_index;
 			speed_cel_frame_num_from_light_index_frame_num_ptr = (int(*)[128])((char *)speed_cel_frame_num_from_light_index_frame_num_ptr + 64);
 			speed_light_multiplier_index += 16;
-		} while (level_frame_types_index < level_frame_size_index);
+		}
 	}
 	//////////////////////////
 	/*

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -468,8 +468,7 @@ LABEL_36:
 	}
 	while (total_level_frame_size < 0x100000);
 	//////////////////////////
-	/*
-	v22 = v20 - 1;
+	/*v22 = v20 - 1;
 	v58 = v22;
 	if ( v22 > 128 )
 	{
@@ -577,8 +576,7 @@ LABEL_66:
 			v56 += 16;
 		}
 		while ( v54 < v22 );
-	}
-	*/
+	}*/
 	//////////////////////////
 	/*
 	*.text:00418FB5 neg     eax
@@ -589,6 +587,7 @@ LABEL_66:
 	* eax = -(eax != 0)
 	* eax only can be 0 or -1...
 	*/
+	
 	if (--level_frame_size_index > 128)// limit the counter to 128
 	{
 		level_frame_size_index = 128;
@@ -606,8 +605,8 @@ LABEL_66:
 		{
 			int level_frame_types_index_save = level_frame_types_index2;
 			int level_frame_types_equal_0x1000 = level_frame_types[level_frame_types_index2] == 4096;
-			Tile tile_defs_ = tile_defs[level_frame_types_index2];
-			int tile_defs_val = ((int)tile_defs_.top) << sizeof(short) | (int)tile_defs_.right;
+			//Tile tile_defs_ = tile_defs[level_frame_types_index2];
+			int tile_defs_val = *((_DWORD *)&tile_defs[0].top + level_frame_types_index2);
 			(*speed_cel_frame_num_from_light_index_frame_num1)[0] = tile_defs_val;
 			if (level_frame_types_equal_0x1000)
 			{
@@ -694,6 +693,7 @@ LABEL_66:
 		} while (level_frame_types_index2 < level_frame_size_index);
 	}
 	//////////////////////////
+	/*
 	v57 = dPiece;
 	v55 = dpiece_defs_map_2;
 	do
@@ -742,7 +742,61 @@ LABEL_66:
 		v55 = (short (*)[112][112])((char *)v55 + 32);
 		v57 = (int (*)[112])((char *)v57 + 4);
 	}
-	while ( (signed int)v55 < (signed int)dpiece_defs_map_2[0][16] ); /* check */
+	while ( (signed int)v55 < (signed int)dpiece_defs_map_2[0][16] );
+	*/
+	//////////////////////////
+	int result = 0;
+	int (*piece_pid_map_ptr)[112] = dPiece;
+	short (*dpieces_defs_map2_ptr)[112][112] = dpiece_defs_map_2;
+	do
+	{
+		int map_length2 = 112;
+		short* dpieces_defs_map3_ptr = (short *)dpieces_defs_map2_ptr;
+		int(*piece_pid_map_ptr2)[112] = piece_pid_map_ptr;
+		do
+		{
+			result = (short)piece_pid_map_ptr2;
+			if ((*piece_pid_map_ptr2)[0])
+			{
+				result = dungeon_type;
+				if (dungeon_type > 0)
+				{
+					short* dpieces_defs_map4_ptr = dpieces_defs_map3_ptr;
+					int dungeon_type2 = dungeon_type;
+					do
+					{
+						result = *dpieces_defs_map4_ptr;
+						if (*dpieces_defs_map4_ptr)
+						{
+							int level_frame_size_index2 = 0;
+							if (level_frame_size_index2 > 0)
+							{
+								do
+								{
+									if ((result & 0xFFF) == *((_DWORD *)&tile_defs[0].top + level_frame_size_index2))
+									{
+										v45 = level_frame_size_index2 + level_frame_types[level_frame_size_index2];
+										level_frame_size_index2 = level_frame_size_index;
+										result = v45 + -32768;
+									}
+									++level_frame_size_index2;
+								} while (level_frame_size_index2 < level_frame_size_index);
+								*dpieces_defs_map4_ptr = result;
+							}
+						}
+						++dpieces_defs_map4_ptr;
+						--dungeon_type2;
+					} while (dungeon_type2);
+				}
+			}
+			++piece_pid_map_ptr2;
+			dpieces_defs_map3_ptr += 1792;
+			--map_length2;
+		} while (map_length2);
+		dpieces_defs_map2_ptr = (short(*)[112][112])((char *)dpieces_defs_map2_ptr + 32);
+		piece_pid_map_ptr = (int(*)[112])((char *)piece_pid_map_ptr + 4);
+	} while ((signed int)dpieces_defs_map2_ptr < (signed int)dpiece_defs_map_2[0][16]);
+	//return result;
 }
 // 525728: using guessed type int light4flag;
 // 53CD4C: using guessed type int nlevel_frames;

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -175,7 +175,16 @@ void __cdecl gendung_418D91()
 	int speed_light_index;
 	char* light_table_ptr;
 	int level_frame_size_val;
+
+	//sixth block
+	int result = 0;
+	int(*piece_pid_map_ptr)[112];
+	int(*piece_pid_map_ptr2)[112];
+	short* dpieces_defs_map3_ptr;
+	short* dpieces_defs_map4_ptr;
+
 	//
+
 	char* speed_cel_ptr;
 	char level_cel_val;
 
@@ -683,17 +692,17 @@ LABEL_66:
 	while ( (signed int)v55 < (signed int)dpiece_defs_map_2[0][16] );
 	*/
 	//////////////////////////
-	int result = 0;
-	int (*piece_pid_map_ptr)[112] = dPiece;
+	result = 0;
+	piece_pid_map_ptr = dPiece;
 	for (i = 0; i < map_length_times_thirty_two; i++)
 	{
-		short* dpieces_defs_map3_ptr = dpiece_defs_map_2[0][0];
-		int(*piece_pid_map_ptr2)[112] = piece_pid_map_ptr;
+		dpieces_defs_map3_ptr = dpiece_defs_map_2[0][0];
+		piece_pid_map_ptr2 = piece_pid_map_ptr;
 		for(j = 0; j < map_length; j++)
 		{
 			if ((*piece_pid_map_ptr2)[0] && (dungeon_type_iterations > 0))
 			{
-				short* dpieces_defs_map4_ptr = dpieces_defs_map3_ptr;
+				dpieces_defs_map4_ptr = dpieces_defs_map3_ptr;
 				for (k = 0; k < dungeon_type_iterations; k++)
 				{
 					result = *dpieces_defs_map4_ptr;
@@ -705,9 +714,8 @@ LABEL_66:
 							{
 								if ((result & 0xFFF) == *((_DWORD *)&tile_defs[0].top + l))
 								{
-									int val = l + level_frame_types[l];
 									level_frame_types_index = l;
-									result = val + -32768;
+									result = l + level_frame_types[l] + -32768;
 								}
 							}
 							*dpieces_defs_map4_ptr = result;

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -142,6 +142,7 @@ void __cdecl gendung_418D91()
 	int i;
 	int j;
 	int k;
+	int h;
 
 	//first block
 	int dungeon_type_iterations;
@@ -323,23 +324,21 @@ LABEL_36:
 	}
 	*/
 	////////////////////////////
-	level_frame_types_index = 0;
 	level_frame_sizes[0] = 0;
-	if (leveltype == DTYPE_HELL && nlevel_frames > 0)
+	if (leveltype == DTYPE_HELL)
 	{
-		do
+		level_frame_count[0] = 0;
+		for (level_frame_types_index = 0; level_frame_types_index < nlevel_frames; level_frame_types_index++)
 		{
-			if (!level_frame_types_index)
-				level_frame_count[0] = 0;
 			set_level_frame_count_zero = 1;
 			if (level_frame_count[level_frame_types_index])
 			{
 				if (level_frame_types[level_frame_types_index] == 4096)
 				{
 					dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[level_frame_types_index];
-					for(i = 0; i < 32; i++)
+					for (j = 0; j < 32; j++)
 					{
-						for (j = 32; j != 0; j -= level_cel_index)
+						for (k = 32; k != 0; k -= level_cel_index)
 						{
 							while (1)
 							{
@@ -349,18 +348,18 @@ LABEL_36:
 									break;
 								//else iterate and go to next dungeon cel ptr
 								level_cel_index = -level_cel_index;
-								j -= level_cel_index;
-								if (!j)
+								k -= level_cel_index;
+								if (!k)
 								{
 									break;
 								}
 							}
-							if (!j)
+							if (!k)
 							{
 								break;
 							}
 
-							for (k = 0; k < level_cel_index; k++)
+							for (h = 0; h < level_cel_index; h++)
 							{
 								frame_num = *dungeon_cel_ptr++;
 								if (frame_num < 32 && frame_num > 0) //check frame type
@@ -374,7 +373,7 @@ LABEL_36:
 				else
 				{
 					dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[level_frame_types_index];
-					for (i = 0; i < level_frame_sizes[level_frame_types_index]; i++)
+					for (j = 0; j < level_frame_sizes[level_frame_types_index]; j++)
 					{
 						unsigned char frame_num = *dungeon_cel_ptr++;
 						if (frame_num < 32 && frame_num > 0) //check frame type
@@ -388,8 +387,7 @@ LABEL_36:
 					level_frame_count[level_frame_types_index] = 0;
 				}
 			}
-			++level_frame_types_index;
-		} while (level_frame_types_index < nlevel_frames);
+		}
 	}
 	
 	//////////////////////////

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -138,68 +138,32 @@ LABEL_13:
 
 void __cdecl gendung_418D91()
 {
-	signed int v0; // edx
-	short (*v1)[112][112]; // edi
-	short (*v2)[112][112]; // esi
-	signed int v3; // ebx
-	int i; // edx
-	short v5; // ax
-	int v6; // ecx
-	signed int v7; // edx
-	int v8; // eax
-	int v9; // edi
-	char *v10; // esi
-	int j; // ecx
-	unsigned char v12; // al
-	unsigned char *v13; // esi
-	int v14; // ecx
-	signed int v15; // edx
-	int v16; // eax
-	int v17; // ecx
-	unsigned char v18; // al
-	signed int v19; // ecx
-	int v20; // edi
-	int v21; // edx
-	int v22; // edi
-	int v23; // eax
-	int v24; // eax
-	bool v25; // zf
-	int v26; // edx
-	char *v27; // esi
-	char *speed_cel_ptr; // edi
-	int k; // ecx
-	char *v33; // esi
-	char *v34; // edi
-	int v36; // ecx
-	signed int v37; // edx
-	int v38; // eax
-	int v39; // ecx
-	short (*v42)[112][112]; // esi
-	short v43; // ax
-	unsigned short v44; // dx
-	short v45; // ax
-	int v46; // [esp-4h] [ebp-38h]
-	int v47; // [esp-4h] [ebp-38h]
-	int v48; // [esp+Ch] [ebp-28h]
-	int (*v49)[128]; // [esp+10h] [ebp-24h]
-	int (*v50)[112]; // [esp+10h] [ebp-24h]
-	int v51; // [esp+14h] [ebp-20h]
-	short (*v52)[112][112]; // [esp+14h] [ebp-20h]
-	signed int v53; // [esp+18h] [ebp-1Ch]
-	int v54; // [esp+18h] [ebp-1Ch]
-	short (*v55)[112][112]; // [esp+18h] [ebp-1Ch]
-	int v56; // [esp+1Ch] [ebp-18h]
-	int (*v57)[112]; // [esp+1Ch] [ebp-18h]
-	signed int v58; // [esp+20h] [ebp-14h]
-	int v59; // [esp+20h] [ebp-14h]
-	int v60; // [esp+24h] [ebp-10h]
-	signed int v61; // [esp+24h] [ebp-10h]
-	int v62; // [esp+28h] [ebp-Ch]
-	int v63; // [esp+2Ch] [ebp-8h]
-	signed int v64; // [esp+30h] [ebp-4h]
-	signed int v65; // [esp+30h] [ebp-4h]
-	int _EAX;
-	char *_EBX;
+	//iteator variables
+	int i;
+	int j;
+	int k;
+
+	//first block
+	int dungeon_type_iterations;
+	int map_length; //112
+	int map_length_times_thirty_two; //112 * 32 (0xE00)
+	short* dpiece_defs_map_2_ptr; //iterating through map entries
+	short map_block_info; // TODO add ref
+	short frame; // TODO add ref
+
+	//second block
+	int* dungeon_cel;
+	int frame_size;
+
+	//third block
+	int level_frame_types_index;
+	char set_level_frame_count_zero; //really should be a bool (is project using c99/c11?)
+	char* dungeon_cel_ptr;
+	char level_cel_index;
+	unsigned char frame_num;
+
+	//
+	char* speed_cel_ptr;
 
 	//v0 = 0;
 	memset(level_frame_types, 0, sizeof(level_frame_types));
@@ -245,29 +209,27 @@ void __cdecl gendung_418D91()
 	}
 	while ( (signed int)v1 < (signed int)dpiece_defs_map_2[0][16] );
 	*/
-	int dungeon_type_iterations = 2 * (leveltype == DTYPE_HELL) + 10;
-	int map_length = sizeof(dpiece_defs_map_2[0][0]) / sizeof(dpiece_defs_map_2[0][0][0]);
-	short(*dpiece_defs_map_2_ptr)[112][112] = dpiece_defs_map_2;
-	do
+	dungeon_type_iterations = 2 * (leveltype == DTYPE_HELL) + 10; //12 if in HELL else 10
+	map_length = sizeof(dpiece_defs_map_2[0][0]) / sizeof(dpiece_defs_map_2[0][0][0]);
+	map_length_times_thirty_two = map_length * 32;
+	dpiece_defs_map_2_ptr = dpiece_defs_map_2[0][0];
+	for (i = 0; i < map_length_times_thirty_two; i++)
 	{
-		short(*dpiece_defs_map_2_ptr2)[112] = dpiece_defs_map_2[0];
-		int current_map_index = map_length;
-		do
+		for(j = 0; j < map_length; j++)
 		{
-			for(i = 0; i < dungeon_type_iterations; i++)
+			for (k = 0; k < dungeon_type_iterations; k++)
 			{
-				short map_block_info = (*dpiece_defs_map_2_ptr2)[i];
-				if(map_block_info)
+				map_block_info = dpiece_defs_map_2_ptr[k + j * map_length_times_thirty_two/2];
+				if (map_block_info)
 				{
-					short frame = map_block_info & 0x0FFF;
+					frame = map_block_info & 0x0FFF;
 					++level_frame_count[frame];
 					level_frame_types[frame] = map_block_info & 0x7000;
 				}
 			}
-			dpiece_defs_map_2_ptr2 += 16;
-		} while (--current_map_index);
-		dpiece_defs_map_2_ptr = (short(*)[112][112])((char *)dpiece_defs_map_2_ptr + 32);
-	} while ((char*)dpiece_defs_map_2_ptr < (char*)dpiece_defs_map_2[0][16]);
+		}
+		dpiece_defs_map_2_ptr += 16;
+	}
 	///////////////////////////
 	/*
 	v7 = 1;
@@ -285,13 +247,12 @@ void __cdecl gendung_418D91()
 	}
 	*/
 	////////////////////////////
-	i = 1;
-	int* dungeon_cel = (int*)pDungeonCels;
+	dungeon_cel = (int*)pDungeonCels;
 	nlevel_frames = dungeon_cel[0] & 0xFFFF;
 	for (i = 1; i < nlevel_frames; i++)
 	{
-		const int cel_val = dungeon_cel[i + 1] - dungeon_cel[i];
-		level_frame_sizes[i] = cel_val & 0xFFFF;
+		frame_size = dungeon_cel[i + 1] - dungeon_cel[i];
+		level_frame_sizes[i] = frame_size & 0xFFFF;
 	}
 	////////////////////////////
 	/*
@@ -362,7 +323,7 @@ LABEL_36:
 	}
 	*/
 	////////////////////////////
-	int level_frame_types_index = 0;
+	level_frame_types_index = 0;
 	level_frame_sizes[0] = 0;
 	if (leveltype == DTYPE_HELL && nlevel_frames > 0)
 	{
@@ -370,15 +331,14 @@ LABEL_36:
 		{
 			if (!level_frame_types_index)
 				level_frame_count[0] = 0;
-			char set_level_frame_count_zero = 1; //really should be a bool (is project using c99/c11?)
+			set_level_frame_count_zero = 1;
 			if (level_frame_count[level_frame_types_index])
 			{
 				if (level_frame_types[level_frame_types_index] == 4096)
 				{
-					char* dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[level_frame_types_index];
+					dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[level_frame_types_index];
 					for(i = 0; i < 32; i++)
 					{
-						char level_cel_index;
 						for (j = 32; j != 0; j -= level_cel_index)
 						{
 							while (1)
@@ -402,7 +362,7 @@ LABEL_36:
 
 							for (k = 0; k < level_cel_index; k++)
 							{
-								unsigned char frame_num = *dungeon_cel_ptr++;
+								frame_num = *dungeon_cel_ptr++;
 								if (frame_num < 32 && frame_num > 0) //check frame type
 								{
 									set_level_frame_count_zero = 0;
@@ -413,7 +373,7 @@ LABEL_36:
 				}
 				else
 				{
-					char* dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[level_frame_types_index];
+					dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[level_frame_types_index];
 					for (i = 0; i < level_frame_sizes[level_frame_types_index]; i++)
 					{
 						unsigned char frame_num = *dungeon_cel_ptr++;

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -166,7 +166,7 @@ void __cdecl gendung_418D91()
 	bool v25; // zf
 	int v26; // edx
 	char *v27; // esi
-	char *v28; // edi
+	char *speed_cel_ptr; // edi
 	int k; // ecx
 	char *v33; // esi
 	char *v34; // edi
@@ -376,44 +376,40 @@ LABEL_36:
 				if (level_frame_types[level_frame_types_index] == 4096)
 				{
 					char* dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[level_frame_types_index];
-					int level_cel_size = 32;
-					do
+					for(i = 0; i < 32; i++)
 					{
-						int level_cel_size_check = 32;
-						do
+						char level_cel_index;
+						for (j = 32; j != 0; j -= level_cel_index)
 						{
-							char level_cel_block = 0;
-							char level_cel_break = 0;
-							while (!level_cel_break)
+							while (1)
 							{
-								level_cel_block = *dungeon_cel_ptr++;
+								level_cel_index = *dungeon_cel_ptr++;
 								//check msb (0 is valid)
-								if ((level_cel_block & 0x80u) == 0)
+								if ((level_cel_index & 0x80u) == 0)
 									break;
 								//else iterate and go to next dungeon cel ptr
-								level_cel_block = -level_cel_block;
-								level_cel_size_check -= level_cel_block;
-								if (!level_cel_size_check)
+								level_cel_index = -level_cel_index;
+								j -= level_cel_index;
+								if (!j)
 								{
-									level_cel_break = 1;
+									break;
 								}
 							}
-							if (level_cel_break)
+							if (!j)
 							{
 								break;
 							}
 
-							level_cel_size_check -= level_cel_block;
-							do
+							for (k = 0; k < level_cel_index; k++)
 							{
 								unsigned char frame_num = *dungeon_cel_ptr++;
 								if (frame_num < 32 && frame_num > 0) //check frame type
 								{
 									set_level_frame_count_zero = 0;
 								}
-							} while (--level_cel_block);
-						} while (level_cel_size_check);
-					} while (--level_cel_size);
+							}
+						}
+					}
 				}
 				else
 				{
@@ -592,105 +588,82 @@ LABEL_66:
 	{
 		level_frame_size_index = 128;
 	}
-	int ligthing_flags_enable = -(light4flag != 0); // 0 if 0 else -1
-	int add_val = 0;
-	_LOBYTE(ligthing_flags_enable) = ligthing_flags_enable & 0xF4;
-	int level_frame_types_index2 = 0;
-	int ligthing_flags_enable_plus_0xF = ligthing_flags_enable + 0xF;
+	int ligthing_flag_enable = -(light4flag != 0); // 0 if 0 else -1
+	int level_frame_total_size = 0;
+	int lighting_flag_index = (ligthing_flag_enable & 0xF4) + 0xF;
+	level_frame_types_index = 0;
 	if (level_frame_size_index > 0)
 	{
-		int speed_light_index2 = 0;
-		int (*speed_cel_frame_num_from_light_index_frame_num1)[128] = speed_cel_frame_num_from_light_index_frame_num;
+		int speed_light_multiplier_index = 0;
+		int (*speed_cel_frame_num_from_light_index_frame_num_ptr)[128] = speed_cel_frame_num_from_light_index_frame_num;
 		do
 		{
-			int level_frame_types_index_save = level_frame_types_index2;
-			int level_frame_types_equal_0x1000 = level_frame_types[level_frame_types_index2] == 4096;
 			//Tile tile_defs_ = tile_defs[level_frame_types_index2];
-			int tile_defs_val = *((_DWORD *)&tile_defs[0].top + level_frame_types_index2);
-			(*speed_cel_frame_num_from_light_index_frame_num1)[0] = tile_defs_val;
-			if (level_frame_types_equal_0x1000)
+			int tile_defs_val = *((_DWORD *)&tile_defs[0].top + level_frame_types_index);
+			(*speed_cel_frame_num_from_light_index_frame_num_ptr)[0] = tile_defs_val;
+			if (level_frame_types[level_frame_types_index] == 4096)
 			{
 				int speed_light_index = 1;
-				if (ligthing_flags_enable_plus_0xF > 1)// always true... if original value was 1
+				do
 				{
-					do
+					speed_cel_frame_num_from_light_index_frame_num[0][speed_light_index + speed_light_multiplier_index] = level_frame_total_size;
+					char* dungeon_cel_ptr = (char*)dungeon_cel + dungeon_cel[tile_defs_val];
+					speed_cel_ptr  = (char *)pSpeedCels + level_frame_total_size;
+					char* light_table_ptr = (char *)pLightTbl + 0x100 * speed_light_index;
+					for (i = 0; i < 32; i++)
 					{
-						speed_cel_frame_num_from_light_index_frame_num[0][speed_light_index + speed_light_index2] = add_val;
-						char* level_cel_ptr3 = (char *)dungeon_cel + *((_DWORD *)dungeon_cel + tile_defs_val);
-						char* speed_cel_ptr = (char *)pSpeedCels + add_val;
-						_EBX = (char *)pLightTbl + 0x100 * speed_light_index;// not useless, used for xlat
-						int thirty_two_to_0_ = 32;
-						int thirty_two_to_0 = 0;
-						do
+						char level_cel_val;
+						for(j = 32; j != 0; j-= level_cel_val)
 						{
-							thirty_two_to_0 = thirty_two_to_0_;
-							int is_zero = 32;
-							do
+							while (1)
 							{
-								int level_cel_val6 = 0;
-								while (1)
+								level_cel_val = *dungeon_cel_ptr++;
+								*speed_cel_ptr++ = level_cel_val;
+								if ((level_cel_val & 0x80u) == 0)
+									break;
+								level_cel_val = -level_cel_val;
+								j -= level_cel_val;
+								if (!j)
 								{
-									level_cel_val6 = (unsigned __int8)*level_cel_ptr3++;
-									*speed_cel_ptr++ = level_cel_val6;
-									if ((level_cel_val6 & 0x80u) == 0)
-										break;
-									_LOBYTE(level_cel_val6) = -(char)level_cel_val6;
-									is_zero -= level_cel_val6;
-									if (!is_zero)
-										goto LABEL_63;
+									break;
 								}
-								is_zero -= level_cel_val6;
-								int iteration_level_cel_val = level_cel_val6;
-								do
-								{
-									char _AL = *level_cel_ptr3++;      // al = ebx[*level_cel_ptr++]
-									__asm { xlat }
-									*speed_cel_ptr++ = _AL;
-									--iteration_level_cel_val;
-								} while (iteration_level_cel_val);
-							} while (is_zero);
-						LABEL_63:
-							thirty_two_to_0_ = thirty_two_to_0 - 1;
-						} while (thirty_two_to_0 != 1);
-						add_val += level_frame_sizes[level_frame_types_index2];
-						++speed_light_index;
-					} while (speed_light_index < ligthing_flags_enable_plus_0xF);
-					goto LABEL_65;
-				}
+							}
+							if (!j)
+							{
+								break;
+							}
+
+							for(k = 0; k < level_cel_val; k++)
+							{
+								*speed_cel_ptr++ = light_table_ptr[*dungeon_cel_ptr++];
+							}
+						}
+					}
+					level_frame_total_size += level_frame_sizes[level_frame_types_index];
+					++speed_light_index;
+				} while (speed_light_index < lighting_flag_index);
 			}
 			else
 			{
-				int level_frame_size_val = level_frame_sizes[level_frame_types_index_save];
-				int level_frame_size_val2 = level_frame_sizes[level_frame_types_index_save];
-				int speed_light_index3 = 1;
-				if (ligthing_flags_enable_plus_0xF > 1)
+				int level_frame_size_val = level_frame_sizes[level_frame_types_index];
+				int speed_light_index = 1;
+				for(speed_light_index = 1; speed_light_index < lighting_flag_index; speed_light_index++)
 				{
-					do                                    // copy
+					speed_cel_frame_num_from_light_index_frame_num[0][speed_light_index + speed_light_multiplier_index] = level_frame_total_size;
+					char* level_cel_ptr4 = (char *)dungeon_cel + *((_DWORD *)dungeon_cel + tile_defs_val);
+					char* light_table_ptr = (char *)pLightTbl + 0x100 * speed_light_index;
+					speed_cel_ptr = (char *)pSpeedCels + level_frame_total_size;
+					for (i = 0; i < level_frame_size_val; i++)
 					{
-						speed_cel_frame_num_from_light_index_frame_num[0][speed_light_index3 + speed_light_index2] = add_val;
-						char* level_cel_ptr4 = (char *)dungeon_cel + *((_DWORD *)dungeon_cel + tile_defs_val);
-						v28 = (char *)pSpeedCels + add_val;
-						_EBX = (char *)pLightTbl + 0x100 * speed_light_index3;
-						for (k = level_frame_size_val2; k; --k)
-						{
-							char _AL = *level_cel_ptr4++;
-							__asm { xlat }
-							*v28++ = _AL;
-						}
-						add_val += level_frame_size_val;
-						++speed_light_index3;
-					} while (speed_light_index3 < ligthing_flags_enable_plus_0xF);
-				LABEL_65:
-					//level_frame_size_index = level_frame_size_counter_minus_one2;
-					goto LABEL_66;
+						*speed_cel_ptr++ = light_table_ptr[*level_cel_ptr4++];
+					}
+					level_frame_total_size += level_frame_size_val;
 				}
 			}
-		LABEL_66:
-			++level_frame_types_index2;
-			speed_cel_frame_num_from_light_index_frame_num1 = (int(*)[128])((char *)speed_cel_frame_num_from_light_index_frame_num1
-				+ 64);
-			speed_light_index2 += 16;
-		} while (level_frame_types_index2 < level_frame_size_index);
+			++level_frame_types_index;
+			speed_cel_frame_num_from_light_index_frame_num_ptr = (int(*)[128])((char *)speed_cel_frame_num_from_light_index_frame_num_ptr + 64);
+			speed_light_multiplier_index += 16;
+		} while (level_frame_types_index < level_frame_size_index);
 	}
 	//////////////////////////
 	/*

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -142,7 +142,7 @@ void __cdecl gendung_418D91()
 	int i;
 	int j;
 	int k;
-	int h;
+	int l;
 
 	//first block
 	int dungeon_type_iterations;
@@ -372,7 +372,7 @@ LABEL_36:
 								break;
 							}
 
-							for (h = 0; h < level_cel_index; h++)
+							for (l = 0; l < level_cel_index; l++)
 							{
 								frame_num = *dungeon_cel_ptr++;
 								if (frame_num < 32 && frame_num > 0) //check frame type
@@ -685,29 +685,28 @@ LABEL_66:
 	//////////////////////////
 	int result = 0;
 	int (*piece_pid_map_ptr)[112] = dPiece;
-	for (i = 0; i < 0xE00; i++)
+	for (i = 0; i < map_length_times_thirty_two; i++)
 	{
-		int map_length2 = 112;
 		short* dpieces_defs_map3_ptr = dpiece_defs_map_2[0][0];
 		int(*piece_pid_map_ptr2)[112] = piece_pid_map_ptr;
-		do
+		for(j = 0; j < map_length; j++)
 		{
 			if ((*piece_pid_map_ptr2)[0] && (dungeon_type_iterations > 0))
 			{
 				short* dpieces_defs_map4_ptr = dpieces_defs_map3_ptr;
-				for (j = 0; j < dungeon_type_iterations; j++)
+				for (k = 0; k < dungeon_type_iterations; k++)
 				{
 					result = *dpieces_defs_map4_ptr;
 					if (*dpieces_defs_map4_ptr)
 					{
 						if (level_frame_types_index > 0)
 						{
-							for (k = 0; k < level_frame_size_index; k++)
+							for (l = 0; l < level_frame_size_index; l++)
 							{
-								if ((result & 0xFFF) == *((_DWORD *)&tile_defs[0].top + k))
+								if ((result & 0xFFF) == *((_DWORD *)&tile_defs[0].top + l))
 								{
-									int val = k + level_frame_types[k];
-									level_frame_types_index = k;
+									int val = l + level_frame_types[l];
+									level_frame_types_index = l;
 									result = val + -32768;
 								}
 							}
@@ -719,9 +718,8 @@ LABEL_66:
 				}
 			}
 			++piece_pid_map_ptr2;
-			dpieces_defs_map3_ptr += 1792;
-			--map_length2;
-		} while (map_length2);
+			dpieces_defs_map3_ptr += map_length_times_thirty_two/2;
+		}
 		piece_pid_map_ptr = (int(*)[112])((char *)piece_pid_map_ptr + 4);
 	}
 }

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -136,15 +136,14 @@ LABEL_13:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-void __cdecl gendung_418D91()
+void __cdecl SetupDungeon()
 {
-	//iteator variables
+	//indexing variables
 	int i;
 	int j;
 	int k;
 	int l;
 
-	//first block
 	int dungeon_type_iterations; //12 if hell else 10
 	int map_length; //112
 	int map_length_times_thirty_two; //112 * 32 (0xE00)
@@ -153,23 +152,19 @@ void __cdecl gendung_418D91()
 	short frame_num; // map_block_info & 0x0FFF
 	short frame_type; //map_block_info & 0x7000 >> 12
 
-	//second block
 	int* dungeon_cel; //same as pDungeonCels, but casted to int*
 	int frame_size; // calculated from dungeon_cel[i + 1] - dungeon_cel[i], stored into level_frame_sizes
 
-	//third block
 	int level_frame_types_index; //used to index level_frame_types
 	char set_level_frame_count_zero; //bool used to check whether or not we should set current index into level frame count to zero
 	char* level_cel_ptr; //ptr to pDungeonCels (moved around)
 	char level_cel_index; //index into dungeon_cel_ptr
 	unsigned char frame_num2; 
 
-	//fourth block
 	int total_level_frame_size;
 	int level_frame_size_index;
 	int frame_multiplier;
 
-	//fifth block
 	int ligthing_flag_enable;
 	int level_frame_total_size;
 	int lighting_flag_index;
@@ -180,62 +175,25 @@ void __cdecl gendung_418D91()
 	int(*speed_cel_frame_num_from_light_index_frame_num_ptr)[128];
 	int tile_defs_val;
 
-	//sixth block
 	int dpieces_defs_map2_val;
 	int(*piece_pid_map_ptr)[112];
 	int(*piece_pid_map_ptr2)[112];
 	short* dpieces_defs_map3_ptr;
 	short* dpieces_defs_map4_ptr;
 
-	//
-
 	char* speed_cel_ptr;
 	char level_cel_val;
 
-	//v0 = 0;
 	memset(level_frame_types, 0, sizeof(level_frame_types));
 	memset(level_frame_count, 0, sizeof(level_frame_count));
-	/*
-	do
-	{
-		*((_DWORD *)&tile_defs[0].top + v0) = v0;
-		++v0;
-	} while (v0 < 2048);
-	*/
+
 	//set tile_defs to be 1,2,3,...
 	for (i = 0; i < sizeof(tile_defs)/sizeof(*tile_defs); i++)
 	{
 		tile_defs[i].top = i * 2;
 		tile_defs[i].left = i * 2 + 1;
 	}
-	/////////////////////
-	/*
-	v1 = dpiece_defs_map_2;
-	v48 = 2 * (leveltype == DTYPE_HELL) + 10;
-	do
-	{
-		v2 = v1;
-		v3 = 112;
-		do
-		{
-			for ( i = 0; i < v48; ++i )
-			{
-				v5 = (*v2)[0][i];
-				if ( (*v2)[0][i] )
-				{
-					v6 = v5 & 0xFFF;
-					++level_frame_count[v6];
-					level_frame_types[v6] = v5 & 0x7000;
-				}
-			}
-			v2 = (short (*)[112][112])((char *)v2 + 0xE00);
-			--v3;
-		}
-		while ( v3 );
-		v1 = (short (*)[112][112])((char *)v1 + 32);
-	}
-	while ( (signed int)v1 < (signed int)dpiece_defs_map_2[0][16] );
-	*/
+
 	dungeon_type_iterations = 2 * (leveltype == DTYPE_HELL) + 10; //12 if in HELL else 10
 	map_length = sizeof(dpiece_defs_map_2[0][0]) / sizeof(dpiece_defs_map_2[0][0][0]);
 	map_length_times_thirty_two = map_length * 32;
@@ -258,23 +216,7 @@ void __cdecl gendung_418D91()
 		}
 		dpiece_defs_map_2_ptr += 16;
 	}
-	///////////////////////////
-	/*
-	v7 = 1;
-	nlevel_frames = *(_DWORD *)pDungeonCels & 0xFFFF;
-	v8 = nlevel_frames;
-	if ( nlevel_frames > 1 )
-	{
-		do
-		{
-			level_frame_sizes[v7] = (*((_DWORD *)pDungeonCels + v7 + 1) - *((_DWORD *)pDungeonCels + v7)) & 0xFFFF;
-			v8 = nlevel_frames;
-			++v7;
-		}
-		while ( v7 < nlevel_frames );
-	}
-	*/
-	////////////////////////////
+
 	dungeon_cel = (int*)pDungeonCels;
 	nlevel_frames = dungeon_cel[0] & 0xFFFF;
 	for (i = 1; i < nlevel_frames; i++)
@@ -282,75 +224,7 @@ void __cdecl gendung_418D91()
 		frame_size = dungeon_cel[i + 1] - dungeon_cel[i];
 		level_frame_sizes[i] = frame_size & 0xFFFF;
 	}
-	////////////////////////////
-	/*
-	v9 = 0;
-	level_frame_sizes[0] = 0;
-	if ( leveltype == DTYPE_HELL && v8 > 0 )
-	{
-		do
-		{
-			if ( !v9 )
-				level_frame_count[0] = 0;
-			v53 = 1;
-			if ( level_frame_count[v9] )
-			{
-				if ( level_frame_types[v9] == 4096 )
-				{
-					v13 = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + v9);
-					v14 = 32;
-					do
-					{
-						v46 = v14;
-						v15 = 32;
-						do
-						{
-							while ( 1 )
-							{
-								v16 = *v13++;
-								if ( (v16 & 0x80u) == 0 )
-									break;
-								_LOBYTE(v16) = -(char)v16;
-								v15 -= v16;
-								if ( !v15 )
-									goto LABEL_36;
-							}
-							v15 -= v16;
-							v17 = v16;
-							do
-							{
-								v18 = *v13++;
-								if ( v18 && v18 < 0x20u )
-									v53 = 0;
-								--v17;
-							}
-							while ( v17 );
-						}
-						while ( v15 );
-LABEL_36:
-						v14 = v46 - 1;
-					}
-					while ( v46 != 1 );
-				}
-				else
-				{
-					v10 = (char *)pDungeonCels + *((_DWORD *)pDungeonCels + v9);
-					for ( j = level_frame_sizes[v9]; j; --j )
-					{
-						v12 = *v10++;
-						if ( v12 && v12 < 0x20u )
-							v53 = 0;
-					}
-				}
-				if ( !v53 )
-					level_frame_count[v9] = 0;
-			}
-			++v9;
-		}
-		while ( v9 < nlevel_frames );
-	}
-	*/
-	////////////////////////////
+
 	level_frame_sizes[0] = 0;
 	if (leveltype == DTYPE_HELL)
 	{
@@ -418,28 +292,6 @@ LABEL_36:
 		}
 	}
 	
-	//////////////////////////
-	/*
-	gendung_4191BF(2047);
-	v19 = 0;
-	v20 = 0;
-	if ( light4flag )
-	{
-		do
-		{
-			v21 = level_frame_sizes[v20++];
-			v19 += 2 * v21;
-		}
-		while ( v19 < 0x100000 );
-	}
-	else
-	{
-		do
-			v19 += 14 * level_frame_sizes[v20++];
-		while ( v19 < 0x100000 );
-	}
-	*/
-	//////////////////////////
 	gendung_4191BF(2047);
 	total_level_frame_size = 0;
 	level_frame_size_index = 0;
@@ -448,127 +300,7 @@ LABEL_36:
 	{
 		total_level_frame_size += frame_multiplier * level_frame_sizes[level_frame_size_index++];
 	}
-	//////////////////////////
-	/*v22 = v20 - 1;
-	v58 = v22;
-	if ( v22 > 128 )
-	{
-		v58 = 128;
-		v22 = 128;
-	}
-	v23 = -(light4flag != 0);
-	v63 = 0;
-	_LOBYTE(v23) = v23 & 0xF4;
-	v54 = 0;
-	v60 = v23 + 15;
-	if ( v22 > 0 )
-	{
-		v56 = 0;
-		v49 = speed_cel_frame_num_from_light_index_frame_num;
-		do
-		{
-			v24 = v54;
-			v25 = level_frame_types[v54] == 4096;
-			v62 = *((_DWORD *)&tile_defs[0].top + v54);
-			(*v49)[0] = v62;
-			if ( v25 )
-			{
-				v65 = 1;
-				if ( v60 > 1 )
-				{
-					do
-					{
-						speed_cel_frame_num_from_light_index_frame_num[0][v65 + v56] = v63;
-						v33 = (char *)pDungeonCels + *((_DWORD *)pDungeonCels + v62);
-						v34 = (char *)pSpeedCels + v63;
-						_EBX = &pLightTbl[256 * v65];
-						v36 = 32;
-						do
-						{
-							v47 = v36;
-							v37 = 32;
-							do
-							{
-								while ( 1 )
-								{
-									v38 = (unsigned char)*v33++;
-									*v34++ = v38;
-									if ( (v38 & 0x80u) == 0 )
-										break;
-									_LOBYTE(v38) = -(char)v38;
-									v37 -= v38;
-									if ( !v37 )
-										goto LABEL_63;
-								}
-								v37 -= v38;
-								v39 = v38;
-								do
-								{
-									_EAX = *v33++;
-									ASM_XLAT(_EAX,_EBX);
-									*v34++ = _EAX;
-									--v39;
-								}
-								while ( v39 );
-							}
-							while ( v37 );
-LABEL_63:
-							v36 = v47 - 1;
-						}
-						while ( v47 != 1 );
-						v63 += level_frame_sizes[v54];
-						++v65;
-					}
-					while ( v65 < v60 );
-					goto LABEL_65;
-				}
-			}
-			else
-			{
-				v26 = level_frame_sizes[v24];
-				v51 = level_frame_sizes[v24];
-				v64 = 1;
-				if ( v60 > 1 )
-				{
-					do
-					{
-						speed_cel_frame_num_from_light_index_frame_num[0][v64 + v56] = v63;
-						v27 = (char *)pDungeonCels + *((_DWORD *)pDungeonCels + v62);
-						v28 = (char *)pSpeedCels + v63;
-						_EBX = &pLightTbl[256 * v64];
-						for ( k = v51; k; --k )
-						{
-							_EAX = *v27++;
-							ASM_XLAT(_EAX,_EBX);
-							*v28++ = _EAX;
-						}
-						v63 += v26;
-						++v64;
-					}
-					while ( v64 < v60 );
-LABEL_65:
-					v22 = v58;
-					goto LABEL_66;
-				}
-			}
-LABEL_66:
-			++v54;
-			v49 = (int (*)[128])((char *)v49 + 64);
-			v56 += 16;
-		}
-		while ( v54 < v22 );
-	}*/
-	//////////////////////////
-	/*
-	*.text:00418FB5 neg     eax
-	.text:00418FB7 sbb     eax, eax
-	* if eax == 0, CF = 0 else 1
-	* eax = eax - (eax + CF)
-	* eax = eax - eax - eax != 0
-	* eax = -(eax != 0)
-	* eax only can be 0 or -1...
-	*/
-	
+
 	if (--level_frame_size_index > 128)// limit the index to 128
 	{
 		level_frame_size_index = 128;
@@ -644,59 +376,7 @@ LABEL_66:
 			speed_light_multiplier_index += 16;
 		}
 	}
-	//////////////////////////
-	/*
-	v57 = dPiece;
-	v55 = dpiece_defs_map_2;
-	do
-	{
-		v61 = 112;
-		v52 = v55;
-		v50 = v57;
-		do
-		{
-			if ( (*v50)[0] && v48 > 0 )
-			{
-				v42 = v52;
-				v59 = v48;
-				do
-				{
-					v43 = *(_WORD *)v42;
-					if ( *(_WORD *)v42 )
-					{
-						v44 = 0;
-						if ( v22 > 0 )
-						{
-							do
-							{
-								if ( (v43 & 0xFFF) == *((_DWORD *)&tile_defs[0].top + v44) )
-								{
-									v45 = v44 + level_frame_types[v44];
-									v44 = v22;
-									v43 = v45 + -32768;
-								}
-								++v44;
-							}
-							while ( v44 < v22 );
-							*(_WORD *)v42 = v43;
-						}
-					}
-					v42 = (short (*)[112][112])((char *)v42 + 2);
-					--v59;
-				}
-				while ( v59 );
-			}
-			++v50;
-			v52 = (short (*)[112][112])((char *)v52 + 3584);
-			--v61;
-		}
-		while ( v61 );
-		v55 = (short (*)[112][112])((char *)v55 + 32);
-		v57 = (int (*)[112])((char *)v57 + 4);
-	}
-	while ( (signed int)v55 < (signed int)dpiece_defs_map_2[0][16] );
-	*/
-	//////////////////////////
+
 	dpieces_defs_map2_val = 0;
 	piece_pid_map_ptr = dPiece;
 	for (i = 0; i < map_length_times_thirty_two; i++)

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -245,7 +245,7 @@ void __cdecl gendung_418D91()
 	}
 	while ( (signed int)v1 < (signed int)dpiece_defs_map_2[0][16] );
 	*/
-	int dungeon_type = 2 * (leveltype == DTYPE_HELL) + 10;
+	int dungeon_type_iterations = 2 * (leveltype == DTYPE_HELL) + 10;
 	int map_length = sizeof(dpiece_defs_map_2[0][0]) / sizeof(dpiece_defs_map_2[0][0][0]);
 	short(*dpiece_defs_map_2_ptr)[112][112] = dpiece_defs_map_2;
 	do
@@ -254,7 +254,7 @@ void __cdecl gendung_418D91()
 		int current_map_index = map_length;
 		do
 		{
-			for(i = 0; i < dungeon_type; i++)
+			for(i = 0; i < dungeon_type_iterations; i++)
 			{
 				short map_block_info = (*dpiece_defs_map_2_ptr2)[i];
 				if(map_block_info)
@@ -720,56 +720,45 @@ LABEL_66:
 	//////////////////////////
 	int result = 0;
 	int (*piece_pid_map_ptr)[112] = dPiece;
-	short (*dpieces_defs_map2_ptr)[112][112] = dpiece_defs_map_2;
-	do
+	for (i = 0; i < 0xE00; i++)
 	{
 		int map_length2 = 112;
-		short* dpieces_defs_map3_ptr = (short *)dpieces_defs_map2_ptr;
+		short* dpieces_defs_map3_ptr = dpiece_defs_map_2[0][0];
 		int(*piece_pid_map_ptr2)[112] = piece_pid_map_ptr;
 		do
 		{
-			result = (short)piece_pid_map_ptr2;
-			if ((*piece_pid_map_ptr2)[0])
+			if ((*piece_pid_map_ptr2)[0] && (dungeon_type_iterations > 0))
 			{
-				result = dungeon_type;
-				if (dungeon_type > 0)
+				short* dpieces_defs_map4_ptr = dpieces_defs_map3_ptr;
+				for (j = 0; j < dungeon_type_iterations; j++)
 				{
-					short* dpieces_defs_map4_ptr = dpieces_defs_map3_ptr;
-					int dungeon_type2 = dungeon_type;
-					do
+					result = *dpieces_defs_map4_ptr;
+					if (*dpieces_defs_map4_ptr)
 					{
-						result = *dpieces_defs_map4_ptr;
-						if (*dpieces_defs_map4_ptr)
+						if (level_frame_types_index > 0)
 						{
-							int level_frame_size_index2 = 0;
-							if (level_frame_size_index2 > 0)
+							for (k = 0; k < level_frame_size_index; k++)
 							{
-								do
+								if ((result & 0xFFF) == *((_DWORD *)&tile_defs[0].top + k))
 								{
-									if ((result & 0xFFF) == *((_DWORD *)&tile_defs[0].top + level_frame_size_index2))
-									{
-										v45 = level_frame_size_index2 + level_frame_types[level_frame_size_index2];
-										level_frame_size_index2 = level_frame_size_index;
-										result = v45 + -32768;
-									}
-									++level_frame_size_index2;
-								} while (level_frame_size_index2 < level_frame_size_index);
-								*dpieces_defs_map4_ptr = result;
+									int val = k + level_frame_types[k];
+									level_frame_types_index = k;
+									result = val + -32768;
+								}
 							}
+							*dpieces_defs_map4_ptr = result;
 						}
-						++dpieces_defs_map4_ptr;
-						--dungeon_type2;
-					} while (dungeon_type2);
+					}
+					++dpieces_defs_map4_ptr;
+					--dungeon_type_iterations;
 				}
 			}
 			++piece_pid_map_ptr2;
 			dpieces_defs_map3_ptr += 1792;
 			--map_length2;
 		} while (map_length2);
-		dpieces_defs_map2_ptr = (short(*)[112][112])((char *)dpieces_defs_map2_ptr + 32);
 		piece_pid_map_ptr = (int(*)[112])((char *)piece_pid_map_ptr + 4);
-	} while ((signed int)dpieces_defs_map2_ptr < (signed int)dpiece_defs_map_2[0][16]);
-	//return result;
+	}
 }
 // 525728: using guessed type int light4flag;
 // 53CD4C: using guessed type int nlevel_frames;

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -70,7 +70,7 @@ extern int dminy; // weak
 extern short dpiece_defs_map_2[16][112][112];
 
 void __cdecl FillSolidBlockTbls();
-void __cdecl gendung_418D91();
+void __cdecl SetupDungeon();
 void __fastcall gendung_4191BF(int frames);
 void __fastcall gendung_4191FB(int a1, int a2);
 int __fastcall gendung_get_dpiece_num_from_coord(int x, int y);

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -33,7 +33,7 @@ extern char leveltype; // weak
 extern unsigned char currlevel; // idb
 extern char TransList[256];
 extern char nSolidTable[2049];
-extern int level_frame_count[2049];
+extern int level_frame_count[2048];
 extern ScrollStruct ScrollInfo;
 extern void *pDungeonCels;
 extern int speed_cel_frame_num_from_light_index_frame_num[16][128];


### PR DESCRIPTION
Assumed c89 style.

Changes:
Renamed all the variables generated by IDA and removed assembly/macro usage in the function. (Not all variable names are exact.)
Removed most of the do...while when possible and converted into for loops for better readability.
Added comments when necessary and (from what I understand)
int level_frame_count[2049] -> -int level_frame_count[2048]; Documented at http://sanctuary.github.io/notes/#variable/level_frame_count

Minor Issues:
tile_defs gets converted to an int multiple times, but is a struct containing four shorts. Did not want to mess with conversions. 

