### PR TITLE
Implement debug stuff from 1.00

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -115,6 +115,38 @@ void __cdecl MaxSpellsCheat()
 	}
 }
 
+void __fastcall SetSpellLevelCheat(char spl, int spllvl)
+{
+	*(_QWORD *)plr[myplr]._pMemSpells |= 1i64 << (spl - 1);
+	plr[myplr]._pSplLvl[spl] = spllvl;
+}
+
+void __cdecl SetAllSpellsCheat()
+{
+	SetSpellLevelCheat(SPL_FIREBOLT, 8);
+	SetSpellLevelCheat(SPL_CBOLT, 11);
+	SetSpellLevelCheat(SPL_HBOLT, 10);
+	SetSpellLevelCheat(SPL_HEAL, 7);
+	SetSpellLevelCheat(SPL_HEALOTHER, 5);
+	SetSpellLevelCheat(SPL_LIGHTNING, 9);
+	SetSpellLevelCheat(SPL_FIREWALL, 5);
+	SetSpellLevelCheat(SPL_TELEKINESIS, 3);
+	SetSpellLevelCheat(SPL_TOWN, 3);
+	SetSpellLevelCheat(SPL_FLASH, 3);
+	SetSpellLevelCheat(SPL_RNDTELEPORT, 2);
+	SetSpellLevelCheat(SPL_MANASHIELD, 2);
+	SetSpellLevelCheat(SPL_WAVE, 4);
+	SetSpellLevelCheat(SPL_FIREBALL, 3);
+	SetSpellLevelCheat(SPL_STONE, 1);
+	SetSpellLevelCheat(SPL_CHAIN, 1);
+	SetSpellLevelCheat(SPL_GUARDIAN, 4);
+	SetSpellLevelCheat(SPL_ELEMENT, 3);
+	SetSpellLevelCheat(SPL_NOVA, 1);
+	SetSpellLevelCheat(SPL_GOLEM, 2);
+	SetSpellLevelCheat(SPL_FLARE, 1);
+	SetSpellLevelCheat(SPL_BONESPIRIT, 1);
+}
+
 void __fastcall PrintDebugPlayer(bool bNextPlayer)
 {
 	char dstr[128]; // [esp+Ch] [ebp-80h]

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -14,6 +14,8 @@ void __cdecl GiveGoldCheat();
 void __cdecl StoresCheat();
 void __cdecl TakeGoldCheat();
 void __cdecl MaxSpellsCheat();
+void __fastcall SetSpellLevelCheat(char spl, int spllvl);
+void __cdecl SetAllSpellsCheat();
 void __fastcall PrintDebugPlayer(bool bNextPlayer);
 void __cdecl PrintDebugQuest();
 void __fastcall PrintDebugMonster(int m);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -52,6 +52,7 @@ int debug_mode_key_i;
 int dbgplr;
 int dbgqst;
 int dbgmon;
+int arrowdebug;
 int frameflag;
 int frameend;
 int framerate;
@@ -1713,6 +1714,28 @@ LABEL_27:
 					zoomflag = zoomflag == 0;
 					return;
 #ifdef _DEBUG
+				case ')':
+				case '0':
+					if ( debug_mode_key_inverted_v )
+					{
+						if ( arrowdebug > 2 )
+							arrowdebug = 0;
+						if ( !arrowdebug )
+						{
+							plr[myplr]._pIFlags &= ~ISPL_FIRE_ARROWS;
+							plr[myplr]._pIFlags &= ~ISPL_LIGHT_ARROWS;
+						}
+						if ( arrowdebug == 1 )
+							plr[myplr]._pIFlags |= ISPL_FIRE_ARROWS;
+						if ( arrowdebug == 2 )
+							plr[myplr]._pIFlags |= ISPL_LIGHT_ARROWS;
+						arrowdebug++;
+					}
+					return;
+				case ':':
+					if ( !currlevel && debug_mode_key_w )
+						SetAllSpellsCheat();
+					return;
 				case '[':
 					if ( !currlevel && debug_mode_key_w )
 						TakeGoldCheat();

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -89,6 +89,7 @@ extern int debug_mode_key_i;
 extern int dbgplr;
 extern int dbgqst;
 extern int dbgmon;
+extern int arrowdebug;
 extern int frameflag;
 extern int frameend;
 extern int framerate;

--- a/Support/debug.md
+++ b/Support/debug.md
@@ -26,7 +26,7 @@ In-game hotkeys
 - `F2` -> display dungeon information [NOT YET IMPLEMENTED]
 - `F3` -> display number of items on the ground/cursor item
 - `F4` -> display quest status information
-- `0`/`)` -> cycle through active item flags [NOT YET IMPLEMENTED]
+- `0`/`)` -> cycle between regular/magic arrows
 - `8`/`*` -> level up character
 - `~` -> refresh vendor items (Griswold premium and Adria)
 - `]` -> all spells level 10


### PR DESCRIPTION
Two more features: cycle magic/regular arrows and enable all spells at a preset level. I'm curious as to where Blizzard came up with the designated levels for each spell. Either way, it's all being preserved exactly as found in the debug release.

To cycle arrows, use `0` while in god mode.

Also interesting to note that the spells cheat tries to set 'Nova' to level 1. Nova was learnable as a spell before the final game.