### PR TITLE
Several fixes for storm/msgcmd

### DIFF
--- a/3rdParty/Storm/Source/storm.cpp
+++ b/3rdParty/Storm/Source/storm.cpp
@@ -36,7 +36,7 @@ BOOL STORMAPI SNetSendTurn(char *data, size_t databytes) rBool;
 BOOL STORMAPI SNetSetGameMode(DWORD modeFlags, bool makePublic) rBool;
 
 BOOL STORMAPI SNetEnumGamesEx(int a1, int a2, int (__fastcall *callback)(DWORD, DWORD, DWORD), int *hintnextcall) rBool;
-BOOL STORMAPI SNetSendServerChatCommand(const char *command) rBool;
+BOOL STORMAPI SNetSetServerChatCommand(const char *command) rBool;
 
 BOOL STORMAPI SNetDisconnectAll(DWORD flags) rBool;
 BOOL STORMAPI SNetCreateLadderGame(const char *pszGameName, const char *pszGamePassword, const char *pszGameStatString, DWORD dwGameType, DWORD dwGameLadderType, DWORD dwGameModeFlags, char *GameTemplateData, int GameTemplateSize, int playerCount, char *creatorName, char *a11, int *playerID) rBool;

--- a/3rdParty/Storm/Source/storm.def
+++ b/3rdParty/Storm/Source/storm.def
@@ -34,7 +34,7 @@ EXPORTS
   SNetUnregisterEventHandler    @131 NONAME
 
   SNetEnumGamesEx               @133 NONAME
-  SNetSendServerChatCommand     @134 NONAME
+  SNetSetServerChatCommand      @134 NONAME
   ;SNetSendDatagram             @135 NONAME
   ;SNetReceiveDatagram          @136 NONAME
   SNetDisconnectAll             @137 NONAME

--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -432,7 +432,7 @@ SNetSetGameMode(
 #define SNMakeGamePublic() SNetSetGameMode( (DWORD mode, SNetGetGameInfo(GAMEINFO_MODEFLAGS, &mode, 4), mode), true)
 
 BOOL STORMAPI SNetEnumGamesEx(int a1, int a2, int (__fastcall *callback)(DWORD, DWORD, DWORD), int *hintnextcall);
-BOOL STORMAPI SNetSendServerChatCommand(const char *command);
+BOOL STORMAPI SNetSetServerChatCommand(const char *command);
 
 BOOL STORMAPI SNetDisconnectAll(DWORD flags);
 BOOL STORMAPI SNetCreateLadderGame(const char *pszGameName, const char *pszGamePassword, const char *pszGameStatString, DWORD dwGameType, DWORD dwGameLadderType, DWORD dwGameModeFlags, char *GameTemplateData, int GameTemplateSize, int playerCount, char *creatorName, char *a11, int *playerID);

--- a/3rdParty/Storm/Source/storm_gcc.def
+++ b/3rdParty/Storm/Source/storm_gcc.def
@@ -51,7 +51,7 @@ EXPORTS
   SNetUnregisterEventHandler@8  @131 NONAME
 
   SNetEnumGamesEx               @133 NONAME
-  SNetSendServerChatCommand     @134 NONAME
+  SNetSetServerChatCommand      @134 NONAME
   ;SNetSendDatagram             @135 NONAME
   ;SNetReceiveDatagram          @136 NONAME
   SNetDisconnectAll             @137 NONAME

--- a/Source/msgcmd.cpp
+++ b/Source/msgcmd.cpp
@@ -2,6 +2,8 @@
 
 #include "../types.h"
 
+/* TODO: decompile and fix, commands are NOT deleted properly */
+
 int msgcmd_cpp_init_value; // weak
 ChatCmd sgChat_Cmd;
 int sgdwMsgCmdTimer;
@@ -52,15 +54,15 @@ void __cdecl msgcmd_send_chat()
 {
 	ServerCommand *v0; // esi
 	int v1; // eax
-	return; /* fix this */
-	if ( (_DWORD)sgChat_Cmd.extern_msgs[1] > 0 )
+
+	if ( (signed int)sgChat_Cmd.extern_msgs[1] > 0 )
 	{
 		v0 = sgChat_Cmd.extern_msgs[1];
 		v1 = GetTickCount();
 		if ( (unsigned int)(v1 - sgdwMsgCmdTimer) >= 2000 )
 		{
 			sgdwMsgCmdTimer = v1;
-			SNetSendServerChatCommand(v0->command);
+			SNetSetServerChatCommand(v0->command);
 			msgcmd_delete_server_cmd_W(&sgChat_Cmd, v0);
 		}
 	}

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -809,7 +809,7 @@ int __fastcall NetInit(int bSinglePlayer, int *pfExitProgram)
 	{
 		*a4 = 0;
 		SetRndSeed(0);
-		sgGameInitInfo.dwSeed = time(0);
+		sgGameInitInfo.dwSeed = time(NULL);
 		_LOBYTE(sgGameInitInfo.bDiff) = gnDifficulty;
 		memset(&ProgramData, 0, 0x3Cu);
 		ProgramData.size = 60;
@@ -818,10 +818,10 @@ int __fastcall NetInit(int bSinglePlayer, int *pfExitProgram)
 		ProgramData.programid = 'DRTL';
 		ProgramData.versionid = 42;
 		ProgramData.maxplayers = 4;
-		ProgramData.multi_seed = (int)&sgGameInitInfo;
-		ProgramData.initdata = (void *)8;
-		ProgramData.reserved2 = (void *)15;
-		ProgramData.languageid = 1033;
+		ProgramData.initdata = &sgGameInitInfo;
+		ProgramData.initdatabytes = 8;
+		ProgramData.optcategorybits = 15;
+		ProgramData.lcid = 1033;
 		memset(&a2, 0, 0x10u);
 		a2.size = 16;
 		memset(&UiData, 0, 0x50u);
@@ -835,11 +835,11 @@ int __fastcall NetInit(int bSinglePlayer, int *pfExitProgram)
 		UiData.authcallback = UiAuthCallback;
 		UiData.getdatacallback = UiGetDataCallback;
 		UiData.categorycallback = UiCategoryCallback;
-		UiData.selecthero = (void (__cdecl *)())mainmenu_select_hero_dialog;
-		UiData.createhero = (void (__cdecl *)())mainmenu_create_hero;
-		UiData.profiledraw = UiProfileDraw;
+		UiData.selectnamecallback = (void (__cdecl *)())mainmenu_select_hero_dialog;
+		UiData.changenamecallback = (void (__cdecl *)())mainmenu_create_hero;
+		UiData.profilebitmapcallback = UiProfileDraw;
 		UiData.profilecallback = UiProfileCallback;
-		UiData.profilegetstring = UiProfileGetString();
+		UiData.profilefields = UiProfileGetString();
 		memset(sgbPlayerTurnBitTbl, 0, 4u);
 		gbGameDestroyed = 0;
 		memset(sgbPlayerLeftGameTbl, 0, 4u);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -977,8 +977,8 @@ void __fastcall AddPlrExperience(int pnum, int lvl, int exp)
 			}
 			v10 = &plr[v5]._pExperience;
 			*v10 += v7;
-			if ( plr[v5]._pExperience > 2000000000u )
-				*v10 = 2000000000;
+			if ( plr[v5]._pExperience > MAXEXP )
+				*v10 = MAXEXP;
 			v11 = *v10;
 			if ( v11 < ExpLvlsTbl[49] )
 			{

--- a/defs.h
+++ b/defs.h
@@ -27,6 +27,8 @@
 #define MDMAXX					40
 #define MDMAXY					40
 
+// from diablo 2 beta
+#define MAXEXP					2000000000
 
 // Diablo uses a 256 color palette
 // Entry 0-127 (0x00-0x7F) are level specific

--- a/structs.h
+++ b/structs.h
@@ -1038,13 +1038,13 @@ struct _SNETUIDATA
 	void (__cdecl *statuscallback)();
 	void (__cdecl *getdatacallback)();
 	void (__cdecl *categorycallback)();
-	void (__cdecl *field_34)();
-	void (__cdecl *field_38)();
+	void (__cdecl *categorylistcallback)();
+	void (__cdecl *newaccountcallback)();
 	void (__cdecl *profilecallback)();
-	int profilegetstring;
-	void (__cdecl *profiledraw)();
-	void (__cdecl *selecthero)();
-	void (__cdecl *createhero)();
+	int profilefields;
+	void (__cdecl *profilebitmapcallback)();
+	void (__cdecl *selectnamecallback)();
+	void (__cdecl *changenamecallback)();
 };
 
 struct _SNETPROGRAMDATA
@@ -1056,14 +1056,14 @@ struct _SNETPROGRAMDATA
 	int versionid;
 	int reserved1;
 	int maxplayers;
-	int multi_seed;
 	void *initdata;
 	int initdatabytes;
 	void *reserved2;
 	int optcategorybits;
-	int reserved3;
-	int reserved4;
-	int languageid;
+	char *cdkey;
+	char *registereduser;
+	int spawned;
+	int lcid;
 };
 
 struct _uiheroinfo
@@ -1180,7 +1180,7 @@ struct _SNETPLAYERDATA
 	int size;
 	char *playername;
 	char *playerdescription;
-	int field_C;
+	int reserved;
 };
 
 struct _SNETCAPS


### PR DESCRIPTION
A few minor fixes here. The struct corrections are based on [assert strings from a special debug version](https://pastebin.com/qS67GHnv) of storm (StormD.dll). It also contained the correct name for `SNetSendServerChatCommand` which was `Set` instead of `Send`.

`msgcmd` has received a temporary fix. It no longer crashes and the first command sent works. However, it is not cleaned up so it repeats the same command. This should be fixed later on when the function signatures are figured out.

`MAXEXP` was taken from the Diablo 2 beta where the experience system is the same as Diablo 1. Therefore should be correct.

@mewmew Oh, and I was searching through other Blizzard games to document Storm and the network. `msgcmd.cpp` is called `Starcraft\SWAR\lang\net_chat_cmds.cpp` in StarCraft. Unfortunately it doesn't fix into the alphabetical or 8-character constraint.