### PR TITLE
Fix random(idx,v) calls

### DIFF
--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -968,7 +968,6 @@ int __fastcall DRLG_PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, int
 	int v10; // esi
 	int v11; // edx
 	int v12; // eax
-	int v13; // ecx
 	int v14; // esi
 	int v15; // edi
 	int v16; // ebx
@@ -1005,8 +1004,7 @@ int __fastcall DRLG_PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, int
 	v37 = miniset[1];
 	if ( v11 )
 	{
-		_LOBYTE(miniset) = 0;
-		v31 = v10 + random((int)miniset, v11);
+		v31 = v10 + random(0, v11);
 	}
 	else
 	{
@@ -1019,12 +1017,10 @@ int __fastcall DRLG_PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, int
 		v29 = 40 - v37;
 		while ( 1 )
 		{
-			_LOBYTE(miniset) = 0;
-			v12 = random((int)miniset, max);
-			_LOBYTE(v13) = 0;
+			v12 = random(0, max);
 			v14 = v12;
 			v33 = 0;
-			v15 = random(v13, v29);
+			v15 = random(0, v29);
 			while ( 1 )
 			{
 				tmaxa = 1;
@@ -1362,14 +1358,12 @@ void __fastcall L5roomGen(int x, int y, int w, int h, bool dir)
 	int v7; // eax
 	int v8; // ecx
 	int v9; // eax
-	int v10; // ecx
 	int v11; // esi
 	int v12; // edi
 	int v13; // ebx
 	int v14; // eax
 	int v15; // eax
 	int v16; // eax
-	int v17; // ecx
 	int v18; // esi
 	int v19; // edi
 	int v20; // ebx
@@ -1395,8 +1389,7 @@ void __fastcall L5roomGen(int x, int y, int w, int h, bool dir)
 	{
 		while ( 1 )
 		{
-			_LOBYTE(x) = 0;
-			v5 = random(x, 4);
+			v5 = random(0, 4);
 			v6 = 0;
 			_LOBYTE(v6) = dir == 1 ? v5 != 0 : v5 == 0;
 			v7 = v6;
@@ -1409,11 +1402,9 @@ void __fastcall L5roomGen(int x, int y, int w, int h, bool dir)
 			twa = w / 2;
 			do
 			{
-				_LOBYTE(v8) = 0;
-				v9 = random(v8, 5);
-				_LOBYTE(v10) = 0;
+				v9 = random(0, 5);
 				v11 = (v9 + 2) & 0xFFFFFFFE;
-				v12 = (random(v10, 5) + 2) & 0xFFFFFFFE;
+				v12 = (random(0, 5) + 2) & 0xFFFFFFFE;
 				v13 = txa + twa - v11 / 2;
 				tya = v29 - v12;
 				v14 = L5checkRoom(v13 - 1, v29 - v12 - 1, v11 + 2, v12 + 1);
@@ -1442,11 +1433,9 @@ void __fastcall L5roomGen(int x, int y, int w, int h, bool dir)
 		thb = h / 2;
 		do
 		{
-			_LOBYTE(v8) = 0;
-			v16 = random(v8, 5);
-			_LOBYTE(v17) = 0;
+			v16 = random(0, 5);
 			v18 = (v16 + 2) & 0xFFFFFFFE;
-			v19 = (random(v17, 5) + 2) & 0xFFFFFFFE;
+			v19 = (random(0, 5) + 2) & 0xFFFFFFFE;
 			v20 = v29 + thb - v19 / 2;
 			tyb = txa - v18;
 			v21 = L5checkRoom(txa - v18 - 1, v20 - 1, v19 + 2, v18 + 1);
@@ -1780,7 +1769,6 @@ void __fastcall L5HorizWall(int i, int j, char p, int dx)
 	int v4; // edi
 	int v5; // esi
 	int v6; // eax
-	int v7; // ecx
 	char v8; // bl
 	int v9; // eax
 	int v10; // ecx
@@ -1793,9 +1781,8 @@ void __fastcall L5HorizWall(int i, int j, char p, int dx)
 
 	v4 = j;
 	v5 = i;
-	_LOBYTE(i) = 0;
 	v15 = j;
-	v6 = random(i, 4);
+	v6 = random(0, 4);
 	if ( v6 >= 0 )
 	{
 		if ( v6 <= 1 )
@@ -1819,8 +1806,7 @@ void __fastcall L5HorizWall(int i, int j, char p, int dx)
 				_LOBYTE(p) = 27;
 		}
 	}
-	_LOBYTE(v7) = 0;
-	v8 = random(v7, 6) != 5 ? 26 : 12;
+	v8 = random(0, 6) != 5 ? 26 : 12;
 	if ( v16 == 12 )
 		v8 = 12;
 	v9 = v4 + 40 * v5;
@@ -1839,8 +1825,7 @@ void __fastcall L5HorizWall(int i, int j, char p, int dx)
 		while ( v12 );
 		v4 = v15;
 	}
-	_LOBYTE(v10) = 0;
-	v13 = random(v10, dx - 1) + 1;
+	v13 = random(0, dx - 1) + 1;
 	if ( v8 == 12 )
 	{
 		dungeon[v5 + v13][v4] = 12;
@@ -1858,7 +1843,6 @@ void __fastcall L5VertWall(int i, int j, char p, int dy)
 	int v4; // edi
 	int v5; // esi
 	int v6; // eax
-	int v7; // ecx
 	int v8; // eax
 	int v9; // ebx
 	int v10; // esi
@@ -1875,9 +1859,8 @@ void __fastcall L5VertWall(int i, int j, char p, int dy)
 
 	v4 = j;
 	v5 = i;
-	_LOBYTE(i) = 0;
 	v18 = j;
-	v6 = random(i, 4);
+	v6 = random(0, 4);
 	if ( v6 >= 0 )
 	{
 		if ( v6 <= 1 )
@@ -1901,8 +1884,7 @@ void __fastcall L5VertWall(int i, int j, char p, int dy)
 				_LOBYTE(p) = 37;
 		}
 	}
-	_LOBYTE(v7) = 0;
-	v8 = random(v7, 6);
+	v8 = random(0, 6);
 	v9 = 5 - v8;
 	_LOBYTE(v9) = v8 != 5 ? 25 : 11;
 	v19 = v8 != 5 ? 25 : 11;
@@ -1929,8 +1911,7 @@ void __fastcall L5VertWall(int i, int j, char p, int dy)
 		v4 = v18;
 	}
 	v15 = v11 - 1;
-	_LOBYTE(v11) = 0;
-	v16 = random(v11, v15) + 1;
+	v16 = random(0, v15) + 1;
 	if ( (_BYTE)v9 == 11 )
 	{
 		dungeon[0][v16 + v10 * 40 + v4] = 11;

--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -1040,14 +1040,11 @@ bool __fastcall DRLG_L2PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, 
 	int v9; // edi
 	int v10; // edx
 	int v11; // eax
-	int v12; // ecx
 	int v13; // esi
 	int v14; // ebx
 	int v15; // ecx
 	int v16; // eax
-	int v17; // ecx
 	int v18; // eax
-	int v19; // ecx
 	int v20; // edi
 	signed int i; // eax
 	int v22; // ecx
@@ -1079,8 +1076,7 @@ bool __fastcall DRLG_L2PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, 
 	v35 = miniset[1];
 	if ( v10 )
 	{
-		_LOBYTE(miniset) = 0;
-		v30 = v8 + random((int)miniset, v10);
+		v30 = v8 + random(0, v10);
 	}
 	else
 	{
@@ -1098,12 +1094,10 @@ bool __fastcall DRLG_L2PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, 
 		v36 = 40 - v7;
 		do
 		{
-			_LOBYTE(miniset) = 0;
-			v11 = random((int)miniset, max);
-			_LOBYTE(v12) = 0;
+			v11 = random(0, max);
 			v13 = v11;
 			v33 = 0;
-			v14 = random(v12, v36);
+			v14 = random(0, v36);
 			v39 = v14;
 			do
 			{
@@ -1117,22 +1111,19 @@ bool __fastcall DRLG_L2PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, 
 					v15 = cx - v34;
 					if ( v13 >= cx - v34 && v13 <= cx + 12 )
 					{
-						_LOBYTE(v15) = 0;
-						v16 = random(v15, max);
-						_LOBYTE(v17) = 0;
+						v16 = random(0, max);
 						v13 = v16;
 						tmaxa = 0;
-						v39 = random(v17, v36);
+						v39 = random(0, v36);
 						v14 = v39;
 					}
 				}
 				if ( cy != -1 && v14 >= cy - v35 && v14 <= cy + 12 )
 				{
-					v18 = random(cy - v35, max);
-					_LOBYTE(v19) = 0;
+					v18 = random(0, max); /* cy - v35 */
 					v13 = v18;
 					tmaxa = 0;
-					v39 = random(v19, v36);
+					v39 = random(0, v36);
 					v14 = v39;
 				}
 				v20 = 0;
@@ -1318,8 +1309,7 @@ void __fastcall DRLG_L2PlaceRndSet(unsigned char *miniset, int rndper)
 						if ( v23 >= v32 + 2 * v31 )
 						{
 LABEL_34:
-							_LOBYTE(v12) = 0;
-							if ( random((int)v12, 100) < v20 )
+							if ( random(0, 100) < v20 )
 							{
 								for ( j = 0; j < v31; ++j )
 								{
@@ -1739,16 +1729,13 @@ void __fastcall CreateRoom(int nX1, int nY1, int nX2, int nY2, int nRDest, int n
 	int v13; // edx
 	int v14; // edx
 	int v15; // edi
-	int v16; // ecx
 	int v17; // esi
 	int v18; // ebx
 	int v19; // edx
 	int v20; // ecx
 	int v21; // eax
-	int v22; // ecx
 	int v23; // eax
 	int v24; // eax
-	int v25; // ecx
 	int v26; // eax
 	int *v27; // ecx
 	int v28; // eax
@@ -1803,18 +1790,15 @@ LABEL_11:
 				v13 = nY2 - v39;
 			}
 			v14 = v13 - nX1;
-			_LOBYTE(nX1) = 0;
-			v36 = Room_Min + random(nX1, v14);
+			v36 = Room_Min + random(0, v14);
 LABEL_16:
 			if ( ForceHW == 1 )
 			{
 				v41 = nW;
 				v36 = nH;
 			}
-			_LOBYTE(nX1) = 0;
-			v15 = v37 + random(nX1, v9);
-			_LOBYTE(v16) = 0;
-			v17 = v39 + random(v16, v10);
+			v15 = v37 + random(0, v9);
+			v17 = v39 + random(0, v10);
 			v18 = v15 + v41;
 			v43 = v17 + v36;
 			if ( v15 + v41 > nX2 )
@@ -1859,53 +1843,45 @@ LABEL_16:
 			{
 				if ( nHDir == 1 )
 				{
-					_LOBYTE(v20) = 0;
-					v21 = random(v20, v18 - v15 - 2);
-					_LOBYTE(v22) = 0;
+					v21 = random(0, v18 - v15 - 2);
 					nX1a = v21 + v15 + 1;
 					v33 = v17;
-					v23 = random(v22, RoomList[nRDest].nRoomx2 - RoomList[nRDest].nRoomx1 - 2);
+					v23 = random(0, RoomList[nRDest].nRoomx2 - RoomList[nRDest].nRoomx1 - 2);
 					v20 = 20 * nRDest;
 					v34 = v23 + RoomList[nRDest].nRoomx1 + 1;
 					v35 = RoomList[nRDest].nRoomy2;
 				}
 				if ( nHDir == 3 )
 				{
-					_LOBYTE(v20) = 0;
-					v24 = random(v20, v18 - v15 - 2);
-					_LOBYTE(v25) = 0;
+					v24 = random(0, v18 - v15 - 2);
 					nX1a = v24 + v15 + 1;
 					v33 = v43;
-					v26 = random(v25, RoomList[nRDest].nRoomx2 - RoomList[nRDest].nRoomx1 - 2);
+					v26 = random(0, RoomList[nRDest].nRoomx2 - RoomList[nRDest].nRoomx1 - 2);
 					v20 = 20 * nRDest;
 					v34 = v26 + RoomList[nRDest].nRoomx1 + 1;
 					v35 = RoomList[nRDest].nRoomy1;
 				}
 				if ( nHDir == 2 )
 				{
-					_LOBYTE(v20) = 0;
 					nX1a = v18;
-					v33 = random(v20, v43 - v17 - 2) + v17 + 1;
+					v33 = random(0, v43 - v17 - 2) + v17 + 1;
 					v34 = RoomList[nRDest].nRoomx1;
 					v27 = &RoomList[nRDest].nRoomy1;
 					ForceHWa = v27;
 					v28 = RoomList[nRDest].nRoomy2 - *v27;
-					_LOBYTE(v27) = 0;
-					v29 = random((int)v27, v28 - 2);
+					v29 = random(0, v28 - 2);
 					v20 = *ForceHWa;
 					v35 = v29 + *ForceHWa + 1;
 				}
 				if ( nHDir == 4 )
 				{
-					_LOBYTE(v20) = 0;
 					nX1a = v15;
-					v33 = random(v20, v43 - v17 - 2) + v17 + 1;
+					v33 = random(0, v43 - v17 - 2) + v17 + 1;
 					v34 = RoomList[nRDest].nRoomx2;
 					v30 = &RoomList[nRDest].nRoomy1;
 					ForceHWb = v30;
 					v31 = RoomList[nRDest].nRoomy2 - *v30;
-					_LOBYTE(v30) = 0;
-					v35 = random((int)v30, v31 - 2) + *ForceHWb + 1;
+					v35 = random(0, v31 - 2) + *ForceHWb + 1;
 				}
 				AddHall(nX1a, v33, v34, v35, nHDir);
 				v19 = v42;
@@ -1949,8 +1925,7 @@ LABEL_16:
 		}
 		v11 = Room_Max - Room_Min;
 LABEL_7:
-		_LOBYTE(nX1) = 0;
-		v12 = random(nX1, v11);
+		v12 = random(0, v11);
 		nX1 = Room_Min;
 		v41 = Room_Min + v12;
 		goto LABEL_11;
@@ -2100,7 +2075,6 @@ void __fastcall ConnectHall(int nX1, int nY1, int nX2, int nY2, int nHd)
 	int v5; // edi
 	signed int v6; // esi
 	int v7; // eax
-	int v8; // ecx
 	int v9; // edi
 	int v10; // ebx
 	int v11; // ecx
@@ -2114,7 +2088,6 @@ void __fastcall ConnectHall(int nX1, int nY1, int nX2, int nY2, int nHd)
 	int v19; // edx
 	int v20; // eax
 	//int v21; // ST04_4
-	int v22; // ecx
 	int v23; // ebx
 	int v24; // ebx
 	bool v25; // zf
@@ -2138,12 +2111,10 @@ void __fastcall ConnectHall(int nX1, int nY1, int nX2, int nY2, int nHd)
 	v34 = 0;
 	v5 = nY1;
 	v6 = nX1;
-	_LOBYTE(nX1) = 0;
 	nY = nY1;
-	v7 = random(nX1, 100);
-	_LOBYTE(v8) = 0;
+	v7 = random(0, 100);
 	v33 = v7;
-	v32 = random(v8, 100);
+	v32 = random(0, 100);
 	v31 = v6;
 	v30 = v5;
 	CreateDoorType(v6, v5);
@@ -2239,8 +2210,7 @@ void __fastcall ConnectHall(int nX1, int nY1, int nX2, int nY2, int nHd)
 			v24 = 5 * v20;
 			if ( 5 * v20 > 80 )
 				v24 = 80;
-			_LOBYTE(v22) = 0;
-			if ( random(v22, 100) < v24 )
+			if ( random(0, 100) < v24 )
 			{
 				if ( nY2a <= nY || nY >= 40 )
 				{
@@ -2256,8 +2226,7 @@ void __fastcall ConnectHall(int nX1, int nY1, int nX2, int nY2, int nHd)
 			v23 = 2 * v36;
 			if ( 2 * v36 > 30 )
 				v23 = 30;
-			_LOBYTE(v22) = 0;
-			if ( random(v22, 100) < v23 )
+			if ( random(0, 100) < v23 )
 			{
 				if ( nX2a <= v6 || v6 >= 40 )
 					v26 = 4;
@@ -2476,9 +2445,7 @@ LABEL_25:
 bool __cdecl DL2_FillVoids()
 {
 	int i; // eax
-	int v1; // ecx
 	int v2; // eax
-	int v3; // ecx
 	int v4; // edi
 	int v5; // eax
 	int v6; // ebx
@@ -2540,11 +2507,9 @@ bool __cdecl DL2_FillVoids()
 	v48 = 0;
 	for ( i = DL2_NumNoChar(); i > 700 && v48 < 100; i = DL2_NumNoChar() )
 	{
-		_LOBYTE(v1) = 0;
-		v2 = random(v1, 38);
-		_LOBYTE(v3) = 0;
+		v2 = random(0, 38);
 		v4 = v2 + 1;
-		v5 = random(v3, 38);
+		v5 = random(0, 38);
 		v6 = v5 + 1;
 		v7 = v5 + 1 + 40 * v4;
 		if ( predungeon[0][v7] != 35 )

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -684,11 +684,9 @@ int __fastcall DRLG_L3FillRoom(int x1, int y1, int x2, int y2)
 	char *v12; // edx
 	int v13; // eax
 	int i; // ebx
-	int v15; // ecx
 	int v16; // ecx
 	char *v17; // ebx
 	int v18; // edi
-	int v19; // ecx
 	int v21; // [esp+Ch] [ebp-4h]
 	int x2a; // [esp+18h] [ebp+8h]
 	int y2a; // [esp+1Ch] [ebp+Ch]
@@ -756,11 +754,9 @@ LABEL_12:
 	}
 	for ( i = v5; i <= y2; ++i )
 	{
-		_LOBYTE(v8) = 0;
-		if ( random(v8, 2) )
+		if ( random(0, 2) )
 			dungeon[v4][i] = 1;
-		_LOBYTE(v15) = 0;
-		if ( random(v15, 2) )
+		if ( random(0, 2) )
 			dungeon[v6][i] = 1;
 	}
 	if ( v4 <= v6 )
@@ -771,11 +767,9 @@ LABEL_12:
 		y2a = v21 - y2;
 		do
 		{
-			_LOBYTE(v16) = 0;
-			if ( random(v16, 2) )
+			if ( random(0, 2) )
 				v17[y2a] = 1;
-			_LOBYTE(v19) = 0;
-			if ( random(v19, 2) )
+			if ( random(0, 2) )
 				*v17 = 1;
 			v17 += 40;
 			--v18;
@@ -790,12 +784,9 @@ void __fastcall DRLG_L3CreateBlock(int x, int y, int obs, int dir)
 	int v4; // esi
 	int v5; // edi
 	int v6; // eax
-	int v7; // ecx
-	int v8; // ecx
 	int v9; // ebx
 	bool v10; // zf
 	bool v11; // zf
-	int v12; // ecx
 	int y2; // [esp+Ch] [ebp-14h]
 	int x2; // [esp+10h] [ebp-10h]
 	int i; // [esp+14h] [ebp-Ch]
@@ -807,26 +798,22 @@ void __fastcall DRLG_L3CreateBlock(int x, int y, int obs, int dir)
 	v16 = y;
 	for ( i = x; ; i = v4 )
 	{
-		_LOBYTE(x) = 0;
-		v6 = random(x, 2);
-		_LOBYTE(v7) = 0;
+		v6 = random(0, 2);
 		max = v6 + 3;
-		v9 = random(v7, 2) + 3;
+		v9 = random(0, 2) + 3;
 		if ( !dir )
 		{
 			y2 = v16 - 1;
 			v5 = v16 - 1 - v9;
 			if ( max < obs )
 			{
-				_LOBYTE(v8) = 0;
-				v4 = i + random(v8, max);
+				v4 = i + random(0, max);
 			}
 			if ( max == obs )
 				v4 = i;
 			if ( max > obs )
 			{
-				_LOBYTE(v8) = 0;
-				v4 = i - random(v8, max);
+				v4 = i - random(0, max);
 			}
 			x2 = v4 + max;
 		}
@@ -837,16 +824,14 @@ void __fastcall DRLG_L3CreateBlock(int x, int y, int obs, int dir)
 			v10 = v9 == obs;
 			if ( v9 < obs )
 			{
-				_LOBYTE(v8) = 0;
-				v5 = v16 + random(v8, v9);
+				v5 = v16 + random(0, v9);
 				v10 = v9 == obs;
 			}
 			if ( v10 )
 				v5 = v16;
 			if ( v9 > obs )
 			{
-				_LOBYTE(v8) = 0;
-				v5 = v16 - random(v8, v9);
+				v5 = v16 - random(0, v9);
 			}
 			y2 = v5 + v9;
 		}
@@ -856,15 +841,13 @@ void __fastcall DRLG_L3CreateBlock(int x, int y, int obs, int dir)
 			y2 = v16 + 1 + v9;
 			if ( max < obs )
 			{
-				_LOBYTE(v8) = 0;
-				v4 = i + random(v8, max);
+				v4 = i + random(0, max);
 			}
 			if ( max == obs )
 				v4 = i;
 			if ( max > obs )
 			{
-				_LOBYTE(v8) = 0;
-				v4 = i - random(v8, max);
+				v4 = i - random(0, max);
 			}
 			x2 = v4 + max;
 		}
@@ -875,23 +858,20 @@ void __fastcall DRLG_L3CreateBlock(int x, int y, int obs, int dir)
 			x2 = i + 1 + max;
 			if ( v9 < obs )
 			{
-				_LOBYTE(v8) = 0;
-				v5 = v16 + random(v8, v9);
+				v5 = v16 + random(0, v9);
 				v11 = v9 == obs;
 			}
 			if ( v11 )
 				v5 = v16;
 			if ( v9 > obs )
 			{
-				_LOBYTE(v8) = 0;
-				v5 = v16 - random(v8, v9);
+				v5 = v16 - random(0, v9);
 			}
 			y2 = v5 + v9;
 		}
 		if ( DRLG_L3FillRoom(v4, v5, x2, y2) != 1 )
 			break;
-		_LOBYTE(v12) = 0;
-		if ( !random(v12, 4) )
+		if ( !random(0, 4) )
 			break;
 		if ( dir != 2 )
 			DRLG_L3CreateBlock(v4, v5, v9, 0);
@@ -950,8 +930,7 @@ void __cdecl DRLG_L3FillDiags()
 			   + 2 * ((unsigned char)*(v1 - 40) + 2 * ((unsigned char)*(v1 - 1) + 2 * (unsigned char)*(v1 - 41)));
 			if ( v4 == 6 )
 			{
-				_LOBYTE(v3) = 0;
-				if ( !random(v3, 2) )
+				if ( !random(0, 2) )
 				{
 					*(v1 - 41) = 1;
 					goto LABEL_11;
@@ -960,8 +939,7 @@ void __cdecl DRLG_L3FillDiags()
 			}
 			if ( v4 == 9 )
 			{
-				_LOBYTE(v3) = 0;
-				if ( random(v3, 2) )
+				if ( random(0, 2) )
 					*(v1 - 40) = 1;
 				else
 					*(v1 - 1) = 1;
@@ -1056,8 +1034,7 @@ void __cdecl DRLG_L3FillStraights()
 			{
 				if ( v2 > 3 )
 				{
-					_LOBYTE(v1) = 0;
-					if ( random((int)v1, 2) )
+					if ( random(0, 2) )
 					{
 						if ( v0 < v29 )
 						{
@@ -1065,8 +1042,7 @@ void __cdecl DRLG_L3FillStraights()
 							v24 = (char *)dungeon + v4 + v27;
 							do
 							{
-								_LOBYTE(v1) = 0;
-								v6 = random((int)v1, 2);
+								v6 = random(0, 2);
 								v1 = v24;
 								v24 += 40;
 								--v5;
@@ -1113,8 +1089,7 @@ void __cdecl DRLG_L3FillStraights()
 			{
 				if ( v8 > 3 )
 				{
-					_LOBYTE(v7) = 0;
-					if ( random((int)v7, 2) )
+					if ( random(0, 2) )
 					{
 						if ( v0 < v30 )
 						{
@@ -1122,8 +1097,7 @@ void __cdecl DRLG_L3FillStraights()
 							v24 = &dungeon[0][v10 + 1 + v28];
 							do
 							{
-								_LOBYTE(v7) = 0;
-								v12 = random((int)v7, 2);
+								v12 = random(0, 2);
 								v7 = v24;
 								v24 += 40;
 								--v11;
@@ -1165,13 +1139,11 @@ void __cdecl DRLG_L3FillStraights()
 			{
 				if ( v14 > 3 )
 				{
-					_LOBYTE(v7) = 0;
-					if ( random((int)v7, 2) )
+					if ( random(0, 2) )
 					{
 						for ( i = (signed int)v24; i < v15; ++i )
 						{
-							_LOBYTE(v7) = 0;
-							dungeon[v13][i] = random((int)v7, 2);
+							dungeon[v13][i] = random(0, 2);
 						}
 					}
 				}
@@ -1200,13 +1172,11 @@ void __cdecl DRLG_L3FillStraights()
 			{
 				if ( v18 > 3 )
 				{
-					_LOBYTE(v7) = 0;
-					if ( random((int)v7, 2) )
+					if ( random(0, 2) )
 					{
 						for ( j = (signed int)v24; j < v19; ++j )
 						{
-							_LOBYTE(v7) = 0;
-							dungeon[v17 + 1][j] = random((int)v7, 2);
+							dungeon[v17 + 1][j] = random(0, 2);
 						}
 					}
 				}
@@ -1277,8 +1247,7 @@ void __cdecl DRLG_L3MakeMegas()
 			v4 = v3 + 2 * ((unsigned char)*v1 + 2 * ((unsigned char)v1[39] + 2 * (unsigned char)*(v1 - 1)));
 			if ( v4 == 6 )
 			{
-				_LOBYTE(v3) = 0;
-				if ( !random(v3, 2) )
+				if ( !random(0, 2) )
 				{
 					v4 = 12;
 					goto LABEL_9;
@@ -1287,8 +1256,7 @@ void __cdecl DRLG_L3MakeMegas()
 			}
 			if ( v4 == 9 )
 			{
-				_LOBYTE(v3) = 0;
-				v4 = (random(v3, 2) != 0) + 13;
+				v4 = (random(0, 2) != 0) + 13;
 			}
 LABEL_9:
 			--v2;
@@ -1786,8 +1754,7 @@ void __cdecl DRLG_L3Pool()
 				v5 = v2 <= 0 || v4 ? 1 : DRLG_L3SpawnEdge(v2, v0, &totarea);
 				v6 = v0 + 1 >= 40 || v5 ? 1 : DRLG_L3SpawnEdge(x, v0 + 1, &totarea);
 				v17 = v0 - 1 <= 0 || v6 ? 1 : DRLG_L3SpawnEdge(x, v0 - 1, &totarea);
-				_LOBYTE(v3) = 0;
-				v7 = random(v3, 100);
+				v7 = random(0, 100);
 				v8 = totarea;
 				v15 = v7;
 				v9 = v0 - totarea;
@@ -2016,14 +1983,11 @@ int __fastcall DRLG_L3PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, i
 	int v9; // edi
 	int v10; // edx
 	int v11; // eax
-	int v12; // ecx
 	int v13; // esi
 	signed int v14; // ebx
 	int v15; // ecx
 	int v16; // eax
-	int v17; // ecx
 	int v18; // eax
-	int v19; // ecx
 	int v20; // edi
 	signed int i; // eax
 	int v22; // ecx
@@ -2051,8 +2015,7 @@ int __fastcall DRLG_L3PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, i
 	v35 = miniset[1];
 	if ( v10 )
 	{
-		_LOBYTE(miniset) = 0;
-		v30 = v8 + random((int)miniset, v10);
+		v30 = v8 + random(0, v10);
 	}
 	else
 	{
@@ -2069,12 +2032,10 @@ int __fastcall DRLG_L3PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, i
 		v36 = 40 - v7;
 		do
 		{
-			_LOBYTE(miniset) = 0;
-			v11 = random((int)miniset, max);
-			_LOBYTE(v12) = 0;
+			v11 = random(0, max);
 			v13 = v11;
 			v33 = 0;
-			tmax = random(v12, v36);
+			tmax = random(0, v36);
 			while ( 1 )
 			{
 				if ( v33 >= 200 )
@@ -2086,20 +2047,17 @@ int __fastcall DRLG_L3PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, i
 					v15 = cx - v34;
 					if ( v13 >= cx - v34 && v13 <= cx + 12 )
 					{
-						_LOBYTE(v15) = 0;
-						v16 = random(v15, max);
-						_LOBYTE(v17) = 0;
+						v16 = random(0, max);
 						v13 = v16;
-						tmax = random(v17, v36);
+						tmax = random(0, v36);
 						v14 = 0;
 					}
 				}
 				if ( cy != -1 && tmax >= cy - v35 && tmax <= cy + 12 )
 				{
-					v18 = random(cy - v35, max);
-					_LOBYTE(v19) = 0;
+					v18 = random(0, max); /* cy - v35 */
 					v13 = v18;
-					tmax = random(v19, v36);
+					tmax = random(0, v36);
 					v14 = 0;
 				}
 				v20 = 0;
@@ -2291,8 +2249,7 @@ LABEL_43:
 LABEL_33:
 		if ( v29 == 1 )
 		{
-			_LOBYTE(v5) = 0;
-			if ( random((int)v5, 100) < v19 )
+			if ( random(0, 100) < v19 )
 			{
 				for ( j = 0; j < v28; ++j )
 				{

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1222,8 +1222,7 @@ void __fastcall L4HorizWall(int i, int j, int dx)
 		*v9 = 23;
 	if ( *v9 == 22 )
 		*v9 = 29;
-	_LOBYTE(v6) = 0;
-	v10 = v4 + 40 * (v3 + random(v6, dx - 3) + 1);
+	v10 = v4 + 40 * (v3 + random(0, dx - 3) + 1);
 	dungeon[2][v10] = 56;
 	dungeon[1][v10] = 60;
 	v11 = dungeon[0][v10 - 1] == 6;
@@ -1277,8 +1276,7 @@ void __fastcall L4VertWall(int i, int j, int dy)
 	if ( *v7 == 23 )
 		*v7 = 29;
 	v8 = v6 - 3;
-	_LOBYTE(v6) = 0;
-	v9 = random(v6, v8) + 1 + v4 + v3;
+	v9 = random(0, v8) + 1 + v4 + v3;
 	v10 = (char *)dungeon + v9;
 	dungeon[0][v9 + 2] = 52;
 	dungeon[0][v9 + 1] = 6;
@@ -2493,8 +2491,7 @@ void __cdecl uShape()
 		--v0;
 	}
 	while ( v0 >= 0 );
-	_LOBYTE(v0) = 0;
-	v4 = random(v0, 19) + 1;
+	v4 = random(0, 19) + 1;
 	do
 	{
 		if ( hallok[v4] )
@@ -2543,8 +2540,7 @@ void __cdecl uShape()
 		v7 -= 20;
 	}
 	while ( (signed int)v8 >= (signed int)hallok );
-	_LOBYTE(v7) = 0;
-	v11 = random(v7, 19) + 1;
+	v11 = random(0, 19) + 1;
 	do
 	{
 		if ( hallok[v11] )
@@ -2702,13 +2698,11 @@ void __fastcall L4roomGen(int x, int y, int w, int h, int dir)
 	int v7; // eax
 	int v8; // ecx
 	int v9; // eax
-	int v10; // ecx
 	int v11; // esi
 	int v12; // edi
 	int v13; // ebx
 	int v14; // eax
 	int v15; // eax
-	int v16; // ecx
 	int v17; // esi
 	int v18; // edi
 	int v19; // ebx
@@ -2733,8 +2727,7 @@ void __fastcall L4roomGen(int x, int y, int w, int h, int dir)
 	{
 		while ( 1 )
 		{
-			_LOBYTE(x) = 0;
-			v5 = random(x, 4);
+			v5 = random(0, 4);
 			v6 = 0;
 			_LOBYTE(v6) = dir == 1 ? v5 != 0 : v5 == 0;
 			v7 = v6;
@@ -2747,11 +2740,9 @@ void __fastcall L4roomGen(int x, int y, int w, int h, int dir)
 			wa = w / 2;
 			do
 			{
-				_LOBYTE(v8) = 0;
-				v9 = random(v8, 5);
-				_LOBYTE(v10) = 0;
+				v9 = random(0, 5);
 				v11 = (v9 + 2) & 0xFFFFFFFE;
-				v12 = (random(v10, 5) + 2) & 0xFFFFFFFE;
+				v12 = (random(0, 5) + 2) & 0xFFFFFFFE;
 				v13 = xa + wa - v11 / 2;
 				ya = v27 - v12;
 				v14 = L4checkRoom(v13 - 1, v27 - v12 - 1, v11 + 2, v12 + 1);
@@ -2779,11 +2770,9 @@ void __fastcall L4roomGen(int x, int y, int w, int h, int dir)
 		hb = h / 2;
 		do
 		{
-			_LOBYTE(v8) = 0;
-			v15 = random(v8, 5);
-			_LOBYTE(v16) = 0;
+			v15 = random(0, 5);
 			v17 = (v15 + 2) & 0xFFFFFFFE;
-			v18 = (random(v16, 5) + 2) & 0xFFFFFFFE;
+			v18 = (random(0, 5) + 2) & 0xFFFFFFFE;
 			v19 = v27 + hb - v18 / 2;
 			yb = xa - v17;
 			v20 = L4checkRoom(xa - v17 - 1, v19 - 1, v18 + 2, v17 + 1);
@@ -2850,14 +2839,11 @@ bool __fastcall DRLG_L4PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, 
 	int v9; // edi
 	int v10; // edx
 	int v11; // eax
-	int v12; // ecx
 	int v13; // esi
 	int v14; // ebx
 	int v15; // ecx
 	int v16; // eax
-	int v17; // ecx
 	int v18; // eax
-	int v19; // ecx
 	int v20; // edi
 	signed int i; // eax
 	int v22; // ecx
@@ -2889,8 +2875,7 @@ bool __fastcall DRLG_L4PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, 
 	v35 = miniset[1];
 	if ( v10 )
 	{
-		_LOBYTE(miniset) = 0;
-		v30 = v8 + random((int)miniset, v10);
+		v30 = v8 + random(0, v10);
 	}
 	else
 	{
@@ -2908,12 +2893,10 @@ bool __fastcall DRLG_L4PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, 
 		v36 = 40 - v7;
 		do
 		{
-			_LOBYTE(miniset) = 0;
-			v11 = random((int)miniset, max);
-			_LOBYTE(v12) = 0;
+			v11 = random(0, max);
 			v13 = v11;
 			v33 = 0;
-			v14 = random(v12, v36);
+			v14 = random(0, v36);
 			v39 = v14;
 			do
 			{
@@ -2927,22 +2910,19 @@ bool __fastcall DRLG_L4PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, 
 					v15 = cx - v34;
 					if ( v13 >= cx - v34 && v13 <= cx + 12 )
 					{
-						_LOBYTE(v15) = 0;
-						v16 = random(v15, max);
-						_LOBYTE(v17) = 0;
+						v16 = random(0, max);
 						v13 = v16;
 						tmaxa = 0;
-						v39 = random(v17, v36);
+						v39 = random(0, v36);
 						v14 = v39;
 					}
 				}
 				if ( cy != -1 && v14 >= cy - v35 && v14 <= cy + 12 )
 				{
-					v18 = random(cy - v35, max);
-					_LOBYTE(v19) = 0;
+					v18 = random(0, max); /* cy - v35 */
 					v13 = v18;
 					tmaxa = 0;
-					v39 = random(v19, v36);
+					v39 = random(0, v36);
 					v14 = v39;
 				}
 				v20 = 0;

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1022,8 +1022,7 @@ void __fastcall PlayEffect(int i, int mode)
 	v3 = i;
 	if ( !plr[myplr].pLvlLoad )
 	{
-		_LOBYTE(i) = -92;
-		v4 = random(i, 2);
+		v4 = random(164, 2);
 		if ( gbSndInited )
 		{
 			if ( gbSoundOn )
@@ -1188,8 +1187,7 @@ int __fastcall RndSFX(int psfx)
 LABEL_12:
 			v3 = 2;
 LABEL_15:
-			_LOBYTE(psfx) = -91;
-			return v1 + random(psfx, v3);
+			return v1 + random(165, v3);
 		case PS_WARR2:
 LABEL_19:
 			v3 = 3;

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -1845,16 +1845,11 @@ int __cdecl GetRndSeed()
 
 int __fastcall random(int idx, int v)
 {
-	int v2; // esi
-	int v4; // eax
-
-	v2 = v;
 	if ( v <= 0 )
 		return 0;
-	v4 = GetRndSeed();
-	if ( v2 < 0xFFFF )
-		v4 >>= 16;
-	return v4 % v2;
+	if ( v >= 0xFFFF )
+		return GetRndSeed() % v;
+	return (GetRndSeed() >> 16) % v;
 }
 
 struct engine_cpp_init_2

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -1183,8 +1183,7 @@ LABEL_53:
 	}
 	if ( leveltype == DTYPE_CATACOMBS )
 	{
-		_LOBYTE(v5) = 0;
-		v13 = random(v5, 2);
+		v13 = random(0, 2);
 		if ( v13 )
 		{
 			if ( v13 == 1 )
@@ -1205,8 +1204,7 @@ LABEL_53:
 	}
 	if ( leveltype == DTYPE_CAVES )
 	{
-		_LOBYTE(v5) = 0;
-		v14 = random(v5, 2);
+		v14 = random(0, 2);
 		if ( v14 )
 		{
 			if ( v14 == 1 )
@@ -1227,8 +1225,7 @@ LABEL_53:
 	}
 	if ( leveltype == DTYPE_HELL )
 	{
-		_LOBYTE(v5) = 0;
-		v15 = random(v5, 2);
+		v15 = random(0, 2);
 		if ( v15 )
 		{
 			if ( v15 == 1 )
@@ -1258,16 +1255,12 @@ LABEL_53:
 void __fastcall DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, int rndSize)
 {
 	int v5; // ebx
-	int v6; // ecx
 	//int v7; // eax
 	int v8; // esi
 	int v9; // edi
 	int v10; // eax
-	int v11; // ecx
 	int v12; // eax
-	int v13; // ecx
 	int v14; // eax
-	int v15; // ecx
 	int v16; // eax
 	int v17; // edi
 	int v18; // esi
@@ -1296,8 +1289,7 @@ void __fastcall DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int fr
 		{
 			if ( *v24 == floor )
 			{
-				_LOBYTE(v6) = 0;
-				if ( !random(v6, freq) )
+				if ( !random(0, freq) )
 				{
 					//_LOBYTE(v7) = DRLG_WillThemeRoomFit(floor, x, v5, minSize2, maxSize2, &width, &height);
 					if ( DRLG_WillThemeRoomFit(floor, x, v5, minSize2, maxSize2, &width, &height) )
@@ -1306,16 +1298,12 @@ void __fastcall DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int fr
 						{
 							v8 = minSize2 - 2;
 							v9 = maxSize2 - 2;
-							_LOBYTE(v6) = 0;
-							v10 = random(v6, width - (minSize2 - 2) + 1);
-							_LOBYTE(v11) = 0;
-							v12 = minSize2 - 2 + random(v11, v10);
+							v10 = random(0, width - (minSize2 - 2) + 1);
+							v12 = minSize2 - 2 + random(0, v10);
 							if ( v12 < minSize2 - 2 || (width = v12, v12 > v9) )
 								width = minSize2 - 2;
-							_LOBYTE(v13) = 0;
-							v14 = random(v13, height - v8 + 1);
-							_LOBYTE(v15) = 0;
-							v16 = v8 + random(v15, v14);
+							v14 = random(0, height - v8 + 1);
+							v16 = v8 + random(0, v14);
 							if ( v16 < v8 || v16 > v9 )
 								v16 = minSize2 - 2;
 							height = v16;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2390,18 +2390,15 @@ LABEL_71:
 			switch ( v12 )
 			{
 				case UI_WARRIOR:
-					_LOBYTE(v5) = 0;
-					v13 = random(v5, 3) + PS_WARR14;
+					v13 = random(0, 3) + PS_WARR14;
 LABEL_84:
 					PlaySFX(v13);
 					break;
 				case UI_ROGUE:
-					_LOBYTE(v5) = 0;
-					v13 = random(v5, 3) + PS_ROGUE14;
+					v13 = random(0, 3) + PS_ROGUE14;
 					goto LABEL_84;
 				case UI_SORCERER:
-					_LOBYTE(v5) = 0;
-					v13 = random(v5, 3) + PS_MAGE14;
+					v13 = random(0, 3) + PS_MAGE14;
 					goto LABEL_84;
 			}
 		}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1689,8 +1689,7 @@ bool __fastcall GetItemSpace(int x, int y, char inum)
 		v5 = (char (*)[3])((char *)v5 + 4);
 	}
 	while ( (signed int)v5 < (signed int)&itemhold[3][0] );
-	_LOBYTE(v11) = 13;
-	v12 = random(v11, 15) + 1;
+	v12 = random(13, 15) + 1;
 	if ( !v9 )
 		return 0;
 	v14 = 0;
@@ -1858,8 +1857,7 @@ void __fastcall GetBookSpell(int i, int lvl)
 	v3 = i;
 	if ( !lvl )
 		v2 = lvl + 1;
-	_LOBYTE(i) = 14;
-	v4 = random(i, 37) + 1;
+	v4 = random(14, 37) + 1;
 LABEL_13:
 	v6 = 1;
 	while ( v4 > 0 )
@@ -1918,9 +1916,8 @@ void __fastcall GetStaffPower(int i, int lvl, int bs, unsigned char onlygood)
 
 	v4 = lvl;
 	ia = i;
-	_LOBYTE(i) = 15;
 	v5 = -1;
-	if ( !random(i, 10) || onlygood )
+	if ( !random(15, 10) || onlygood )
 	{
 		v6 = 0;
 		v7 = 0;
@@ -1939,8 +1936,7 @@ void __fastcall GetStaffPower(int i, int lvl, int bs, unsigned char onlygood)
 			while ( PL_Prefix[v7].PLPower != -1 );
 			if ( v6 )
 			{
-				_LOBYTE(v7) = 16;
-				v5 = l[random(v7, v6)];
+				v5 = l[random(16, v6)];
 				v9 = ia;
 				v17 = item[ia]._iIName;
 				sprintf(istr, "%s %s", PL_Prefix[v5].PLName, item[ia]._iIName);
@@ -4516,9 +4512,8 @@ LABEL_41:
 				return;
 			}
 			v10 = p;
-			_LOBYTE(p) = 40;
 			v11 = plr[v10]._pMaxMana >> 8;
-			v12 = (v11 & 0xFFFFFFFE) + 2 * random(p, v11);
+			v12 = (v11 & 0xFFFFFFFE) + 2 * random(40, v11);
 			v13 = plr[v10]._pClass;
 			v14 = 32 * v12;
 			if ( v13 == 2 )
@@ -4543,9 +4538,8 @@ LABEL_41:
 		}
 LABEL_71:
 		v61 = p;
-		_LOBYTE(p) = 39;
 		v62 = plr[v61]._pMaxHP >> 8;
-		v63 = (v62 & 0xFFFFFFFE) + 2 * random(p, v62);
+		v63 = (v62 & 0xFFFFFFFE) + 2 * random(39, v62);
 		v64 = plr[v61]._pClass;
 		v65 = 32 * v63;
 		if ( !v64 )
@@ -4664,9 +4658,8 @@ LABEL_71:
 	else
 	{
 		v42 = p;
-		_LOBYTE(p) = 39;
 		v43 = plr[v42]._pMaxHP >> 8;
-		v44 = (v43 & 0xFFFFFFFE) + 2 * random(p, v43);
+		v44 = (v43 & 0xFFFFFFFE) + 2 * random(39, v43);
 		v45 = plr[v42]._pClass;
 		v46 = 32 * v44;
 		if ( !v45 )
@@ -4685,9 +4678,8 @@ LABEL_71:
 			*v50 = v49;
 		v51 = plr[v42]._pMaxMana >> 8;
 		v52 = plr[v42]._pMaxMana >> 8;
-		_LOBYTE(v49) = 40;
 		drawhpflag = 1;
-		v53 = (v51 & 0xFFFFFFFE) + 2 * random(v49, v52);
+		v53 = (v51 & 0xFFFFFFFE) + 2 * random(40, v52);
 		v54 = plr[v42]._pClass;
 		v55 = 32 * v53;
 		if ( v54 == 2 )

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1244,7 +1244,6 @@ bool __fastcall MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, i
 	int v9; // eax
 	int v10; // edi
 	//int v11; // eax
-	int v12; // ecx
 	int v13; // eax
 	int v14; // [esp+Ch] [ebp-10h]
 	int v15; // [esp+10h] [ebp-Ch]
@@ -1274,8 +1273,7 @@ bool __fastcall MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, i
 		return 0;
 	if ( v8 & 1 && v9 == 3 || v8 & 2 && v9 == 1 || v8 & 4 && v9 == 2 )
 		v16 = 1;
-	_LOBYTE(v8) = 68;
-	v14 = random(v8, 100);
+	v14 = random(68, 100);
 	v10 = 90 - (unsigned char)monster[v6].mArmorClass - dist;
 	if ( v10 < 5 )
 		v10 = 5;
@@ -1291,8 +1289,7 @@ bool __fastcall MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, i
 	if ( v14 >= v10 && monster[v6]._mmode != MM_STONE )
 		return 0;
 #endif
-	_LOBYTE(v12) = 68;
-	v13 = v15 + random(v12, maxdam - v15 + 1);
+	v13 = v15 + random(68, maxdam - v15 + 1);
 	if ( !(_BYTE)shift )
 		v13 <<= 6;
 	if ( v16 )
@@ -1344,7 +1341,6 @@ bool __fastcall MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, i
 	char v14; // al
 	int v15; // eax
 	//int v16; // eax
-	int v17; // ecx
 	int v19; // ebx
 	int v20; // ebx
 	int v21; // edx
@@ -1384,8 +1380,7 @@ bool __fastcall MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, i
 		return 0;
 	if ( v9 & 1 && v10 == 3 || v9 & 2 && v10 == 1 || v9 & 4 && v10 == 2 )
 		v26 = 1;
-	_LOBYTE(v10) = 69;
-	v11 = random(v10, 100);
+	v11 = random(69, 100);
 	v8 = missiledata[t].mType == 0;
 	v25 = v11;
 	if ( v8 )
@@ -1439,8 +1434,7 @@ bool __fastcall MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, i
 	}
 	else
 	{
-		_LOBYTE(v17) = 70;
-		v19 = mindam + random(v17, maxdam - mindam + 1);
+		v19 = mindam + random(70, maxdam - mindam + 1);
 	}
 	dist_3 = missiledata[v23].mType;
 	if ( !missiledata[v23].mType )
@@ -1602,8 +1596,7 @@ LABEL_25:
 	}
 	else
 	{
-		_LOBYTE(v11) = 73;
-		v35 = random(v11, 100);
+		v35 = random(73, 100);
 	}
 	if ( (_BYTE)shift == 1 )
 		v35 = 100;
@@ -1646,17 +1639,16 @@ LABEL_50:
 		}
 		else
 		{
-			_LOBYTE(v11) = 75;
 			if ( (_BYTE)shift )
 			{
-				v23 = mind + random(v11, maxd - mind + 1);
+				v23 = mind + random(75, maxd - mind + 1);
 				if ( v34 == -1 && plr[v9]._pIFlags & 0x10000000 )
 					v23 >>= 1;
 				v21 = plr[v9]._pIGetHit + v23;
 			}
 			else
 			{
-				v22 = (mind << 6) + random(v11, (maxd - mind + 1) << 6);
+				v22 = (mind << 6) + random(75, (maxd - mind + 1) << 6);
 				if ( v34 == -1 && plr[v9]._pIFlags & 0x10000000 )
 					v22 >>= 1;
 				v21 = (plr[v9]._pIGetHit << 6) + v22;
@@ -1829,8 +1821,7 @@ LABEL_14:
 		}
 		else
 		{
-			_LOBYTE(v12) = 73;
-			v24 = random(v12, 100);
+			v24 = random(73, 100);
 		}
 		if ( (_BYTE)shift == 1 )
 			v24 = 100;
@@ -1854,8 +1845,7 @@ LABEL_14:
 		}
 		else
 		{
-			_LOBYTE(v16) = 70;
-			v17 = mindam + random(v16, maxdam - mindam + 1);
+			v17 = mindam + random(70, maxdam - mindam + 1);
 			if ( !missiledata[v22].mType )
 				v17 += plr[v10]._pIBonusDamMod + plr[v10]._pDamageMod + v17 * plr[v10]._pIBonusDam / 100;
 			v16 = dista;
@@ -2507,12 +2497,9 @@ void __fastcall GetVileMissPos(int mi, int dx, int dy)
 void __fastcall AddRndTeleport(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // eax
-	int v10; // ecx
 	int v11; // esi
 	int v12; // eax
-	int v13; // ecx
 	int v14; // edi
-	int v15; // ecx
 	int v16; // eax
 	bool v17; // zf
 	int v18; // ecx
@@ -2527,15 +2514,12 @@ void __fastcall AddRndTeleport(int mi, int sx, int sy, int dx, int dy, int midir
 	while ( ++v22 <= 500 )
 	{
 		v9 = random(58, 3);
-		_LOBYTE(v10) = 58;
 		v11 = v9 + 4;
-		v12 = random(v10, 3);
-		_LOBYTE(v13) = 58;
+		v12 = random(58, 3);
 		v14 = v12 + 4;
-		if ( random(v13, 2) == 1 )
+		if ( random(58, 2) == 1 )
 			v11 = -v11;
-		_LOBYTE(v15) = 58;
-		if ( random(v15, 2) == 1 )
+		if ( random(58, 2) == 1 )
 			v14 = -v14;
 		mi = 4 * (sy + v14 + 112 * (v11 + v20));
 		if ( !nSolidTable[dPiece[0][mi / 4u]] && !dObject[v11 + v20][sy + v14] && !dMonster[0][mi / 4u] )
@@ -2743,7 +2727,6 @@ void __fastcall AddLightball(int mi, int sx, int sy, int dx, int dy, int midir, 
 	int v9; // edi
 	int v10; // esi
 	int v11; // esi
-	int v12; // ecx
 	int v13; // eax
 	int v14; // eax
 
@@ -2751,9 +2734,8 @@ void __fastcall AddLightball(int mi, int sx, int sy, int dx, int dy, int midir, 
 	v10 = mi;
 	GetMissileVel(mi, sx, sy, dx, dy, 16);
 	v11 = v10;
-	_LOBYTE(v12) = 63;
 	missile[v11]._midam = dam;
-	v13 = random(v12, 8);
+	v13 = random(63, 8);
 	missile[v11]._mirange = 255;
 	missile[v11]._miAnimFrame = v13 + 1;
 	if ( id >= 0 )
@@ -2775,7 +2757,6 @@ void __fastcall AddFirewall(int mi, int sx, int sy, int dx, int dy, int midir, i
 	int i; // ST1C_4
 	int v11; // esi
 	int v12; // eax
-	int v13; // ecx
 	int v14; // eax
 	int v15; // eax
 	int v16; // eax
@@ -2784,8 +2765,7 @@ void __fastcall AddFirewall(int mi, int sx, int sy, int dx, int dy, int midir, i
 	i = mi;
 	v11 = i;
 	v12 = random(53, 10);
-	_LOBYTE(v13) = 53;
-	missile[v11]._midam = 16 * (random(v13, 10) + v12 + plr[id]._pLevel + 2) >> 1;
+	missile[v11]._midam = 16 * (random(53, 10) + v12 + plr[id]._pLevel + 2) >> 1;
 	GetMissileVel(i, v9, sy, dx, dy, 16);
 	v14 = missile[i]._mispllvl;
 	missile[v11]._mirange = 10;
@@ -2802,7 +2782,6 @@ void __fastcall AddFireball(int mi, int sx, int sy, int dx, int dy, int midir, i
 {
 	int v9; // edi
 	int v10; // eax
-	int v11; // ecx
 	int v12; // ecx
 	int v13; // edx
 	int v14; // esi
@@ -2830,8 +2809,7 @@ void __fastcall AddFireball(int mi, int sx, int sy, int dx, int dy, int midir, i
 	else
 	{
 		v10 = random(60, 10);
-		_LOBYTE(v11) = 60;
-		v12 = 2 * (plr[id]._pLevel + random(v11, 10) + v10) + 4;
+		v12 = 2 * (plr[id]._pLevel + random(60, 10) + v10) + 4;
 		v13 = missile[i]._mispllvl;
 		missile[i]._midam = v12;
 		if ( v13 > 0 )
@@ -2868,7 +2846,6 @@ void __fastcall AddLightctrl(int mi, int sx, int sy, int dx, int dy, int midir, 
 	int v9; // edi
 	int v10; // ebx
 	int v11; // esi
-	int v12; // ecx
 	int v13; // eax
 
 	v9 = sx;
@@ -2879,8 +2856,7 @@ void __fastcall AddLightctrl(int mi, int sx, int sy, int dx, int dy, int midir, 
 	missile[v11]._miVar1 = v9;
 	missile[v11]._miVar2 = sy;
 	GetMissileVel(v10, v9, sy, dx, dy, 32);
-	_LOBYTE(v12) = 52;
-	v13 = random(v12, 8);
+	v13 = random(52, 8);
 	missile[v11]._mirange = 256;
 	missile[v11]._miAnimFrame = v13 + 1;
 }
@@ -3873,7 +3849,6 @@ void __fastcall AddHeal(int mi, int sx, int sy, int dx, int dy, int midir, int m
 {
 	int v9; // esi
 	signed int v10; // ebx
-	int v11; // ecx
 	int v12; // edi
 	int i; // ebx
 	char v14; // al
@@ -3892,8 +3867,7 @@ void __fastcall AddHeal(int mi, int sx, int sy, int dx, int dy, int midir, int m
 	{
 		do
 		{
-			_LOBYTE(v11) = 57;
-			v12 += (random(v11, 4) + 1) << 6;
+			v12 += (random(57, 4) + 1) << 6;
 			++v10;
 		}
 		while ( v10 < plr[v9]._pLevel );
@@ -3901,8 +3875,7 @@ void __fastcall AddHeal(int mi, int sx, int sy, int dx, int dy, int midir, int m
 	v20 = 0;
 	for ( i = v19; v20 < missile[i]._mispllvl; ++v20 )
 	{
-		_LOBYTE(v11) = 57;
-		v12 += (random(v11, 6) + 1) << 6;
+		v12 += (random(57, 6) + 1) << 6;
 	}
 	v14 = plr[v9]._pClass;
 	if ( !v14 )
@@ -3937,7 +3910,6 @@ void __fastcall AddElement(int mi, int sx, int sy, int dx, int dy, int midir, in
 	int v9; // ebx
 	int v10; // edi
 	int v11; // eax
-	int v12; // ecx
 	int v13; // eax
 	int v14; // esi
 	int v15; // ecx
@@ -3955,8 +3927,7 @@ void __fastcall AddElement(int mi, int sx, int sy, int dx, int dy, int midir, in
 		v10 = YDirAdd[midir] + dy;
 	}
 	v11 = random(60, 10);
-	_LOBYTE(v12) = 60;
-	v13 = 2 * (plr[id]._pLevel + random(v12, 10) + v11) + 4;
+	v13 = 2 * (plr[id]._pLevel + random(60, 10) + v11) + 4;
 	v14 = i;
 	v15 = missile[i]._mispllvl;
 	missile[i]._midam = v13;
@@ -4121,25 +4092,19 @@ void __fastcall AddNova(int mi, int sx, int sy, int dx, int dy, int midir, int m
 {
 	int v9; // esi
 	int v10; // eax
-	int v11; // ecx
 	int v12; // ebx
 	int v13; // eax
-	int v14; // ecx
 	int v15; // ebx
 	int v16; // eax
-	int v17; // ecx
 	int v18; // ebx
 	int v19; // eax
-	int v20; // ecx
 	int v21; // ebx
 	int v22; // eax
 	int v23; // ecx
 	int v24; // eax
 	int v25; // eax
-	int v26; // ecx
 	int v27; // edi
 	int v28; // eax
-	int v29; // ecx
 
 	v9 = mi;
 	missile[v9]._miVar1 = dx;
@@ -4147,27 +4112,21 @@ void __fastcall AddNova(int mi, int sx, int sy, int dx, int dy, int midir, int m
 	if ( id == -1 )
 	{
 		v25 = random(66, 3);
-		_LOBYTE(v26) = 66;
 		v27 = v25;
-		v28 = random(v26, 3);
-		_LOBYTE(v29) = 66;
-		missile[v9]._midam = ((unsigned int)currlevel >> 1) + random(v29, 3) + v28 + v27;
+		v28 = random(66, 3);
+		missile[v9]._midam = ((unsigned int)currlevel >> 1) + random(66, 3) + v28 + v27;
 	}
 	else
 	{
 		v10 = random(66, 6);
-		_LOBYTE(v11) = 66;
 		v12 = v10;
-		v13 = random(v11, 6);
-		_LOBYTE(v14) = 66;
+		v13 = random(66, 6);
 		v15 = v13 + v12;
-		v16 = random(v14, 6);
-		_LOBYTE(v17) = 66;
+		v16 = random(66, 6);
 		v18 = v16 + v15;
-		v19 = random(v17, 6);
-		_LOBYTE(v20) = 66;
+		v19 = random(66, 6);
 		v21 = v19 + v18;
-		v22 = random(v20, 6);
+		v22 = random(66, 6);
 		v23 = missile[v9]._mispllvl;
 		v24 = (v22 + v21 + plr[id]._pLevel + 5) >> 1;
 		missile[v9]._midam = v24;
@@ -4258,8 +4217,7 @@ void __fastcall AddApoca(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	{
 		do
 		{
-			_LOBYTE(v12) = 67;
-			missile[v9]._midam += random(v12, 6) + 1;
+			missile[v9]._midam += random(67, 6) + 1;
 			++v13;
 		}
 		while ( v13 < *v14 );
@@ -4272,9 +4230,7 @@ void __fastcall AddApoca(int mi, int sx, int sy, int dx, int dy, int midir, int 
 void __fastcall AddFlame(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
-	int v10; // ecx
 	int v11; // eax
-	int v12; // ecx
 	int v13; // edi
 	int v14; // eax
 
@@ -4292,19 +4248,16 @@ void __fastcall AddFlame(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	missile[v9]._mlid = AddLight(sx, sy, 1);
 	if ( (_BYTE)mienemy )
 	{
-		_LOBYTE(v10) = 77;
 		missile[v9]._midam = (unsigned char)monster[id].mMinDamage
 						   + random(
-								 v10,
+								 77,
 								 (unsigned char)monster[id].mMaxDamage - (unsigned char)monster[id].mMinDamage + 1);
 	}
 	else
 	{
-		_LOBYTE(v10) = 79;
-		v11 = random(v10, plr[id]._pLevel);
-		_LOBYTE(v12) = 79;
+		v11 = random(79, plr[id]._pLevel);
 		v13 = v11;
-		v14 = random(v12, 2);
+		v14 = random(79, 2);
 		missile[v9]._midam = 8 * (v14 + v13) + 16 + ((8 * (v14 + v13) + 16) >> 1);
 	}
 }
@@ -4340,7 +4293,6 @@ void __fastcall AddCbolt(int mi, int sx, int sy, int dx, int dy, int midir, int 
 {
 	int v9; // esi
 	int v10; // eax
-	int v11; // ecx
 	int v12; // edx
 	int v13; // eax
 	int v14; // ecx
@@ -4359,10 +4311,9 @@ void __fastcall AddCbolt(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	else
 	{
 		v10 = random(63, 15);
-		_LOBYTE(v11) = 68;
 		v12 = plr[id]._pMagic;
 		missile[v9]._mirnd = v10 + 1;
-		missile[v9]._midam = random(v11, v12 >> 2) + 1;
+		missile[v9]._midam = random(68, v12 >> 2) + 1;
 	}
 	v14 = dx;
 	if ( x == dx && sy == dy )
@@ -4371,8 +4322,7 @@ void __fastcall AddCbolt(int mi, int sx, int sy, int dx, int dy, int midir, int 
 		dx += XDirAdd[midir];
 		dy += YDirAdd[midir];
 	}
-	_LOBYTE(v14) = 63;
-	missile[v9]._miAnimFrame = random(v14, 8) + 1;
+	missile[v9]._miAnimFrame = random(63, 8) + 1;
 	missile[v9]._mlid = AddLight(x, sy, 5);
 	GetMissileVel(i, x, sy, dx, dy, 8);
 	missile[v9]._miVar3 = 0;
@@ -4390,7 +4340,6 @@ void __fastcall AddHbolt(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	int v13; // eax
 	int v14; // esi
 	int v15; // eax
-	int v16; // ecx
 	signed int v17; // [esp-4h] [ebp-14h]
 	int i; // [esp+Ch] [ebp-4h]
 
@@ -4424,9 +4373,8 @@ LABEL_8:
 	missile[v14]._miVar1 = v11;
 	missile[v14]._miVar2 = sy;
 	v15 = AddLight(v11, sy, 8);
-	_LOBYTE(v16) = 69;
 	missile[v14]._mlid = v15;
-	missile[v14]._midam = random(v16, 10) + plr[id]._pLevel + 9;
+	missile[v14]._midam = random(69, 10) + plr[id]._pLevel + 9;
 	UseMana(id, 31);
 }
 
@@ -4780,7 +4728,6 @@ void __fastcall MI_LArrow(int i)
 	char v2; // al
 	int v3; // ebx
 	int v4; // eax
-	int v5; // ecx
 	int v6; // edi
 	int v7; // ecx
 	int v8; // eax
@@ -4822,12 +4769,10 @@ void __fastcall MI_LArrow(int i)
 		{
 			if ( v3 == -1 )
 			{
-				_LOBYTE(v18) = 68;
-				v21 = random(v18, 10);
+				v21 = random(68, 10);
 				v22 = currlevel;
 				v19 = v21 + currlevel + 1;
-				_LOBYTE(v22) = 68;
-				v20 = random(v22, 10) + 2 * currlevel + 1;
+				v20 = random(68, 10) + 2 * currlevel + 1;
 			}
 			else
 			{
@@ -4842,12 +4787,10 @@ void __fastcall MI_LArrow(int i)
 		{
 			if ( v3 == -1 )
 			{
-				_LOBYTE(v18) = 68;
-				v26 = random(v18, 10);
+				v26 = random(68, 10);
 				v27 = currlevel;
 				v24 = v26 + currlevel + 1;
-				_LOBYTE(v27) = 68;
-				v25 = random(v27, 10) + 2 * currlevel + 1;
+				v25 = random(68, 10) + 2 * currlevel + 1;
 			}
 			else
 			{
@@ -4869,12 +4812,10 @@ void __fastcall MI_LArrow(int i)
 		GetMissilePos(i);
 		if ( v3 == -1 )
 		{
-			_LOBYTE(v5) = 68;
-			v8 = random(v5, 10);
+			v8 = random(68, 10);
 			v9 = currlevel;
 			v6 = v8 + currlevel + 1;
-			_LOBYTE(v9) = 68;
-			v7 = random(v9, 10) + 2 * currlevel + 1;
+			v7 = random(68, 10) + 2 * currlevel + 1;
 		}
 		else if ( missile[v1]._micaster )
 		{
@@ -4988,7 +4929,6 @@ void __fastcall MI_Firebolt(int i)
 	int v5; // edx
 	int v6; // ecx
 	int v7; // eax
-	int v8; // ecx
 	int v9; // edi
 	int v10; // eax
 	int v11; // edi
@@ -5032,16 +4972,14 @@ void __fastcall MI_Firebolt(int i)
 	v9 = missile[v2]._misource;
 	if ( v9 == -1 )
 	{
-		_LOBYTE(v8) = 78;
-		v12 = random(v8, 2 * currlevel);
+		v12 = random(78, 2 * currlevel);
 		v13 = currlevel;
 		goto LABEL_17;
 	}
 	if ( missile[v2]._micaster )
 	{
 		v11 = v9;
-		_LOBYTE(v8) = 77;
-		v12 = random(v8, (unsigned char)monster[v11].mMaxDamage - (unsigned char)monster[v11].mMinDamage + 1);
+		v12 = random(77, (unsigned char)monster[v11].mMaxDamage - (unsigned char)monster[v11].mMinDamage + 1);
 		v13 = (unsigned char)monster[v11].mMinDamage;
 LABEL_17:
 		v10 = v13 + v12;
@@ -5050,8 +4988,7 @@ LABEL_17:
 	switch ( missile[v2]._mitype )
 	{
 		case 1:
-			_LOBYTE(v8) = 75;
-			v10 = (plr[v9]._pMagic >> 3) + random(v8, 10) + missile[v2]._mispllvl + 1;
+			v10 = (plr[v9]._pMagic >> 3) + random(75, 10) + missile[v2]._mispllvl + 1;
 			break;
 		case 0x18:
 			v10 = (plr[v9]._pMagic >> 1) + 3 * missile[v2]._mispllvl - (plr[v9]._pMagic >> 3);
@@ -5245,7 +5182,6 @@ void __fastcall MI_Acidpud(int i)
 void __fastcall MI_Firewall(int i)
 {
 	int v1; // esi
-	int v2; // ecx
 	int v3; // ecx
 	int v4; // eax
 	int ExpLight[14]; // [esp+8h] [ebp-3Ch]
@@ -5271,8 +5207,7 @@ void __fastcall MI_Firewall(int i)
 	if ( missile[i]._mirange == missile[i]._miVar1 )
 	{
 		SetMissDir(i, 1);
-		_LOBYTE(v2) = 83;
-		missile[v1]._miAnimFrame = random(v2, 11) + 1;
+		missile[v1]._miAnimFrame = random(83, 11) + 1;
 	}
 	if ( missile[v1]._mirange == missile[v1]._miAnimLen - 1 )
 	{
@@ -5884,7 +5819,6 @@ void __fastcall MI_Firemove(int i)
 {
 	int v1; // esi
 	int *v2; // eax
-	int v3; // ecx
 	int v4; // ecx
 	int v5; // ebx
 	int v6; // ecx
@@ -5918,8 +5852,7 @@ void __fastcall MI_Firemove(int i)
 	if ( ++*v2 == missile[i]._miAnimLen )
 	{
 		SetMissDir(i, 1);
-		_LOBYTE(v3) = 82;
-		missile[v1]._miAnimFrame = random(v3, 11) + 1;
+		missile[v1]._miAnimFrame = random(82, 11) + 1;
 	}
 	v4 = ia;
 	missile[v1]._mitxoff += missile[v1]._mixvel;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -484,7 +484,7 @@ void __cdecl GetLevelMTypes() /* note-decompile this function again and check */
 	int *v20; // esi
 	int v21; // eax
 	//int v22; // [esp+8h] [ebp-328h]
-	int typelist[89]; // [esp+Ch] [ebp-324h]
+	int typelist[200]; // [esp+Ch] [ebp-324h]
 	int skeltypes[111]; // [esp+170h] [ebp-1C0h]
 	int max; // [esp+32Ch] [ebp-4h]
 
@@ -987,7 +987,6 @@ void __fastcall PlaceUniqueMonst(int uniqindex, int miniontype, int unpackfilesi
 	CMonster *v4; // ecx
 	int v5; // edx
 	int v6; // eax
-	int v7; // ecx
 	int v8; // edi
 	int v9; // eax
 	int v10; // ebx
@@ -1058,11 +1057,9 @@ void __fastcall PlaceUniqueMonst(int uniqindex, int miniontype, int unpackfilesi
 		{
 			do
 			{
-				_LOBYTE(v4) = 91;
-				v6 = random((int)v4, 80);
-				_LOBYTE(v7) = 91;
+				v6 = random(91, 80);
 				v8 = v6 + 16;
-				v9 = random(v7, 80);
+				v9 = random(91, 80);
 				v47 = 0;
 				v4 = (CMonster *)(v8 - 3);
 				v10 = v9 + 16;
@@ -1294,9 +1291,8 @@ LABEL_83:
 			v38 = (int)v3->MType;
 			v39 = *(_DWORD *)(v38 + 4 * v3->_mdir + 8);
 			v40 = v3->_mAnimLen - 1;
-			_LOBYTE(v38) = 88;
 			v3->_mAFNum = v39;
-			v41 = random(v38, v40);
+			v41 = random(88, v40);
 			v3->_mFlags &= 0xFFFFFFFB;
 			v3->_mmode = 0;
 			v3->_mAnimFrame = v41 + 1;
@@ -1400,7 +1396,6 @@ void __fastcall PlaceGroup(int mtype, int num, unsigned char leaderf, int leader
 	int v8; // edi
 	int v9; // esi
 	int v10; // eax
-	int v11; // ecx
 	int v12; // eax
 	int v13; // ecx
 	int v14; // eax
@@ -1412,7 +1407,6 @@ void __fastcall PlaceGroup(int mtype, int num, unsigned char leaderf, int leader
 	int v20; // ecx
 	int v21; // ebx
 	int v22; // ecx
-	int v23; // ecx
 	int mtypea; // [esp+Ch] [ebp-24h]
 	signed int v25; // [esp+14h] [ebp-1Ch]
 	int v26; // [esp+18h] [ebp-18h]
@@ -1445,8 +1439,7 @@ void __fastcall PlaceGroup(int mtype, int num, unsigned char leaderf, int leader
 		}
 		if ( leaderf & 1 )
 		{
-			_LOBYTE(v4) = 92;
-			v7 = random(v4, 8);
+			v7 = random(92, 8);
 			v8 = monster[leader]._mx + offset_x[v7];
 			v9 = monster[leader]._my + offset_y[v7];
 			v29 = monster[leader]._mx + offset_x[v7];
@@ -1456,12 +1449,10 @@ void __fastcall PlaceGroup(int mtype, int num, unsigned char leaderf, int leader
 		{
 			do
 			{
-				_LOBYTE(v4) = 93;
-				v10 = random(v4, 80);
-				_LOBYTE(v11) = 93;
+				v10 = random(93, 80);
 				v8 = v10 + 16;
 				v29 = v10 + 16;
-				v12 = random(v11, 80);
+				v12 = random(93, 80);
 				v9 = v12 + 16;
 				v28 = v12 + 16;
 			}
@@ -1470,7 +1461,7 @@ void __fastcall PlaceGroup(int mtype, int num, unsigned char leaderf, int leader
 		if ( nummonsters + v31 > totalmonsters )
 			v31 = totalmonsters - nummonsters;
 		v26 = 0;
-		for ( i = 0; v26 < v31; v9 += offset_x[random(v23, 8)] )
+		for ( i = 0; v26 < v31; v9 += offset_x[random(94, 8)] )
 		{
 			if ( i >= 100 )
 				break;
@@ -1504,8 +1495,7 @@ void __fastcall PlaceGroup(int mtype, int num, unsigned char leaderf, int leader
 						v21 = nummonsters;
 						v22 = monster[v18].MType->Anims[0].Frames[monster[v18]._mdir];
 						monster[v18]._mAFNum = v22;
-						_LOBYTE(v22) = 88;
-						monster[v21]._mAnimFrame = random(v22, monster[v21]._mAnimLen - 1) + 1;
+						monster[v21]._mAnimFrame = random(88, monster[v21]._mAnimLen - 1) + 1;
 						monster[v21]._mFlags &= 0xFFFFFFFB;
 						monster[v21]._mmode = MM_STAND;
 					}
@@ -1514,9 +1504,7 @@ void __fastcall PlaceGroup(int mtype, int num, unsigned char leaderf, int leader
 				++v30;
 				++v26;
 			}
-			_LOBYTE(v13) = 94;
-			v8 += offset_x[random(v13, 8)];
-			_LOBYTE(v23) = 94;
+			v8 += offset_x[random(94, 8)];
 		}
 		v4 = v30;
 		if ( v30 >= v31 )
@@ -1565,9 +1553,7 @@ void __cdecl InitMonsters()
 	int v11; // esi
 	unsigned char *v12; // edi
 	int v13; // ebx
-	int v14; // ecx
 	int v15; // esi
-	int v16; // ecx
 	int v17; // eax
 	int v18; // eax
 	int v19; // ebx
@@ -1663,22 +1649,19 @@ void __cdecl InitMonsters()
 		{
 			while ( 1 )
 			{
-				_LOBYTE(v8) = 95;
-				v15 = scattertypes[random(v8, max)];
+				v15 = scattertypes[random(95, max)];
 				if ( currlevel == 1 )
 					break;
-				_LOBYTE(v14) = 95;
-				if ( !random(v14, 2) )
+				if ( !random(95, 2) )
 					break;
-				_LOBYTE(v16) = 95;
 				if ( currlevel == 2 )
 				{
-					v17 = random(v16, 2) + 1;
+					v17 = random(95, 2) + 1;
 LABEL_40:
 					v18 = v17 + 1;
 					goto LABEL_41;
 				}
-				v18 = random(v16, 3) + 3;
+				v18 = random(95, 3) + 3;
 LABEL_41:
 				PlaceGroup(v15, v18, 0, 0);
 				if ( nummonsters >= totalmonsters )
@@ -3021,10 +3004,9 @@ void __fastcall M_StartHeal(int i)
 	monster[v2]._mAFNum = v4;
 	v5 = v3->Anims[5].Rate;
 	monster[v2]._mFlags |= 2u;
-	_LOBYTE(v4) = 97;
 	monster[v2]._mAnimFrame = v5;
 	monster[v2]._mmode = MM_HEAL;
-	monster[v2]._mVar1 = monster[v2]._mmaxhp / (16 * (random(v4, 5) + 4));
+	monster[v2]._mVar1 = monster[v2]._mmaxhp / (16 * (random(97, 5) + 4));
 }
 
 void __fastcall M_ChangeLightOffset(int monst)
@@ -3273,7 +3255,6 @@ void __fastcall M_TryM2MHit(int i, int mid, int hper, int mind, int maxd)
 	int v7; // esi
 	int v8; // ebx
 	//int v9; // eax
-	int v10; // ecx
 	int v11; // eax
 	bool ret; // [esp+Ch] [ebp-Ch]
 	char v13[4]; // [esp+10h] [ebp-8h]
@@ -3293,15 +3274,13 @@ void __fastcall M_TryM2MHit(int i, int mid, int hper, int mind, int maxd)
 	if ( (signed int)(monster[v7]._mhitpoints & 0xFFFFFFC0) > 0
 	  && (monster[v7].MType->mtype != MT_ILLWEAV || _LOBYTE(monster[v7]._mgoal) != 2) )
 	{
-		_LOBYTE(i) = 4;
-		v8 = random(i, 100);
+		v8 = random(4, 100);
 		if ( monster[v7]._mmode == MM_STONE )
 			v8 = 0;
 		//_LOBYTE(v9) = CheckMonsterHit(*(int *)arglist, &ret);
 		if ( !CheckMonsterHit(*(int *)arglist, &ret) && v8 < hper )
 		{
-			_LOBYTE(v10) = 5;
-			v11 = (mind + random(v10, maxd - mind + 1)) << 6;
+			v11 = (mind + random(5, maxd - mind + 1)) << 6;
 			monster[v7]._mhitpoints -= v11;
 			if ( (signed int)(monster[v7]._mhitpoints & 0xFFFFFFC0) > 0 )
 			{
@@ -3335,7 +3314,6 @@ void __fastcall M_TryH2HHit(int i, int pnum, int Hit, int MinDam, int MaxDam)
 	int v8; // edi
 	int v9; // eax
 	//int v10; // ST08_4
-	int v11; // ecx
 	int v12; // ecx
 	int v13; // edi
 	int v14; // eax
@@ -3352,7 +3330,6 @@ void __fastcall M_TryH2HHit(int i, int pnum, int Hit, int MinDam, int MaxDam)
 	bool v25; // sf
 	unsigned char v26; // of
 	int v27; // eax
-	int v28; // ecx
 	int v29; // edi
 	int v30; // eax
 	int v31; // eax
@@ -3386,8 +3363,7 @@ void __fastcall M_TryH2HHit(int i, int pnum, int Hit, int MinDam, int MaxDam)
 		//v11 = v10;
 		if ( v8 < 2 && v9 < 2 )
 		{
-			_LOBYTE(v11) = 98;
-			v36 = random(v11, 100);
+			v36 = random(98, 100);
 #ifdef _DEBUG
 			if ( debug_mode_dollar_sign || debug_mode_key_inverted_v )
 				v36 = 1000;
@@ -3427,8 +3403,7 @@ LABEL_23:
 			}
 			else
 			{
-				_LOBYTE(v12) = 98;
-				v15 = random(v12, 100);
+				v15 = random(98, 100);
 			}
 			v16 = (int *)(plr[v7]._pDexterity
 						+ plr[v7]._pBaseToBlk
@@ -3492,8 +3467,7 @@ LABEL_23:
 							}
 						}
 					}
-					_LOBYTE(v16) = 99;
-					v29 = (plr[v7]._pIGetHit << 6) + (MinDam << 6) + random((int)v16, (MaxDam - MinDam + 1) << 6);
+					v29 = (plr[v7]._pIGetHit << 6) + (MinDam << 6) + random(99, (MaxDam - MinDam + 1) << 6);
 					if ( v29 < 64 )
 						v29 = 64;
 					if ( plr_num == myplr )
@@ -3503,8 +3477,7 @@ LABEL_23:
 					}
 					if ( plr[v7]._pIFlags & 0x4000000 )
 					{
-						_LOBYTE(v28) = 99;
-						v30 = (random(v28, 3) + 1) << 6;
+						v30 = (random(99, 3) + 1) << 6;
 						monster[v6]._mhitpoints -= v30;
 						if ( (signed int)(monster[v6]._mhitpoints & 0xFFFFFFC0) > 0 )
 							M_StartHit(arglist, plr_num, v30);
@@ -3958,7 +3931,6 @@ void __fastcall M_Teleport(int i)
 	//int v2; // ST04_4
 	MonsterStruct *v3; // esi
 	int v4; // eax
-	int v5; // ecx
 	int v6; // edi
 	int v7; // ebx
 	int v8; // eax
@@ -3984,14 +3956,12 @@ void __fastcall M_Teleport(int i)
 	if ( v3->_mmode != 15 )
 	{
 		v10 = (unsigned char)v3->_menemyx;
-		_LOBYTE(i) = 100;
 		v12 = (unsigned char)v3->_menemyy;
-		v4 = random(i, 2);
-		_LOBYTE(v5) = 100;
+		v4 = random(100, 2);
 		v11 = 2 * v4 - 1;
 		v17 = -1;
 		v6 = 0; /* v9 */
-		v13 = 2 * random(v5, 2) - 1;
+		v13 = 2 * random(100, 2) - 1;
 		while ( !v15 )
 		{
 			v16 = -1;
@@ -4481,9 +4451,7 @@ bool __fastcall M_CallWalk(int i, int md)
 	int v3; // edi
 	int v4; // ebp
 	//int v5; // eax
-	int v6; // ecx
 	bool v7; // ebx
-	int v8; // ecx
 	int v9; // ebx
 	//int v10; // eax
 	int v11; // ebx
@@ -4499,9 +4467,8 @@ bool __fastcall M_CallWalk(int i, int md)
 	v3 = i;
 	v4 = md;
 	//_LOBYTE(v5) = DirOK(i, md);
-	_LOBYTE(v6) = 101;
 	v7 = DirOK(i, md);
-	if ( random(v6, 2) )
+	if ( random(101, 2) )
 	{
 		if ( v7 )
 			goto LABEL_10;
@@ -4532,8 +4499,7 @@ bool __fastcall M_CallWalk(int i, int md)
 LABEL_10:
 	v14 = 1;
 LABEL_11:
-	_LOBYTE(v8) = 102;
-	if ( random(v8, 2) )
+	if ( random(102, 2) )
 	{
 		if ( v14 )
 			goto LABEL_20;
@@ -4594,7 +4560,6 @@ bool __fastcall M_CallWalk2(int i, int md)
 	int v2; // esi
 	int v3; // ebx
 	//int v4; // eax
-	int v5; // ecx
 	bool v6; // edi
 	int v7; // edi
 	//int v8; // eax
@@ -4606,9 +4571,8 @@ bool __fastcall M_CallWalk2(int i, int md)
 	v2 = md;
 	v3 = i;
 	//_LOBYTE(v4) = DirOK(i, md);
-	_LOBYTE(v5) = 101;
 	v6 = DirOK(i, md);
-	if ( random(v5, 2) )
+	if ( random(101, 2) )
 	{
 		if ( v6 )
 			goto LABEL_10;
@@ -4747,9 +4711,8 @@ void __fastcall MAI_Zombie(int i)
 		{
 			v5 = v3->_mx - (unsigned char)v3->_menemyx;
 			v6 = v4 - (unsigned char)v3->_menemyy;
-			_LOBYTE(i) = 103;
 			md = v3->_mdir;
-			v14 = random(i, 100);
+			v14 = random(103, 100);
 			if ( abs(v5) >= 2 || abs(v6) >= 2 )
 			{
 				if ( v14 < 2 * (unsigned char)v3->_mint + 10 )
@@ -4758,13 +4721,11 @@ void __fastcall MAI_Zombie(int i)
 					v8 = 2 * (unsigned char)v3->_mint + 4;
 					if ( v7 >= v8 || (v9 = abs(v6), v8 = 2 * (unsigned char)v3->_mint + 4, v9 >= v8) )
 					{
-						_LOBYTE(v8) = 104;
-						v11 = random(v8, 100);
+						v11 = random(104, 100);
 						v12 = 2 * (unsigned char)v3->_mint + 20;
 						if ( v11 < v12 )
 						{
-							_LOBYTE(v12) = 104;
-							md = random(v12, 8);
+							md = random(104, 8);
 						}
 						M_DumbWalk(arglist, md);
 					}
@@ -4796,7 +4757,6 @@ void __fastcall MAI_SkelSd(int i)
 	int v7; // ebx
 	int v8; // eax
 	//int v9; // ST04_4
-	int v10; // ecx
 	int v11; // eax
 	//int v12; // ST04_4
 	int v13; // eax
@@ -4825,13 +4785,11 @@ void __fastcall MAI_SkelSd(int i)
 		{
 			if ( v2->_mVar1 != 13 )
 			{
-				_LOBYTE(v10) = 106;
-				v16 = random(v10, 100);
+				v16 = random(106, 100);
 				v17 = 4 * (unsigned char)v2->_mint;
 				if ( v16 < 35 - v17 )
 				{
-					_LOBYTE(v17) = 106;
-					v15 = 15 - 2 * (unsigned char)v2->_mint + random(v17, 10);
+					v15 = 15 - 2 * (unsigned char)v2->_mint + random(106, 10);
 					goto LABEL_10;
 				}
 			}
@@ -4841,13 +4799,11 @@ void __fastcall MAI_SkelSd(int i)
 		{
 			if ( v2->_mVar1 != 13 )
 			{
-				_LOBYTE(v10) = 105;
-				v13 = random(v10, 100);
+				v13 = random(105, 100);
 				v14 = 2 * (unsigned char)v2->_mint + 20;
 				if ( v13 >= v14 )
 				{
-					_LOBYTE(v14) = 105;
-					v15 = random(v14, 10) + 2 * (5 - (unsigned char)v2->_mint);
+					v15 = random(105, 10) + 2 * (5 - (unsigned char)v2->_mint);
 LABEL_10:
 					M_StartDelay(arglist, v15);
 					goto LABEL_16;
@@ -4920,7 +4876,6 @@ void __fastcall MAI_Snake(int i)
 	int v10; // ebx
 	int v11; // eax
 	//int v12; // ST1C_4
-	int v13; // ecx
 	int v14; // eax
 	int v15; // eax
 	int v16; // ecx
@@ -4928,7 +4883,6 @@ void __fastcall MAI_Snake(int i)
 	int v18; // ecx
 	int v19; // eax
 	//int v20; // ST1C_4
-	int v21; // ecx
 	int v22; // eax
 	//int v23; // ST1C_4
 	int v24; // ebx
@@ -4984,7 +4938,7 @@ void __fastcall MAI_Snake(int i)
 				v14 = esi3->_mVar1;
 				if ( v14 == 13
 				  || v14 == 14
-				  || (_LOBYTE(v13) = 105, v15 = random(v13, 100), v16 = (unsigned char)esi3->_mint + 20, v15 < v16) )
+				  || (v15 = random(105, 100), v16 = (unsigned char)esi3->_mint + 20, v15 < v16) )
 				{
 					M_StartAttack(arglist);
 LABEL_49:
@@ -4992,8 +4946,7 @@ LABEL_49:
 						esi3->_mAFNum = esi3->MType->Anims[0].Frames[esi3->_mdir];
 					return;
 				}
-				_LOBYTE(v16) = 105;
-				v17 = 10 - (unsigned char)esi3->_mint + random(v16, 10);
+				v17 = 10 - (unsigned char)esi3->_mint + random(105, 10);
 				v18 = arglist;
 LABEL_11:
 				M_StartDelay(v18, v17);
@@ -5023,13 +4976,11 @@ LABEL_11:
 		}
 		if ( esi3->_mVar1 != 13 )
 		{
-			_LOBYTE(v21) = 106;
-			v27 = random(v21, 100);
+			v27 = random(106, 100);
 			v28 = 2 * (unsigned char)esi3->_mint;
 			if ( v27 < 35 - v28 )
 			{
-				_LOBYTE(v28) = 106;
-				v17 = 15 - (unsigned char)esi3->_mint + random(v28, 10);
+				v17 = 15 - (unsigned char)esi3->_mint + random(106, 10);
 				v18 = v24;
 				goto LABEL_11;
 			}
@@ -5116,12 +5067,9 @@ void __fastcall MAI_Bat(int i)
 	int v5; // edi
 	int v6; // ebx
 	int v7; // eax
-	int v8; // ecx
-	int v9; // ecx
 	int v10; // edx
 	bool v11; // eax
 	int v12; // ecx
-	int v13; // ecx
 	CMonster *v14; // eax
 	int v15; // edi
 	int v16; // eax
@@ -5147,16 +5095,14 @@ void __fastcall MAI_Bat(int i)
 		v5 = v3 - (unsigned char)esi3->_menemyx;
 		v6 = v4 - (unsigned char)esi3->_menemyy;
 		v7 = GetDirection(v3, v4, esi3->_lastx, esi3->_lasty);
-		_LOBYTE(v8) = 107;
 		midir = v7;
 		esi3->_mdir = v7;
-		v22 = random(v8, 100);
+		v22 = random(107, 100);
 		if ( _LOBYTE(esi3->_mgoal) == 2 )
 		{
 			if ( esi3->_mgoalvar1 )
 			{
-				_LOBYTE(v9) = 108;
-				if ( random(v9, 2) )
+				if ( random(108, 2) )
 					v10 = left[midir];
 				else
 					v10 = right[midir];
@@ -5212,8 +5158,7 @@ void __fastcall MAI_Bat(int i)
 				if ( v14->mtype == 41 )
 				{
 					v15 = (unsigned char)esi3->_menemyx;
-					_LOBYTE(v13) = 109;
-					v16 = random(v13, 10);
+					v16 = random(109, 10);
 					AddMissile(v15, (unsigned char)esi3->_menemyy, v15 + 1, 0, -1, 8, 1, arglist, v16 + 1, 0);
 				}
 			}
@@ -5230,7 +5175,6 @@ void __fastcall MAI_SkelBow(int i)
 	int v3; // edi
 	int v4; // ebx
 	int v5; // eax
-	int v6; // ecx
 	int v7; // eax
 	//int v8; // ST04_4
 	int v9; // ecx
@@ -5257,10 +5201,9 @@ void __fastcall MAI_SkelBow(int i)
 		v3 = v2->_mx - (unsigned char)v2->_menemyx;
 		v4 = v2->_my - (unsigned char)v2->_menemyy;
 		v5 = M_GetDir(arglist);
-		_LOBYTE(v6) = 110;
 		v17 = v5;
 		v2->_mdir = v5;
-		v19 = random(v6, 100);
+		v19 = random(110, 100);
 		v7 = abs(v3);
 		//v9 = v8;
 		if ( v7 < 4 )
@@ -5283,8 +5226,7 @@ void __fastcall MAI_SkelBow(int i)
 		v15 = (unsigned char)v2->_menemyy;
 		if ( !v18 )
 		{
-			_LOBYTE(v9) = 110;
-			if ( random(v9, 100) < 2 * (unsigned char)v2->_mint + 3 )
+			if ( random(110, 100) < 2 * (unsigned char)v2->_mint + 3 )
 			{
 				//_LOBYTE(v16) = LineClear(v2->_mx, v2->_my, v14, v15);
 				if ( LineClear(v2->_mx, v2->_my, v14, v15) )
@@ -5303,7 +5245,6 @@ void __fastcall MAI_Fat(int i)
 	int v3; // edi
 	int v4; // ebx
 	int v5; // eax
-	int v6; // ecx
 	int v7; // eax
 	signed int v8; // ecx
 	int v9; // eax
@@ -5321,10 +5262,9 @@ void __fastcall MAI_Fat(int i)
 		v3 = v2->_mx - (unsigned char)v2->_menemyx;
 		v4 = v2->_my - (unsigned char)v2->_menemyy;
 		v5 = M_GetDir(arglist);
-		_LOBYTE(v6) = 111;
 		md = v5;
 		v2->_mdir = v5;
-		v12 = random(v6, 100);
+		v12 = random(111, 100);
 		if ( abs(v3) >= 2 || abs(v4) >= 2 )
 		{
 			v8 = v2->_mVar2;
@@ -5358,7 +5298,6 @@ void __fastcall MAI_Sneak(int i)
 	MonsterStruct *v2; // esi
 	int v3; // ebx
 	int v4; // ebx
-	int v5; // ecx
 	int v6; // edi
 	int v7; // eax
 	//int v8; // ST04_4
@@ -5409,17 +5348,15 @@ void __fastcall MAI_Sneak(int i)
 				md = opposite[md];
 				if ( v2->MType->mtype == MT_UNSEEN )
 				{
-					_LOBYTE(v5) = 112;
-					if ( random(v5, 2) )
+					if ( random(112, 2) )
 						v11 = left[md];
 					else
 						v11 = right[md];
 					md = v11;
 				}
 			}
-			_LOBYTE(v5) = 112;
 			v2->_mdir = md;
-			v15 = random(v5, 100);
+			v15 = random(112, 100);
 			if ( abs(v17) < v6 && abs(v4) < v6 && v2->_mFlags & 1 )
 			{
 				M_StartFadein(arglist, md, 0);
@@ -5466,11 +5403,9 @@ void __fastcall MAI_Fireman(int i)
 	int v5; // ebx
 	int v6; // edi
 	int v7; // edx
-	int v8; // ecx
 	char v9; // al
 	//int v10; // eax
 	//int v11; // eax
-	int v12; // ecx
 	int v13; // eax
 	//int v14; // eax
 	int v15; // edx
@@ -5526,8 +5461,7 @@ void __fastcall MAI_Fireman(int i)
 				}
 				else
 				{
-					_LOBYTE(v12) = 112;
-					v13 = random(v12, 10);
+					v13 = random(112, 10);
 					M_StartDelay(arglist, v13 + 5);
 				}
 				++monster[esi3]._mgoalvar1;
@@ -5539,9 +5473,8 @@ LABEL_18:
 			_LOBYTE(monster[esi3]._mgoal) = 5;
 			break;
 	}
-	_LOBYTE(v8) = 112;
 	monster[esi3]._mdir = midir;
-	random(v8, 100);
+	random(112, 100);
 	if ( monster[esi3]._mmode )
 		return;
 	if ( abs(v6) < 2 && abs(v5) < 2 && _LOBYTE(monster[esi3]._mgoal) == 1 )
@@ -5647,8 +5580,7 @@ void __fastcall MAI_Fallen(int i)
 			M_CallWalk(v1, v14);
 			return;
 		}
-		_LOBYTE(i) = 113;
-		if ( !random(i, 4) )
+		if ( !random(113, 4) )
 		{
 			if ( !(monster[v3]._mFlags & 8) )
 			{
@@ -5726,23 +5658,18 @@ void __fastcall MAI_Round(int i, unsigned char special)
 	int v5; // ecx
 	int v6; // edi
 	int v7; // ebx
-	int v8; // ecx
 	int v9; // eax
 	//int v10; // ST04_4
-	int v11; // ecx
 	int v12; // eax
 	//int v13; // ST04_4
-	int v14; // ecx
 	int v15; // edi
 	int v16; // eax
 	int v17; // ecx
 	bool v18; // eax
 	//int v19; // eax
-	int v20; // ecx
 	int v21; // eax
 	int v22; // eax
 	//int v23; // ST04_4
-	int v24; // ecx
 	signed int v25; // ecx
 	int v26; // eax
 	int v27; // [esp+4h] [ebp-18h]
@@ -5770,8 +5697,7 @@ void __fastcall MAI_Round(int i, unsigned char special)
 		md = GetDirection(v5, v4, v3->_lastx, v3->_lasty);
 		if ( v3->_msquelch < 0xFFu ) /* check sign */
 			MonstCheckDoors(arglist);
-		_LOBYTE(v8) = 114;
-		v30 = random(v8, 100);
+		v30 = random(114, 100);
 		if ( (abs(v7) >= 2 || abs(v32) >= 2) && v3->_msquelch == -1 )
 		{
 			v29 = &dung_map[v6][v28];
@@ -5788,14 +5714,12 @@ void __fastcall MAI_Round(int i, unsigned char special)
 						if ( v12 < 4 )
 							goto LABEL_26;
 					}
-					_LOBYTE(v11) = 115;
-					if ( random(v11, 4) )
+					if ( random(115, 4) )
 						goto LABEL_26;
 					if ( _LOBYTE(v3->_mgoal) != 4 )
 					{
 						v3->_mgoalvar1 = 0;
-						_LOBYTE(v14) = 116;
-						v3->_mgoalvar2 = random(v14, 2);
+						v3->_mgoalvar2 = random(116, 2);
 					}
 				}
 				_LOBYTE(v3->_mgoal) = 4;
@@ -5813,8 +5737,7 @@ void __fastcall MAI_Round(int i, unsigned char special)
 						//_LOBYTE(v19) = M_RoundWalk(arglist, md, &v3->_mgoalvar2);
 						if ( !M_RoundWalk(arglist, md, &v3->_mgoalvar2) )
 						{
-							_LOBYTE(v20) = 125;
-							v21 = random(v20, 10);
+							v21 = random(125, 10);
 							M_StartDelay(arglist, v21 + 10);
 						}
 						goto LABEL_26;
@@ -5840,7 +5763,7 @@ LABEL_26:
 			else if ( v30 < 2 * (unsigned char)v3->_mint + 23 )
 			{
 				v3->_mdir = md;
-				if ( v27 && v3->_mhitpoints < v3->_mmaxhp >> 1 && (_LOBYTE(v24) = 117, random(v24, 2)) )
+				if ( v27 && v3->_mhitpoints < v3->_mmaxhp >> 1 && random(117, 2) )
 					M_StartSpAttack(arglist);
 				else
 					M_StartAttack(arglist);
@@ -5865,12 +5788,10 @@ void __fastcall MAI_Ranged(int i, int missile_type, unsigned char special)
 	int v7; // ecx
 	int v8; // ebx
 	int v9; // edi
-	int v10; // ecx
 	bool v11; // zf
 	int v12; // eax
 	int v13; // eax
 	//int v14; // ST00_4
-	int v15; // ecx
 	//int v16; // eax
 	int x2; // [esp+8h] [ebp-14h]
 	int y2; // [esp+Ch] [ebp-10h]
@@ -5901,8 +5822,7 @@ void __fastcall MAI_Ranged(int i, int missile_type, unsigned char special)
 			monster[v4]._mdir = v20;
 			if ( v11 )
 			{
-				_LOBYTE(v10) = 118;
-				v12 = random(v10, 20);
+				v12 = random(118, 20);
 				M_StartDelay(arglist, v12);
 			}
 			else if ( abs(v9) < 4 )
@@ -5911,8 +5831,7 @@ void __fastcall MAI_Ranged(int i, int missile_type, unsigned char special)
 				//v15 = v14;
 				if ( v13 < 4 )
 				{
-					_LOBYTE(v15) = 119;
-					if ( random(v15, 100) < 10 * ((unsigned char)monster[v4]._mint + 7) )
+					if ( random(119, 100) < 10 * ((unsigned char)monster[v4]._mint + 7) )
 						M_CallWalk(arglist, opposite[v20]);
 				}
 			}
@@ -6028,9 +5947,8 @@ LABEL_10:
 			{
 				if ( !monster[v2]._mgoalvar1 )
 				{
-					_LOBYTE(v5) = 120;
 					v6 = arglist;
-					if ( random(v5, 2) )
+					if ( random(120, 2) )
 					{
 						v7 = -4;
 						do
@@ -6175,7 +6093,6 @@ void __fastcall MAI_RoundRanged(int i, int missile_type, unsigned char checkdoor
 	int v7; // edx
 	int v8; // ebx
 	int v9; // edi
-	int v10; // ecx
 	int v11; // eax
 	//int v12; // ST04_4
 	int v13; // ecx
@@ -6222,8 +6139,7 @@ void __fastcall MAI_RoundRanged(int i, int missile_type, unsigned char checkdoor
 		md = GetDirection(v6->_mx, v7, v6->_lastx, v6->_lasty);
 		if ( checkdoors && v6->_msquelch < 0xFFu ) /* check sign */
 			MonstCheckDoors(arglist);
-		_LOBYTE(v10) = 121;
-		checkdoorsa = random(v10, 10000);
+		checkdoorsa = random(121, 10000);
 		v11 = abs(v9);
 		//v13 = v12;
 		if ( v11 < 2 )
@@ -6248,14 +6164,12 @@ void __fastcall MAI_RoundRanged(int i, int missile_type, unsigned char checkdoor
 					goto LABEL_28;
 			}
 			v18 = lessmissiles;
-			_LOBYTE(v18) = 122;
-			if ( random(v18, 4 << lessmissiles) )
+			if ( random(122, 4 << lessmissiles) )
 				goto LABEL_28;
 			if ( _LOBYTE(v6->_mgoal) != 4 )
 			{
 				v6->_mgoalvar1 = 0;
-				_LOBYTE(v13) = 123;
-				v6->_mgoalvar2 = random(v13, 2);
+				v6->_mgoalvar2 = random(123, 2);
 			}
 		}
 		_LOBYTE(v6->_mgoal) = 4;
@@ -6301,8 +6215,7 @@ LABEL_28:
 				//v13 = v26;
 				if ( v25 >= 2 || (v27 = abs(v8), v27 >= 2) ) /* v13 = v28,  */
 				{
-					_LOBYTE(v13) = 124;
-					v29 = random(v13, 100);
+					v29 = random(124, 100);
 					v30 = (unsigned char)v6->_mint;
 					if ( v29 < 1000 * (v30 + 5)
 					  || ((v13 = v6->_mVar1, v13 == 1) || v13 == 2 || v13 == 3) && !v6->_mVar2 && v29 < 1000 * (v30 + 8) )
@@ -6319,8 +6232,7 @@ LABEL_28:
 		}
 		if ( v6->_mmode == MM_STAND )
 		{
-			_LOBYTE(v13) = 125;
-			v31 = random(v13, 10);
+			v31 = random(125, 10);
 			M_StartDelay(arglist, v31 + 5);
 		}
 	}
@@ -6354,7 +6266,6 @@ void __fastcall MAI_RR2(int i, int mistype, int dam)
 	int v6; // edx
 	int v7; // ebx
 	int v8; // edi
-	int v9; // ecx
 	int v10; // eax
 	//int v11; // ST04_4
 	int v12; // ecx
@@ -6371,7 +6282,6 @@ void __fastcall MAI_RR2(int i, int mistype, int dam)
 	int v23; // ecx
 	int v24; // eax
 	//int v25; // ST04_4
-	int v26; // ecx
 	int v27; // eax
 	//int v28; // ST04_4
 	int v29; // eax
@@ -6410,8 +6320,7 @@ void __fastcall MAI_RR2(int i, int mistype, int dam)
 		md = GetDirection(v4->_mx, v6, v4->_lastx, v4->_lasty);
 		if ( v4->_msquelch < 0xFFu ) /* check sign */
 			MonstCheckDoors(arglist);
-		_LOBYTE(v9) = 121;
-		v38 = random(v9, 100);
+		v38 = random(121, 100);
 		v10 = abs(v8);
 		//v12 = v11;
 		if ( v10 >= 2 || (v13 = abs(v7), v13 >= 2) ) /* v12 = v14,  */
@@ -6435,8 +6344,7 @@ void __fastcall MAI_RR2(int i, int mistype, int dam)
 						if ( _LOBYTE(v4->_mgoal) != 4 )
 						{
 							v4->_mgoalvar1 = 0;
-							_LOBYTE(v12) = 123;
-							v4->_mgoalvar2 = random(v12, 2);
+							v4->_mgoalvar2 = random(123, 2);
 						}
 					}
 					_LOBYTE(v4->_mgoal) = 4;
@@ -6474,8 +6382,7 @@ LABEL_26:
 							//v26 = v25;
 							if ( v24 >= 2 || (v27 = abs(v7), v27 >= 2) ) /* v26 = v28,  */
 							{
-								_LOBYTE(v26) = 124;
-								v31 = random(v26, 100);
+								v31 = random(124, 100);
 								v12 = (unsigned char)v4->_mint;
 								if ( v31 < 2 * (5 * v12 + 25)
 								  || ((v32 = v4->_mVar1, v32 == 1) || v32 == 2 || v32 == 3)
@@ -6486,8 +6393,7 @@ LABEL_26:
 								}
 								goto LABEL_47;
 							}
-							_LOBYTE(v26) = 124;
-							v29 = random(v26, 100);
+							v29 = random(124, 100);
 							v12 = 10 * ((unsigned char)v4->_mint + 4);
 							if ( v29 >= v12 )
 							{
@@ -6496,15 +6402,13 @@ LABEL_47:
 LABEL_48:
 								if ( v4->_mmode == MM_STAND )
 								{
-									_LOBYTE(v12) = 125;
-									v33 = random(v12, 10);
+									v33 = random(125, 10);
 									M_StartDelay(arglist, v33 + 5);
 								}
 								return;
 							}
-							_LOBYTE(v12) = 124;
 							v4->_mdir = md;
-							v30 = random(v12, 2);
+							v30 = random(124, 2);
 							v23 = arglist;
 							if ( v30 )
 							{
@@ -6648,26 +6552,21 @@ void __fastcall MAI_SkelKing(int i)
 	int v3; // edx
 	int v4; // ebx
 	int v5; // edi
-	int v6; // ecx
 	int v7; // eax
 	//int v8; // ST04_4
-	int v9; // ecx
 	int v10; // eax
 	//int v11; // ST04_4
-	int v12; // ecx
 	int v13; // ebx
 	int v14; // eax
 	int v15; // ecx
 	bool v16; // eax
 	//int v17; // eax
-	int v18; // ecx
 	int v19; // eax
 	bool v20; // eax
 	int v21; // edi
 	int v22; // ebx
 	int v23; // eax
 	//int v24; // ST04_4
-	int v25; // ecx
 	int v26; // eax
 	//int v27; // ST04_4
 	int v28; // eax
@@ -6698,8 +6597,7 @@ void __fastcall MAI_SkelKing(int i)
 		md = GetDirection(v2->_mx, v3, v2->_lastx, v2->_lasty);
 		if ( v2->_msquelch < 0xFFu ) /* check sign */
 			MonstCheckDoors(arglist);
-		_LOBYTE(v6) = 126;
-		v35 = random(v6, 100);
+		v35 = random(126, 100);
 		if ( (abs(v5) >= 2 || abs(v4) >= 2) && v2->_msquelch == -1 )
 		{
 			v32 = &dung_map[x2][y2];
@@ -6716,14 +6614,12 @@ void __fastcall MAI_SkelKing(int i)
 						if ( v10 < 3 )
 							goto LABEL_26;
 					}
-					_LOBYTE(v9) = 127;
-					if ( random(v9, 4) )
+					if ( random(127, 4) )
 						goto LABEL_26;
 					if ( _LOBYTE(v2->_mgoal) != 4 )
 					{
 						v2->_mgoalvar1 = 0;
-						_LOBYTE(v12) = -128;
-						v2->_mgoalvar2 = random(v12, 2);
+						v2->_mgoalvar2 = random(128, 2);
 					}
 				}
 				_LOBYTE(v2->_mgoal) = 4;
@@ -6747,8 +6643,7 @@ void __fastcall MAI_SkelKing(int i)
 						//_LOBYTE(v17) = M_RoundWalk(arglist, md, &v2->_mgoalvar2);
 						if ( !M_RoundWalk(arglist, md, &v2->_mgoalvar2) )
 						{
-							_LOBYTE(v18) = 125;
-							v19 = random(v18, 10);
+							v19 = random(125, 10);
 							M_StartDelay(arglist, v19 + 10);
 						}
 						goto LABEL_26;
@@ -6778,14 +6673,12 @@ LABEL_26:
 				//v25 = v24;
 				if ( v23 >= 2 || (v26 = abs(v4), v26 >= 2) ) /* v25 = v27,  */
 				{
-					_LOBYTE(v25) = -127;
-					v28 = random(v25, 100);
+					v28 = random(129, 100);
 					v29 = (unsigned char)v2->_mint;
 					if ( v28 >= v29 + 25
 					  && ((v30 = v2->_mVar1, v30 != 1) && v30 != 2 && v30 != 3 || v2->_mVar2 || (v29 += 75, v28 >= v29)) )
 					{
-						_LOBYTE(v29) = -126;
-						v31 = random(v29, 10);
+						v31 = random(130, 10);
 						M_StartDelay(arglist, v31 + 10);
 					}
 					else
@@ -6813,24 +6706,19 @@ void __fastcall MAI_Rhino(int i)
 	int v3; // edx
 	int v4; // ebx
 	int v5; // edi
-	int v6; // ecx
 	int v7; // eax
 	//int v8; // ST1C_4
-	int v9; // ecx
 	int v10; // eax
 	//int v11; // ST1C_4
-	int v12; // ecx
 	int v13; // ebx
 	int v14; // eax
 	int v15; // ecx
 	//int v16; // eax
-	int v17; // ecx
 	int v18; // eax
 	bool v19; // eax
 	int v20; // ecx
 	int v21; // eax
 	//int v22; // ST1C_4
-	int v23; // ecx
 	int v24; // eax
 	//int v25; // ST1C_4
 	int v26; // eax
@@ -6860,8 +6748,7 @@ void __fastcall MAI_Rhino(int i)
 		midir = GetDirection(esi3->_mx, v3, esi3->_lastx, esi3->_lasty);
 		if ( esi3->_msquelch < 0xFFu ) /* check sign */
 			MonstCheckDoors(arglist);
-		_LOBYTE(v6) = -125;
-		v30 = random(v6, 100);
+		v30 = random(131, 100);
 		if ( abs(v5) >= 2 || abs(v4) >= 2 )
 		{
 			if ( _LOBYTE(esi3->_mgoal) != 4 )
@@ -6875,14 +6762,12 @@ void __fastcall MAI_Rhino(int i)
 					if ( v10 < 5 )
 						goto LABEL_23;
 				}
-				_LOBYTE(v9) = -124;
-				if ( !random(v9, 4) )
+				if ( !random(132, 4) )
 					goto LABEL_23;
 				if ( _LOBYTE(esi3->_mgoal) != 4 )
 				{
 					esi3->_mgoalvar1 = 0;
-					_LOBYTE(v12) = -123;
-					esi3->_mgoalvar2 = random(v12, 2);
+					esi3->_mgoalvar2 = random(133, 2);
 				}
 			}
 			_LOBYTE(esi3->_mgoal) = 4;
@@ -6904,8 +6789,7 @@ void __fastcall MAI_Rhino(int i)
 				//_LOBYTE(v16) = M_RoundWalk(arglist, midir, &esi3->_mgoalvar2);
 				if ( !M_RoundWalk(arglist, midir, &esi3->_mgoalvar2) )
 				{
-					_LOBYTE(v17) = 125;
-					v18 = random(v17, 10);
+					v18 = random(125, 10);
 					M_StartDelay(arglist, v18 + 10);
 				}
 				goto LABEL_23;
@@ -6941,16 +6825,14 @@ LABEL_23:
 				//v23 = v22;
 				if ( v21 >= 2 || (v24 = abs(v4), v24 >= 2) ) /* v23 = v25,  */
 				{
-					_LOBYTE(v23) = -122;
-					v26 = random(v23, 100);
+					v26 = random(134, 100);
 					v27 = 2 * (unsigned char)esi3->_mint;
 					if ( v26 >= v27 + 33
 					  && ((v28 = esi3->_mVar1, v28 != 1) && v28 != 2 && v28 != 3
 					   || esi3->_mVar2
 					   || (v27 += 83, v26 >= v27)) )
 					{
-						_LOBYTE(v27) = -121;
-						v29 = random(v27, 10);
+						v29 = random(135, 10);
 						M_StartDelay(arglist, v29 + 10);
 					}
 					else
@@ -6978,8 +6860,6 @@ void __fastcall MAI_Counselor(int i)
 	int v4; // edi
 	int v5; // edx
 	int v6; // ebp
-	int v7; // ecx
-	int v8; // ecx
 	char v9; // al
 	int v10; // ecx
 	bool v11; // zf
@@ -6995,7 +6875,6 @@ void __fastcall MAI_Counselor(int i)
 	//int v21; // eax
 	int v22; // eax
 	//int v23; // ST1C_4
-	int v24; // ecx
 	int v25; // eax
 	//int v26; // ST1C_4
 	int v27; // edx
@@ -7028,8 +6907,7 @@ void __fastcall MAI_Counselor(int i)
 		md = GetDirection(v3, v5, monster[v2]._lastx, monster[v2]._lasty);
 		if ( monster[v2]._msquelch < 0xFFu ) /* check sign */
 			MonstCheckDoors(v1);
-		_LOBYTE(v7) = 121;
-		v39 = random(v7, 100);
+		v39 = random(121, 100);
 		v9 = monster[v2]._mgoal;
 		if ( v9 == 2 )
 		{
@@ -7081,8 +6959,7 @@ LABEL_21:
 LABEL_39:
 			if ( monster[v2]._mmode == MM_STAND )
 			{
-				_LOBYTE(v8) = 125;
-				v34 = random(v8, 10);
+				v34 = random(125, 10);
 				M_StartDelay(v1, v34 + 5);
 			}
 			return;
@@ -7098,9 +6975,8 @@ LABEL_39:
 				//_LOBYTE(v31) = LineClear(monster[v2]._mx, monster[v2]._my, x2, y2);
 				if ( LineClear(monster[v2]._mx, monster[v2]._my, x2, y2) )
 				{
-					_LOBYTE(v24) = 77;
 					v32 = random(
-							  v24,
+							  77,
 							  (unsigned char)monster[v2].mMaxDamage - (unsigned char)monster[v2].mMinDamage + 1);
 					M_StartRAttack(
 						v1,
@@ -7109,8 +6985,7 @@ LABEL_39:
 					goto LABEL_39;
 				}
 			}
-			_LOBYTE(v24) = 124;
-			if ( random(v24, 100) < 30 )
+			if ( random(124, 100) < 30 )
 			{
 				v27 = md;
 				_LOBYTE(monster[v2]._mgoal) = 4;
@@ -7133,9 +7008,9 @@ LABEL_29:
 				goto LABEL_39;
 			}
 			if ( monster[v2]._mVar1 == 13
-			  || (_LOBYTE(v24) = 105, v29 = random(v24, 100),
-									 v30 = 2 * (unsigned char)monster[v2]._mint + 20,
-									 v29 < v30) )
+			  || (v29 = random(105, 100),
+				  v30 = 2 * (unsigned char)monster[v2]._mint + 20,
+				  v29 < v30) )
 			{
 				M_StartRAttack(v1, -1, 0);
 				AddMissile(monster[v2]._mx, monster[v2]._my, 0, 0, monster[v2]._mdir, 11, 1, v1, 4, 0);
@@ -7143,8 +7018,7 @@ LABEL_29:
 				goto LABEL_39;
 			}
 		}
-		_LOBYTE(v30) = 105;
-		v33 = random(v30, 10);
+		v33 = random(105, 10);
 		M_StartDelay(v1, v33 + 2 * (5 - (unsigned char)monster[v2]._mint));
 		goto LABEL_39;
 	}
@@ -8840,7 +8714,6 @@ int __fastcall M_SpawnSkel(int x, int y, int dir)
 	CMonster *v3; // ebx
 	CMonster *v4; // esi
 	int v5; // edx
-	int v6; // ecx
 	int v7; // esi
 	//int v8; // edx
 	int v9; // eax
@@ -8869,9 +8742,8 @@ int __fastcall M_SpawnSkel(int x, int y, int dir)
 	while ( v15 );
 	if ( !v5 )
 		return -1;
-	_LOBYTE(v6) = -120;
 	v7 = 0;
-	v14 = random(v6, v5);
+	v14 = random(136, v5);
 	v16 = 0;
 	if ( nummtypes > 0 )
 	{
@@ -8968,8 +8840,7 @@ bool __fastcall SpawnSkeleton(int ii, int x, int y)
 			while ( a3 <= v4 + 1 );
 			if ( v20 )
 			{
-				_LOBYTE(v6) = -119;
-				v11 = random(v6, 15);
+				v11 = random(137, 15);
 				v12 = 0;
 				v13 = 0;
 				a3a = v11 + 1;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -467,15 +467,15 @@ void __fastcall InitRndLocObj(int min, int max, int objtype)
 	int i; // [esp+8h] [ebp-4h]
 
 	i = 0;
-	numobjs = min + random(-117, max - min);
+	numobjs = min + random(139, max - min);
 	if ( numobjs > 0 )
 	{
 		while ( 1 )
 		{
 			do
 			{
-				xp = random(-117, 80) + 16;
-				yp = random(-117, 80) + 16;
+				xp = random(139, 80) + 16;
+				yp = random(139, 80) + 16;
 			}
 			while ( !RndLocOk(xp - 1, yp - 1) );
 			if ( RndLocOk(xp, yp - 1) )
@@ -517,15 +517,15 @@ void __fastcall InitRndLocBigObj(int min, int max, int objtype)
 	int i; // [esp+8h] [ebp-4h]
 
 	i = 0;
-	numobjs = min + random(-116, max - min);
+	numobjs = min + random(140, max - min);
 	if ( numobjs > 0 )
 	{
 		while ( 1 )
 		{
 			do
 			{
-				xp = random(-116, 80) + 16;
-				yp = random(-116, 80) + 16;
+				xp = random(140, 80) + 16;
+				yp = random(140, 80) + 16;
 			}
 			while ( !RndLocOk(xp - 1, yp - 2) );
 			if ( RndLocOk(xp, yp - 2) )
@@ -572,10 +572,8 @@ void __fastcall InitRndLocObj5x5(int min, int max, int objtype)
 {
 	int v3; // esi
 	int v4; // edx
-	int v5; // ecx
 	int v6; // ebx
 	int v7; // eax
-	int v8; // ecx
 	int v9; // edi
 	int v10; // esi
 	int v11; // edx
@@ -587,9 +585,8 @@ void __fastcall InitRndLocObj5x5(int min, int max, int objtype)
 
 	v3 = min;
 	v4 = max - min;
-	_LOBYTE(min) = -117;
 	v13 = 0;
-	v6 = v3 + random(min, v4);
+	v6 = v3 + random(139, v4);
 	if ( v6 > 0 )
 	{
 		do
@@ -597,13 +594,11 @@ void __fastcall InitRndLocObj5x5(int min, int max, int objtype)
 			v14 = 0;
 			while ( 1 )
 			{
-				_LOBYTE(v5) = -117;
 				v12 = 1;
-				v7 = random(v5, 80);
-				_LOBYTE(v8) = -117;
+				v7 = random(139, 80);
 				v9 = v7 + 16;
 				v15 = -2;
-				v10 = random(v8, 80) + 16;
+				v10 = random(139, 80) + 16;
 				do
 				{
 					v16 = -2;
@@ -741,8 +736,8 @@ void __fastcall AddBookLever(int lx1, int ly1, int lx2, int ly2, int x1, int y1,
 	while ( 1 )
 	{
 		v17 = 1;
-		v9 = random(-117, 80) + 16;
-		v10 = random(-117, 80) + 16;
+		v9 = random(139, 80) + 16;
+		v10 = random(139, 80) + 16;
 		v11 = -2;
 		do
 		{
@@ -798,23 +793,23 @@ void __cdecl InitRndBarrels()
 	int v10; // [esp+Ch] [ebp-4h]
 
 	v10 = 0;
-	v0 = random(-113, 5) + 3;
+	v0 = random(143, 5) + 3;
 	if ( v0 > 0 )
 	{
 		do
 		{
 			do
 			{
-				v1 = random(-113, 80) + 16;
-				v2 = random(-113, 80) + 16;
+				v1 = random(143, 80) + 16;
+				v2 = random(143, 80) + 16;
 			}
 			while ( !RndLocOk(v1, v2) );
-			v3 = random(-113, 4);
+			v3 = random(143, 4);
 			AddObject(OBJ_BARRELEX - (v3 != 0), v1, v2);
 			v4 = 1;
 			v5 = 0;
 			v9 = 1;
-			while ( !random(-113, v5) && v4 )
+			while ( !random(143, v5) && v4 )
 			{
 				v8 = 0;
 				v4 = 0;
@@ -822,7 +817,7 @@ void __cdecl InitRndBarrels()
 				{
 					if ( v8 >= 3 )
 						break;
-					v6 = random(-113, 8);
+					v6 = random(143, 8);
 					v1 += bxadd[v6];
 					v2 += byadd[v6];
 					++v8;
@@ -831,7 +826,7 @@ void __cdecl InitRndBarrels()
 				while ( !v4 );
 				if ( v4 )
 				{
-					v7 = random(-113, 5);
+					v7 = random(143, 5);
 					AddObject(OBJ_BARRELEX - (v7 != 0), v1, v2);
 					++v9;
 				}
@@ -946,7 +941,6 @@ void __cdecl AddL2Torches()
 	int v1; // edi
 	char *v2; // ebx
 	//int v3; // eax
-	int v4; // ecx
 	int (*v5)[112]; // [esp+Ch] [ebp-Ch]
 	int v6; // [esp+10h] [ebp-8h]
 	int (*v7)[112]; // [esp+14h] [ebp-4h]
@@ -966,29 +960,25 @@ void __cdecl AddL2Torches()
 			v6 = (*v5)[0];
 			if ( (*v5)[0] == 1 )
 			{
-				_LOBYTE(v4) = -111;
-				if ( random(v4, 3) )
+				if ( random(145, 3) )
 					goto LABEL_18;
 				AddObject(OBJ_TORCHL2, v1, v0);
 			}
 			if ( v6 == 5 )
 			{
-				_LOBYTE(v4) = -111;
-				if ( random(v4, 3) )
+				if ( random(145, 3) )
 					goto LABEL_18;
 				AddObject(OBJ_TORCHR2, v1, v0);
 			}
 			if ( v6 == 37 )
 			{
-				_LOBYTE(v4) = -111;
-				if ( random(v4, 10) || *(v2 - 111) )
+				if ( random(145, 10) || *(v2 - 111) )
 					goto LABEL_18;
 				AddObject(OBJ_TORCHL, v1 - 1, v0);
 			}
 			if ( v6 == 41 )
 			{
-				_LOBYTE(v4) = -111;
-				if ( !random(v4, 10) && !*v2 )
+				if ( !random(145, 10) && !*v2 )
 					AddObject(OBJ_TORCHR, v1, v0 - 1);
 			}
 LABEL_18:
@@ -1057,12 +1047,12 @@ void __cdecl AddObjTraps()
 		v13 = (char *)dObject + v0;
 		do
 		{
-			if ( *v2 > 0 && random(-112, 100) < v15 )
+			if ( *v2 > 0 && random(144, 100) < v15 )
 			{
 				v3 = (char)(*v2 - 1);
 				if ( AllObjects[object[v3]._otype].oTrapFlag )
 				{
-					if ( random(-112, 2) )
+					if ( random(144, 2) )
 					{
 						v8 = v0 - 1;
 						for ( i = &dPiece[v16][v0-1]; !nSolidTable[*i]; i-- ) /* check dpiece */
@@ -1289,8 +1279,8 @@ void __cdecl AddStoryBooks()
 	while ( 1 )
 	{
 		y = 1;
-		v0 = random(-117, 80) + 16;
-		v1 = random(-117, 80) + 16;
+		v0 = random(139, 80) + 16;
+		v1 = random(139, 80) + 16;
 		v2 = -2;
 		do
 		{
@@ -1348,8 +1338,7 @@ void __fastcall AddHookedBodies(int freq)
 		{
 			if ( *v2 == 1 || *v2 == 2 )
 			{
-				_LOBYTE(freq) = 0;
-				if ( !random(freq, max) )
+				if ( !random(0, max) )
 				{
 					//_LOBYTE(v4) = SkipThemeRoom(x, y);
 					if ( SkipThemeRoom(x, y) )
@@ -1358,8 +1347,7 @@ void __fastcall AddHookedBodies(int freq)
 						{
 							if ( *v2 == 2 && v2[1] == 6 )
 							{
-								_LOBYTE(freq) = 0;
-								v7 = random(freq, 2);
+								v7 = random(0, 2);
 								if ( v7 )
 								{
 									if ( v7 != 1 )
@@ -1377,8 +1365,7 @@ void __fastcall AddHookedBodies(int freq)
 						}
 						else
 						{
-							_LOBYTE(freq) = 0;
-							v5 = random(freq, 3);
+							v5 = random(0, 3);
 							if ( v5 )
 							{
 								v6 = v5 - 1;
@@ -1441,8 +1428,8 @@ void __cdecl AddLazStand()
 	while ( 1 )
 	{
 		v5 = 1;
-		v0 = random(-117, 80) + 16;
-		v1 = random(-117, 80) + 16;
+		v0 = random(139, 80) + 16;
+		v1 = random(139, 80) + 16;
 		v2 = -3;
 		do
 		{
@@ -1792,7 +1779,6 @@ void __fastcall SetupObject(int i, int x, int y, int ot)
 	int v9; // eax
 	int v10; // edx
 	int v11; // eax
-	int v12; // ecx
 	int v13; // eax
 	int v14; // eax
 
@@ -1812,13 +1798,11 @@ void __fastcall SetupObject(int i, int x, int y, int ot)
 	if ( v9 )
 	{
 		v10 = AllObjects[v5].oAnimDelay;
-		_LOBYTE(v6) = -110;
 		object[v4]._oAnimDelay = v10;
-		object[v4]._oAnimCnt = random(v6, v10);
+		object[v4]._oAnimCnt = random(146, v10);
 		v11 = AllObjects[v5].oAnimLen;
-		_LOBYTE(v12) = -110;
 		object[v4]._oAnimLen = v11;
-		v13 = random(v12, v11 - 1) + 1;
+		v13 = random(146, v11 - 1) + 1;
 	}
 	else
 	{
@@ -1900,13 +1884,11 @@ void __fastcall AddChest(int i, int t)
 	int v2; // edi
 	int v3; // esi
 	int v4; // esi
-	int v5; // ecx
 	int v6; // [esp-4h] [ebp-Ch]
 
 	v2 = t;
 	v3 = i;
-	_LOBYTE(i) = -109;
-	if ( !random(i, 2) )
+	if ( !random(147, 2) )
 		object[v3]._oAnimFrame += 3;
 	v4 = v3;
 	object[v4]._oRndSeed = GetRndSeed();
@@ -1932,8 +1914,7 @@ LABEL_9:
 			}
 			v6 = 4;
 LABEL_18:
-			_LOBYTE(v5) = -109;
-			object[v4]._oVar1 = random(v5, v6);
+			object[v4]._oVar1 = random(147, v6);
 			break;
 		case OBJ_TCHEST1:
 LABEL_22:
@@ -1949,8 +1930,7 @@ LABEL_22:
 		case OBJ_TCHEST3:
 			goto LABEL_9;
 	}
-	_LOBYTE(v5) = -109;
-	object[v4]._oVar2 = random(v5, 8);
+	object[v4]._oVar2 = random(147, 8);
 }
 // 5CF31D: using guessed type char setlevel;
 
@@ -1993,8 +1973,7 @@ void __fastcall AddSarc(int i)
 	v2 = -1 - i;
 	v3 = 112 * object[i]._ox;
 	dObject[0][v3 + object[v1]._oy - 1] = v2; /* dungeon[39][v3 + 39 + object[v1]._oy] = v2; */
-	_LOBYTE(v3) = -103;
-	object[v1]._oVar1 = random(v3, 10);
+	object[v1]._oVar1 = random(153, 10);
 	v4 = GetRndSeed();
 	v6 = __OFSUB__(object[v1]._oVar1, 8);
 	v5 = object[v1]._oVar1 - 8 < 0;
@@ -2052,9 +2031,7 @@ void __fastcall AddBarrel(int i)
 {
 	int v1; // esi
 	int v2; // eax
-	int v3; // ecx
 	int v4; // eax
-	int v5; // ecx
 	int v6; // eax
 	bool v7; // sf
 	unsigned char v8; // of
@@ -2062,12 +2039,10 @@ void __fastcall AddBarrel(int i)
 	v1 = i;
 	object[i]._oVar1 = 0;
 	v2 = GetRndSeed();
-	_LOBYTE(v3) = -107;
 	object[v1]._oRndSeed = v2;
-	v4 = random(v3, 10);
-	_LOBYTE(v5) = -107;
+	v4 = random(149, 10);
 	object[v1]._oVar2 = v4;
-	v6 = random(v5, 3);
+	v6 = random(149, 3);
 	v8 = __OFSUB__(object[v1]._oVar2, 8);
 	v7 = object[v1]._oVar2 - 8 < 0;
 	object[v1]._oVar3 = v6;
@@ -2112,13 +2087,11 @@ void __fastcall AddShrine(int i)
 	while ( v3 < 26 );
 	do
 	{
-		_LOBYTE(v4) = -106;
-		v6 = random((int)v4, 26);
+		v6 = random(150, 26);
 	}
 	while ( !slist[v6] );
-	_LOBYTE(v4) = -106;
 	object[v1]._oVar1 = v6;
-	if ( random((int)v4, 2) )
+	if ( random(150, 2) )
 	{
 		object[v1]._oAnimFrame = 12;
 		object[v1]._oAnimLen = 22;
@@ -2165,14 +2138,12 @@ void __fastcall AddDecap(int i)
 {
 	int v1; // esi
 	int v2; // eax
-	int v3; // ecx
 	int v4; // eax
 
 	v1 = i;
 	v2 = GetRndSeed();
-	_LOBYTE(v3) = -105;
 	object[v1]._oRndSeed = v2;
-	v4 = random(v3, 8);
+	v4 = random(151, 8);
 	object[v1]._oPreFlag = 1;
 	object[v1]._oAnimFrame = v4 + 1;
 }
@@ -2272,7 +2243,6 @@ void __fastcall GetRndObjLoc(int randarea, int *xx, int *yy)
 {
 	int *v3; // ebx
 	int v4; // eax
-	int v5; // ecx
 	int v6; // eax
 	int v7; // esi
 	bool v8; // eax
@@ -2291,11 +2261,9 @@ void __fastcall GetRndObjLoc(int randarea, int *xx, int *yy)
 LABEL_3:
 			if ( ++v10 > 1000 && v12 > 1 )
 				--v12;
-			_LOBYTE(randarea) = 0;
-			v4 = random(randarea, 112);
-			_LOBYTE(v5) = 0;
+			v4 = random(0, 112);
 			*v3 = v4;
-			v6 = random(v5, 112);
+			v6 = random(0, 112);
 			v7 = v6;
 			*yy = v6;
 			v8 = 0;
@@ -4778,9 +4746,8 @@ void __fastcall TryDisarm(int pnum, int i)
 	v4 = v3;
 	if ( object[v4]._oTrapFlag )
 	{
-		_LOBYTE(pnum) = -102;
 		v5 = 2 * plr[v2]._pDexterity - 5 * currlevel;
-		if ( random(pnum, 100) <= v5 )
+		if ( random(154, 100) <= v5 )
 		{
 			v6 = nobjects;
 			for ( j = 0; j < v6; ++j )
@@ -4823,7 +4790,6 @@ void __fastcall OperateShrine(int pnum, int i, int sType)
 	int v5; // eax
 	int v6; // ecx
 	int v7; // ecx
-	int v8; // ecx
 	int v9; // eax
 	int v10; // eax
 	int v11; // eax
@@ -4905,7 +4871,6 @@ void __fastcall OperateShrine(int pnum, int i, int sType)
 	int v87; // eax
 	int v88; // ebx
 	int v89; // eax
-	int v90; // ecx
 	int v91; // esi
 	int v92; // eax
 	int v93; // edx
@@ -4947,7 +4912,6 @@ void __fastcall OperateShrine(int pnum, int i, int sType)
 	int *v129; // ecx
 	int *v130; // eax
 	signed int v131; // ecx
-	int v132; // ecx
 	int v133; // eax
 	int v134; // ebx
 	int v135; // edi
@@ -5003,8 +4967,7 @@ void __fastcall OperateShrine(int pnum, int i, int sType)
 					ModifyPlrMag(arglist, -1);
 					ModifyPlrDex(arglist, -1);
 					ModifyPlrVit(arglist, -1);
-					_LOBYTE(v8) = 0;
-					v9 = random(v8, 4);
+					v9 = random(0, 4);
 					if ( v9 )
 					{
 						v10 = v9 - 1;
@@ -5098,8 +5061,7 @@ void __fastcall OperateShrine(int pnum, int i, int sType)
 					while ( v20 );
 					if ( !v18 )
 						goto LABEL_47;
-					_LOBYTE(v7) = 0;
-					v21 = random(v7, 7);
+					v21 = random(0, 7);
 					v7 = v13 * 21720 + 368 * v21;
 					if ( *(int *)((char *)&plr[0].InvBody[0]._itype + v7) != -1 )
 					{
@@ -5339,8 +5301,7 @@ LABEL_47:
 					while ( v59 <= 37 );
 					do
 					{
-						_LOBYTE(v7) = 0;
-						v60 = random(v7, 37);
+						v60 = random(0, 37);
 						v7 = v60;
 					}
 					while ( !(plr[v53]._pMemSpells[1] & ((unsigned __int64)((__int64)1 << v60) >> 32) | plr[v53]._pMemSpells[0] & (unsigned int)((__int64)1 << v60)) );
@@ -5544,11 +5505,9 @@ LABEL_47:
 				v88 = 0;
 				do
 				{
-					_LOBYTE(v7) = -97;
-					v89 = random(v7, 112);
-					_LOBYTE(v90) = -97;
+					v89 = random(159, 112);
 					v91 = v89;
-					v92 = random(v90, 112);
+					v92 = random(159, 112);
 					if ( ++v88 > 12544 )
 						break;
 					v7 = v92 + 112 * v91;
@@ -5618,8 +5577,7 @@ LABEL_47:
 				{
 					if ( !plr[v106].InvGrid[sfx_idd] )
 					{
-						_LOBYTE(v7) = -96;
-						v107 = 5 * (unsigned char)leveltype + random(v7, 10 * (unsigned char)leveltype);
+						v107 = 5 * (unsigned char)leveltype + random(160, 10 * (unsigned char)leveltype);
 						v108 = plr[v106]._pNumInv;
 						v109 = v106 * 21720 + 368 * v108;
 						qmemcpy((char *)plr[0].InvList + v109, &golditem, 0x170u);
@@ -5788,8 +5746,7 @@ LABEL_47:
 				}
 				_LOBYTE(v7) = 39;
 				InitDiabloMsg(v7);
-				_LOBYTE(v132) = -101;
-				v133 = random(v132, 4);
+				v133 = random(155, 4);
 				v134 = 1;
 				v135 = 2 * (v133 == 1) - 1;
 				if ( v133 == 2 || (v134 = -1, v133 != 3) )
@@ -5855,7 +5812,6 @@ void __fastcall OperateSkelBook(int pnum, int i, unsigned char sendmsg)
 	unsigned short v3; // di
 	int v4; // esi
 	bool v5; // zf
-	int v6; // ecx
 	int v7; // eax
 	int v8; // ecx
 	int v9; // edx
@@ -5874,8 +5830,7 @@ void __fastcall OperateSkelBook(int pnum, int i, unsigned char sendmsg)
 		if ( v5 )
 		{
 			SetRndSeed(object[v4]._oRndSeed);
-			_LOBYTE(v6) = -95;
-			v7 = random(v6, 5);
+			v7 = random(161, 5);
 			v8 = object[v4]._ox;
 			v9 = object[v4]._oy;
 			if ( v7 )
@@ -5962,7 +5917,6 @@ void __fastcall OperateArmorStand(int pnum, int i, unsigned char sendmsg)
 	int v4; // esi
 	int *v5; // eax
 	bool v6; // zf
-	int v7; // ecx
 	unsigned char v8; // al
 	int v9; // [esp-10h] [ebp-20h]
 	int v10; // [esp-8h] [ebp-18h]
@@ -5980,8 +5934,7 @@ void __fastcall OperateArmorStand(int pnum, int i, unsigned char sendmsg)
 		if ( v6 )
 		{
 			SetRndSeed(object[v4]._oRndSeed);
-			_LOBYTE(v7) = 0;
-			v8 = random(v7, 2);
+			v8 = random(0, 2);
 			if ( currlevel > 5u )
 			{
 				if ( currlevel >= 6u && currlevel <= 9u )
@@ -6081,7 +6034,6 @@ bool __fastcall OperateFountains(int pnum, int i)
 	int v3; // esi
 	int v4; // edi
 	bool v5; // bp
-	int v6; // ecx
 	signed int v7; // ebx
 	int v8; // ebp
 	int v10; // eax
@@ -6202,8 +6154,7 @@ LABEL_38:
 					return 0;
 				do
 				{
-					_LOBYTE(v6) = 0;
-					v10 = random(v6, 4);
+					v10 = random(0, 4);
 					v11 = v10;
 					if ( v10 != v7 )
 					{
@@ -6258,7 +6209,6 @@ void __fastcall OperateWeaponRack(int pnum, int i, unsigned char sendmsg)
 {
 	unsigned short v3; // di
 	int v4; // esi
-	int v5; // ecx
 	int v6; // eax
 	int v7; // eax
 	int v8; // eax
@@ -6275,8 +6225,7 @@ void __fastcall OperateWeaponRack(int pnum, int i, unsigned char sendmsg)
 	if ( !object[i]._oSelFlag )
 		return;
 	SetRndSeed(object[v4]._oRndSeed);
-	_LOBYTE(v5) = 0;
-	v6 = random(v5, 4);
+	v6 = random(0, 4);
 	if ( v6 )
 	{
 		v7 = v6 - 1;
@@ -6868,9 +6817,8 @@ void __fastcall BreakObject(int pnum, int oi)
 	else
 	{
 		v4 = pnum;
-		_LOBYTE(pnum) = -93;
 		v5 = plr[v2]._pIMinDam;
-		v6 = v5 + random(pnum, plr[v2]._pIMaxDam - v5 + 1);
+		v6 = v5 + random(163, plr[v2]._pIMaxDam - v5 + 1);
 		v7 = plr[v4]._pIBonusDamMod + plr[v4]._pDamageMod + v6 * plr[v4]._pIBonusDam / 100 + v6;
 	}
 	v8 = object[v3]._otype;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1044,9 +1044,7 @@ void __fastcall InitPlayer(int pnum, bool FirstTime)
 	PlayerStruct *v4; // edi
 	int v5; // eax
 	int v6; // ST08_4
-	int v7; // ecx
 	int v8; // eax
-	int v9; // ecx
 	int v10; // ST08_4
 	int v11; // edx
 	int v12; // eax
@@ -1100,11 +1098,9 @@ void __fastcall InitPlayer(int pnum, bool FirstTime)
 			v6 = plr[v3]._pNWidth;
 			v4->_pmode = 0;
 			NewPlrAnim(v2, plr[v3]._pNAnim[0], plr[v3]._pNFrames, 3, v6);
-			_LOBYTE(v7) = 2;
-			v8 = random(v7, plr[v3]._pNFrames - 1);
-			_LOBYTE(v9) = 2;
+			v8 = random(2, plr[v3]._pNFrames - 1);
 			plr[v3]._pAnimFrame = v8 + 1;
-			plr[v3]._pAnimCnt = random(v9, 3);
+			plr[v3]._pAnimCnt = random(2, 3);
 		}
 		v13 = 0;
 		v14 = v2 == myplr;
@@ -3177,8 +3173,7 @@ bool __fastcall WeaponDur(int pnum, int durrnd)
 	v2 = pnum;
 	if ( pnum != myplr )
 		return 0;
-	_LOBYTE(pnum) = 3;
-	if ( random(pnum, durrnd) )
+	if ( random(3, durrnd) )
 		return 0;
 	if ( v2 >= 4 )
 		TermMsg("WeaponDur: illegal player %d", v2);
@@ -3254,7 +3249,6 @@ bool __fastcall PlrHitMonst(int pnum, int m)
 	int v12; // edi
 	int v13; // edi
 	//int v14; // eax
-	int v15; // ecx
 	int v16; // edx
 	int v17; // eax
 	int v18; // ecx
@@ -3311,8 +3305,7 @@ bool __fastcall PlrHitMonst(int pnum, int m)
 		//pnum = v7;
 	}
 	v42 = 0;
-	_LOBYTE(pnum) = 4;
-	v8 = random(pnum, 100);
+	v8 = random(4, 100);
 	v23 = *(MON_MODE *)((char *)&monster[0]._mmode + v5) == MM_STONE;
 	v46 = v8;
 	if ( v23 )
@@ -3336,17 +3329,15 @@ bool __fastcall PlrHitMonst(int pnum, int m)
 	if ( (signed int)v46 < v13 )
 #endif
 	{
-		_LOBYTE(v15) = 5;
 		v16 = plr[v9]._pIMaxDam - plr[v9]._pIMinDam + 1;
 		v48 = plr[v9]._pIMinDam;
-		v17 = random(v15, v16);
+		v17 = random(5, v16);
 		v18 = 100;
 		v19 = plr[v9]._pIBonusDamMod + plr[v9]._pDamageMod + (v48 + v17) * plr[v9]._pIBonusDam / 100 + v48 + v17;
 		if ( !_LOBYTE(plr[v9]._pClass) )
 		{
-			_LOBYTE(v18) = 6;
 			v48 = plr[v9]._pLevel;
-			v20 = random(v18, 100);
+			v20 = random(6, 100);
 			if ( v20 < v48 )
 				v19 *= 2;
 		}
@@ -3383,8 +3374,7 @@ LABEL_40:
 			*(int *)((char *)&monster[0]._mhitpoints + v5) -= v26;
 		if ( v24 & 2 )
 		{
-			_LOBYTE(v25) = 7;
-			v27 = random(v25, v26 >> 3);
+			v27 = random(7, v26 >> 3);
 			v28 = plr[v9]._pMaxHP;
 			v29 = &plr[v9]._pHitPoints;
 			*v29 += v27;
@@ -3529,9 +3519,8 @@ bool __fastcall PlrHitPlr(int pnum, char p)
 		TermMsg("PlrHitPlr: illegal attacking player %d", v3);
 		//pnum = v7;
 	}
-	_LOBYTE(pnum) = 4;
 	v8 = v3;
-	v29 = random(pnum, 100);
+	v29 = random(4, 100);
 	v9 = (plr[v8]._pDexterity >> 1) - plr[v5]._pIBonusAC - plr[v5]._pIAC - plr[v5]._pDexterity / 5;
 	v10 = plr[v8]._pLevel;
 	v11 = v9 + v10 + 50;
@@ -3549,8 +3538,7 @@ bool __fastcall PlrHitPlr(int pnum, char p)
 	}
 	else
 	{
-		_LOBYTE(v9) = 5;
-		v14 = random(v9, 100);
+		v14 = random(5, 100);
 	}
 	v15 = plr[v5]._pDexterity + plr[v5]._pBaseToBlk + 2 * plr[v5]._pLevel - 2 * plr[v8]._pLevel;
 	if ( v15 < 0 )
@@ -3562,22 +3550,19 @@ bool __fastcall PlrHitPlr(int pnum, char p)
 		if ( v14 >= v15 )
 		{
 			v17 = plr[v8]._pIMinDam;
-			_LOBYTE(v15) = 5;
-			v18 = random(v15, plr[v8]._pIMaxDam - v17 + 1);
+			v18 = random(5, plr[v8]._pIMaxDam - v17 + 1);
 			v19 = 100;
 			v20 = plr[v8]._pIBonusDamMod + plr[v8]._pDamageMod + (v17 + v18) * plr[v8]._pIBonusDam / 100 + v17 + v18;
 			if ( !_LOBYTE(plr[v8]._pClass) )
 			{
 				v21 = plr[v8]._pLevel;
-				_LOBYTE(v19) = 6;
-				if ( random(v19, 100) < v21 )
+				if ( random(6, 100) < v21 )
 					v20 *= 2;
 			}
 			v22 = v20 << 6;
 			if ( plr[v8]._pIFlags & 2 )
 			{
-				_LOBYTE(v19) = 7;
-				v23 = random(v19, v22 >> 3);
+				v23 = random(7, v22 >> 3);
 				v24 = plr[v8]._pMaxHP;
 				v25 = &plr[v8]._pHitPoints;
 				*v25 += v23;
@@ -3826,7 +3811,6 @@ int __fastcall PM_DoBlock(int pnum)
 {
 	int v1; // esi
 	int v2; // eax
-	int v3; // ecx
 
 	v1 = pnum;
 	if ( (unsigned int)pnum >= 4 )
@@ -3838,8 +3822,7 @@ int __fastcall PM_DoBlock(int pnum)
 		return 0;
 	StartStand(v1, plr[v2]._pdir);
 	ClearPlrPVars(v1);
-	_LOBYTE(v3) = 3;
-	if ( !random(v3, 10) )
+	if ( !random(3, 10) )
 		ShieldDur(v1);
 	return 1;
 }
@@ -3909,7 +3892,6 @@ int __fastcall PM_DoGotHit(int pnum)
 	int v2; // eax
 	int v3; // edx
 	int v4; // ecx
-	int v5; // ecx
 
 	v1 = pnum;
 	if ( (unsigned int)pnum >= 4 )
@@ -3927,8 +3909,7 @@ int __fastcall PM_DoGotHit(int pnum)
 		return 0;
 	StartStand(v1, plr[v2]._pdir);
 	ClearPlrPVars(v1);
-	_LOBYTE(v5) = 3;
-	if ( random(v5, 4) )
+	if ( random(3, 4) )
 		ArmorDur(v1);
 	return 1;
 }
@@ -3956,8 +3937,7 @@ void __fastcall ArmorDur(int pnum)
 		v3 = &plr[v1];
 		if ( v3->InvBody[6]._itype != -1 || v3->InvBody[0]._itype != -1 )
 		{
-			_LOBYTE(pnum) = 8;
-			v4 = random(pnum, 3);
+			v4 = random(8, 3);
 			v5 = v3->InvBody[6]._itype;
 			if ( v5 == -1 )
 				goto LABEL_23;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -63,14 +63,9 @@ void __cdecl InitQuests()
 	unsigned char v8; // al
 	unsigned char v9; // al
 	char v10; // al
-	int v11; // ecx
-	int v12; // ecx
 	int v13; // eax
-	int v14; // ecx
 	int v15; // eax
-	int v16; // ecx
 	int v17; // eax
-	int v18; // ecx
 	int v19; // eax
 	char v20; // [esp+8h] [ebp-4h]
 
@@ -149,22 +144,17 @@ void __cdecl InitQuests()
 	if ( v0 == 1 )
 	{
 		SetRndSeed(glSeedTbl[15]);
-		_LOBYTE(v11) = 0;
-		if ( random(v11, 2) )
+		if ( random(0, 2) )
 			quests[13]._qactive = 0;
 		else
 			quests[12]._qactive = 0;
-		_LOBYTE(v12) = 0;
-		v13 = random(v12, 3);
-		_LOBYTE(v14) = 0;
+		v13 = random(0, 3);
 		quests[QuestGroup1[v13]]._qactive = 0;
-		v15 = random(v14, 3);
-		_LOBYTE(v16) = 0;
+		v15 = random(0, 3);
 		quests[QuestGroup2[v15]]._qactive = 0;
-		v17 = random(v16, 3);
-		_LOBYTE(v18) = 0;
+		v17 = random(0, 3);
 		quests[QuestGroup3[v17]]._qactive = 0;
-		v19 = random(v18, 2);
+		v19 = random(0, 2);
 		v0 = gbMaxPlayers;
 		quests[QuestGroup4[v19]]._qactive = 0;
 	}

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -3889,7 +3889,6 @@ void __cdecl S_TalkEnter()
 	int *v4; // ecx
 	int v5; // esi
 	signed int v6; // ebp
-	int v7; // ecx
 	int v8; // eax
 	int v9; // ebx
 	int v10; // ecx
@@ -3927,8 +3926,7 @@ void __cdecl S_TalkEnter()
 		if ( stextsel == v5 - 2 )
 		{
 			SetRndSeed(towner[talker]._tSeed);
-			_LOBYTE(v7) = 0;
-			v8 = random(v7, gossipend - gossipstart + 1);
+			v8 = random(0, gossipend - gossipstart + 1);
 			InitQTextMsg(gossipstart + v8);
 		}
 		else

--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -542,15 +542,12 @@ void __cdecl InitThemes()
 	char v1; // bl
 	int v2; // edi
 	//int v3; // eax
-	int v4; // ecx
 	int i; // ebx
 	//int v6; // eax
-	int v7; // ecx
 	int v8; // esi
 	int v9; // ecx
 	int j; // eax
 	//int v11; // eax
-	int v12; // ecx
 	int *v13; // edi
 	int v14; // esi
 	int *v15; // ebx
@@ -589,14 +586,12 @@ void __cdecl InitThemes()
 				//_LOBYTE(v3) = CheckThemeRoom(v2);
 				if ( CheckThemeRoom(v2) )
 				{
-					_LOBYTE(v4) = 0;
 					themes[v0].ttval = v2;
-					for ( i = ThemeGood[random(v4, 4)]; ; i = random(v7, 17) )
+					for ( i = ThemeGood[random(0, 4)]; ; i = random(0, 17) )
 					{
 						//_LOBYTE(v6) = SpecialThemeFit(numthemes, i);
 						if ( SpecialThemeFit(numthemes, i) )
 							break;
-						_LOBYTE(v7) = 0;
 					}
 					v8 = numthemes;
 					themes[numthemes].ttype = i;
@@ -642,14 +637,12 @@ LABEL_23:
 			{
 				if ( themes[k].ttype == -1 )
 				{
-					_LOBYTE(v12) = 0;
 					themes[k].ttval = *v13;
-					for ( l = ThemeGood[random(v12, 4)]; ; l = random(v12, 17) )
+					for ( l = ThemeGood[random(0, 4)]; ; l = random(0, 17) )
 					{
 						//_LOBYTE(v20) = SpecialThemeFit(k, l);
 						if ( SpecialThemeFit(k, l) )
 							break;
-						_LOBYTE(v12) = 0;
 					}
 					themes[k].ttype = l;
 				}
@@ -953,8 +946,6 @@ void __fastcall Theme_Library(int t)
 	int v2; // ebx
 	char *v3; // esi
 	//int v4; // eax
-	int v5; // ecx
-	int v6; // ecx
 	int v7; // eax
 	//int v8; // eax
 	int ta; // [esp+Ch] [ebp-14h]
@@ -999,12 +990,10 @@ void __fastcall Theme_Library(int t)
 			{
 				if ( !*v10 )
 				{
-					_LOBYTE(v5) = 0;
-					if ( !random(v5, librnd[leveltype]) )
+					if ( !random(0, librnd[leveltype]) )
 					{
 						AddObject(OBJ_BOOKSTAND, v2, v1);
-						_LOBYTE(v6) = 0;
-						if ( random(v6, 2 * librnd[leveltype]) )
+						if ( random(0, 2 * librnd[leveltype]) )
 						{
 							v7 = *v3 - 1;
 							object[v7]._oSelFlag = 0;
@@ -1035,7 +1024,6 @@ void __fastcall Theme_Torture(int t)
 	int v2; // esi
 	char *v3; // edi
 	//int v4; // eax
-	int v5; // ecx
 	int *x; // [esp+Ch] [ebp-14h]
 	char monstrnd[5]; // [esp+10h] [ebp-10h]
 	int *v8; // [esp+14h] [ebp-Ch]
@@ -1065,8 +1053,7 @@ void __fastcall Theme_Torture(int t)
 				//LOBYTE(v4) = CheckThemeObj3(v10, v2, v1, -1);
 				if ( CheckThemeObj3(v10, v2, v1, -1) )
 				{
-					_LOBYTE(v5) = 0;
-					if ( !random(v5, tortrnd[leveltype]) )
+					if ( !random(0, tortrnd[leveltype]) )
 						AddObject(OBJ_TNUDEM2, v10, v2);
 				}
 			}
@@ -1103,7 +1090,6 @@ void __fastcall Theme_Decap(int t)
 	int v2; // esi
 	char *v3; // edi
 	//int v4; // eax
-	int v5; // ecx
 	int *x; // [esp+Ch] [ebp-14h]
 	char monstrnd[5]; // [esp+10h] [ebp-10h]
 	int *v8; // [esp+14h] [ebp-Ch]
@@ -1133,8 +1119,7 @@ void __fastcall Theme_Decap(int t)
 				//LOBYTE(v4) = CheckThemeObj3(v10, v2, v1, -1);
 				if ( CheckThemeObj3(v10, v2, v1, -1) )
 				{
-					_LOBYTE(v5) = 0;
-					if ( !random(v5, decaprnd[leveltype]) )
+					if ( !random(0, decaprnd[leveltype]) )
 						AddObject(OBJ_DECAP, v10, v2);
 				}
 			}
@@ -1171,7 +1156,6 @@ void __fastcall Theme_ArmorStand(int t)
 	int v2; // ebx
 	char *v3; // edi
 	//int v4; // eax
-	int v5; // ecx
 	int ta; // [esp+Ch] [ebp-14h]
 	int *v7; // [esp+10h] [ebp-10h]
 	char monstrnd[5]; // [esp+14h] [ebp-Ch]
@@ -1206,8 +1190,7 @@ void __fastcall Theme_ArmorStand(int t)
 				//LOBYTE(v4) = CheckThemeObj3(v2, v1, ta, -1);
 				if ( CheckThemeObj3(v2, v1, ta, -1) )
 				{
-					_LOBYTE(v5) = 0;
-					if ( !random(v5, armorrnd[leveltype]) )
+					if ( !random(0, armorrnd[leveltype]) )
 						AddObject(OBJ_ARMORSTANDN, v2, v1);
 				}
 			}
@@ -1319,7 +1302,6 @@ void __fastcall Theme_BrnCross(int t)
 	int v2; // ebx
 	char *v3; // edi
 	//int v4; // eax
-	int v5; // ecx
 	int ta; // [esp+Ch] [ebp-14h]
 	int *v7; // [esp+10h] [ebp-10h]
 	char monstrnd[5]; // [esp+14h] [ebp-Ch]
@@ -1349,8 +1331,7 @@ void __fastcall Theme_BrnCross(int t)
 				//LOBYTE(v4) = CheckThemeObj3(v2, v1, ta, -1);
 				if ( CheckThemeObj3(v2, v1, ta, -1) )
 				{
-					_LOBYTE(v5) = 0;
-					if ( !random(v5, bcrossrnd[leveltype]) )
+					if ( !random(0, bcrossrnd[leveltype]) )
 						AddObject(OBJ_TBCROSS, v2, v1);
 				}
 			}
@@ -1375,7 +1356,6 @@ void __fastcall Theme_WeaponRack(int t)
 	int v2; // ebx
 	char *v3; // edi
 	//int v4; // eax
-	int v5; // ecx
 	int ta; // [esp+Ch] [ebp-14h]
 	int *v7; // [esp+10h] [ebp-10h]
 	char monstrnd[5]; // [esp+14h] [ebp-Ch]
@@ -1410,8 +1390,7 @@ void __fastcall Theme_WeaponRack(int t)
 				//LOBYTE(v4) = CheckThemeObj3(v2, v1, ta, -1);
 				if ( CheckThemeObj3(v2, v1, ta, -1) )
 				{
-					_LOBYTE(v5) = 0;
-					if ( !random(v5, weaponrnd[leveltype]) )
+					if ( !random(0, weaponrnd[leveltype]) )
 						AddObject(OBJ_WEAPONRACKN, v2, v1);
 				}
 			}

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -672,7 +672,6 @@ void __cdecl InitCows()
 	int v5; // eax
 	void **v6; // ecx
 	int v7; // edi
-	int v8; // ecx
 	int v9; // edx
 	int v10; // eax
 	int v11; // ecx
@@ -700,8 +699,7 @@ void __cdecl InitCows()
 		towner[numtowners]._tNFrames = 12;
 		NewTownerAnim(v7, (void *)towner[0]._tNAnim[v4 + 58 * v7], 12, 3);
 		v7 *= 232;
-		_LOBYTE(v8) = 0;
-		*(int *)((char *)&towner[0]._tAnimFrame + v7) = random(v8, 11) + 1;
+		*(int *)((char *)&towner[0]._tAnimFrame + v7) = random(0, 11) + 1;
 		*(int *)((char *)&towner[0]._tSelFlag + v7) = 1;
 		strcpy(&towner[0]._tName[v7], "Cow");
 		v9 = v3 + cowoffx[v4];
@@ -990,8 +988,6 @@ void __fastcall TalkToTowner(int p, int t)
 {
 	int v2; // ebx
 	int v3; // edi
-	int v4; // ecx
-	int v5; // ecx
 	int v6; // ebp
 	int v7; // esi
 	int v8; // eax
@@ -1011,13 +1007,10 @@ void __fastcall TalkToTowner(int p, int t)
 
 	v2 = t;
 	v3 = p;
-	_LOBYTE(p) = 6;
 	v21 = t;
-	random(p, 3);
-	_LOBYTE(v4) = 6;
-	random(v4, 4);
-	_LOBYTE(v5) = 6;
-	random(v5, 5);
+	random(6, 3); /* figure out what these are for */
+	random(6, 4);
+	random(6, 5);
 	v6 = v3;
 	v7 = v2;
 	inv_item_num = abs(plr[v3].WorldX - towner[v2]._tx);


### PR DESCRIPTION
The first field of the function `random` (index) is unused. It is supposed to be an `int` but the compiler optimized it to `unsigned char` due to all values being able to fit. This caused the decompiled code to sometimes overwrite other variables when setting this value. All calls have been fixed.

Also, fixed the stack size of `GetLevelMTypes`, the battle.net beta and PSX list it as having `skeltypes[111]` and `typelist[200]` but they are merged together due to optimizing. Thanks to @seritools for pointing this out.

Also replaced `random` with the beta version which is cleaner and closer to the original.