### PR TITLE
Fix decompilation of init_create_window

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -305,7 +305,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	{
 		diablo_init_screen();
 		diablo_parse_flags(lpCmdLine);
-		init_create_window();
+		init_create_window(nCmdShow);
 		sound_init();
 		UiInitialize();
 #ifdef _DEBUG

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -168,7 +168,7 @@ void __fastcall init_disable_screensaver(bool disable)
 	}
 }
 
-void __cdecl init_create_window()
+void __fastcall init_create_window(int nCmdShow)
 {
 	int nHeight; // eax
 	HWND hWnd; // esi
@@ -201,7 +201,7 @@ void __cdecl init_create_window()
 	hWnd = CreateWindowExA(0, "DIABLO", "DIABLO", WS_POPUP, 0, 0, nWidth, nHeight, NULL, NULL, ghInst, NULL);
 	if ( !hWnd )
 		TermMsg("Unable to create main window");
-	ShowWindow(hWnd, SW_SHOWNORMAL);
+	ShowWindow(hWnd, SW_SHOWNORMAL); // nCmdShow used only in beta: ShowWindow(hWnd, nCmdShow)
 	UpdateWindow(hWnd);
 	init_await_mom_parent_exit();
 	dx_init(hWnd);

--- a/Source/init.h
+++ b/Source/init.h
@@ -20,7 +20,7 @@ void __fastcall init_cleanup(bool show_cursor);
 void __cdecl init_run_office_from_start_menu();
 void __fastcall init_run_office(char *dir);
 void __fastcall init_disable_screensaver(bool disable);
-void __cdecl init_create_window();
+void __fastcall init_create_window(int nCmdShow);
 void __cdecl init_kill_mom_parent();
 HWND __cdecl init_find_mom_parent();
 void __cdecl init_await_mom_parent_exit();

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -9,7 +9,7 @@ int nummissiles; // idb
 int ManashieldFlag;
 unk_missile_struct misflagstruct_unknown[125];
 int MissilePreFlag; // weak
-
+int unk_missile_flag; // weak
 
 MissileData missiledata[68] =
 {
@@ -2328,7 +2328,7 @@ void __cdecl InitMissiles()
 		++v4;
 	}
 	while ( v4 < 125 );
-	// END_unkmis_126 = 0;
+	unk_missile_flag = 0;
 	v5 = &misflagstruct_unknown[0].field_4;
 	do
 	{
@@ -2354,7 +2354,7 @@ void __cdecl InitMissiles()
 	}
 	while ( v6 < 112 );
 }
-// 64CCD8: using guessed type int END_unkmis_126;
+// 64CCD8: using guessed type int unk_missile_flag;
 
 void __fastcall AddLArrow(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -9,7 +9,7 @@ extern int nummissiles; // idb
 extern int ManashieldFlag;
 extern unk_missile_struct misflagstruct_unknown[125];
 extern int MissilePreFlag; // weak
-// int END_unkmis_126; // weak
+extern int unk_missile_flag; // weak
 
 void __fastcall GetDamageAmt(int i, int *mind, int *maxd);
 int __fastcall CheckBlock(int fx, int fy, int tx, int ty);


### PR DESCRIPTION
Thanks to @mewmew for fixing this via Sanctuary/notes. I had this one entered wrong even though `nCmdShow` is passed to the function (although unused, but it is used in the beta).

Also fixed the unused missile flag. There appears to be a struct and index for it that are initialized but never used. It looks like the following:
```
Unknown_Index = 0; // index/count of table
for(i = 0; i < MAXMISSILES; i++)
  Unknown_Struct[i].field0 = -1; // missile id probably, -1 if slot is empty
  Unknown_Struct[i].field4 = 0; // 1st variable for slot
  Unknown_Struct[i].field8 = 0; // 2nd variable for slot
```
This struct isn't used in any version of Diablo, including the beta/demo. If I had to guess it was used very early on in development for storing something related to missiles, and they simply forgot to remove it.