### PR TITLE
Fix decompilation of skeleton spawning

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -8853,6 +8853,7 @@ int __fastcall M_SpawnSkel(int x, int y, int dir)
 
 	ya = y;
 	xa = x;
+	v5 = 0;
 	if ( nummtypes <= 0 )
 		return -1;
 	v3 = Monsters;
@@ -9005,10 +9006,12 @@ bool __fastcall SpawnSkeleton(int ii, int x, int y)
 
 int __cdecl PreSpawnSkeleton()
 {
-	int skeltypes; // edx
-	int j; // edx
+	int skeltypes; // edx // should be i/j
+	int j; // edx // remove
 	int skel; // eax
-	int i; // [esp+10h] [ebp-4h]
+	int i; // [esp+10h] [ebp-4h] // should be skeltypes
+
+	skeltypes = 0;
 
 	if ( nummtypes <= 0 )
 		return -1;

--- a/Support/debug.md
+++ b/Support/debug.md
@@ -47,3 +47,8 @@ In-game hotkeys
 - `M` -> switch current debug monster
 - `r`/`R` -> display game seeds
 - `t`/`T` -> display player and cursor coordinates
+
+Multiplayer hotkeys [NOT YET IMPLEMENTED]
+- `Ctrl`+`C` -> trigger breakpoint
+- `Ctrl`+`P` -> print mouse clicks and frame counter for each player
+- `Ctrl`+`S` -> sleep the network thread


### PR DESCRIPTION
They now work properly for both barrels and King Leoric. Thanks to @qndel for finding the fix. This issue was the decompiler not adding the zero initialization for those variables, meaning they were random values (of whatever is in the stack) and caused crashing.

This fixes #91 #123 #126 #130 

Also added notes about the recently [discovered multiplayer commands](https://github.com/diasurgical/scalpel/pull/7#issuecomment-410114482).