### PR TITLE
Fix signature of multi_send_pinfo(...)

### DIFF
--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -63,16 +63,14 @@ void __fastcall dthread_remove_player(int pnum)
 	LeaveCriticalSection(&sgMemCrit);
 }
 
-void __fastcall dthread_send_delta(int pnum, int cmd, void *pbSrc, int dwLen)
+void __fastcall dthread_send_delta(int pnum, char cmd, void *pbSrc, int dwLen)
 {
-	char v4; // bl
 	TMegaPkt *v5; // eax
 	TMegaPkt *v6; // esi
 	TMegaPkt *v7; // eax
 	TMegaPkt **v8; // ecx
 	int v9; // [esp+4h] [ebp-4h]
 
-	v4 = cmd;
 	v9 = pnum;
 	if ( gbMaxPlayers != 1 )
 	{
@@ -80,7 +78,7 @@ void __fastcall dthread_send_delta(int pnum, int cmd, void *pbSrc, int dwLen)
 		v6 = v5;
 		v5->pNext = 0;
 		v5->dwSpaceLeft = v9;
-		v5->data[0] = v4;
+		v5->data[0] = cmd;
 		*(_DWORD *)&v5->data[4] = dwLen;
 		memcpy(&v5->data[8], pbSrc, dwLen);
 		EnterCriticalSection(&sgMemCrit);

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -14,7 +14,7 @@ void __cdecl dthread_init_mutex();
 void __cdecl dthread_cleanup_mutex_atexit();
 void __cdecl dthread_cleanup_mutex();
 void __fastcall dthread_remove_player(int pnum);
-void __fastcall dthread_send_delta(int pnum, int cmd, void *pbSrc, int dwLen);
+void __fastcall dthread_send_delta(int pnum, char cmd, void *pbSrc, int dwLen);
 void __cdecl dthread_start();
 unsigned int __stdcall dthread_handler(void *a1);
 void __cdecl dthread_cleanup();

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -791,7 +791,6 @@ int __fastcall NetInit(int bSinglePlayer, int *pfExitProgram)
 	int v2; // ebx
 	int v4; // eax
 	//int v5; // ecx
-	TCmdPlrInfoHdr *v6; // edx
 	bool v7; // zf
 	//int v9; // eax
 	//int v10; // eax
@@ -871,8 +870,7 @@ int __fastcall NetInit(int bSinglePlayer, int *pfExitProgram)
 		gbSomebodyWonGameKludge = 0;
 		nthread_send_and_recv_turn(0, 0);
 		SetupLocalCoords();
-		_LOBYTE(v6) = CMD_SEND_PLRINFO;
-		multi_send_pinfo(-2, v6);
+		multi_send_pinfo(-2, CMD_SEND_PLRINFO);
 		gbActivePlayers = 1;
 		v7 = sgbPlayerTurnBitTbl[myplr] == 0;
 		plr[myplr].plractive = 1;
@@ -913,18 +911,16 @@ void __fastcall multi_clear_pkt(char *a1)
 	a1[4] = 0;
 }
 
-void __fastcall multi_send_pinfo(int pnum, TCmdPlrInfoHdr *cmd)
+void __fastcall multi_send_pinfo(int pnum, char cmd)
 {
 	char v2; // bl
 	int v3; // esi
-	int v4; // edx
 	PkPlayerStruct pkplr; // [esp+8h] [ebp-4F4h]
 
-	v2 = (char)cmd;
+	v2 = cmd;
 	v3 = pnum;
 	PackPlayer(&pkplr, myplr, 1);
-	_LOBYTE(v4) = v2;
-	dthread_send_delta(v3, v4, &pkplr, 1266);
+	dthread_send_delta(v3, v2, &pkplr, 1266);
 }
 
 int __fastcall InitNewSeed(int newseed)
@@ -1109,8 +1105,7 @@ void __fastcall multi_player_joins(int pnum, TCmdPlrInfoHdr *cmd, int a3)
 		{
 			if ( !a3 && !*v5 )
 			{
-				_LOBYTE(cmd) = CMD_ACK_PLRINFO;
-				multi_send_pinfo(pnum, cmd);
+				multi_send_pinfo(pnum, CMD_ACK_PLRINFO);
 			}
 			memcpy((char *)&pkplr[v3] + (unsigned short)v4->wOffset, &v4[1], (unsigned short)v4->wBytes);
 			*v5 += v4->wBytes;

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -58,7 +58,7 @@ char __fastcall multi_event_handler(int a1);
 void __stdcall multi_handle_events(_SNETEVENT *pEvt);
 int __fastcall NetInit(int bSinglePlayer, int *pfExitProgram);
 void __fastcall multi_clear_pkt(char *a1);
-void __fastcall multi_send_pinfo(int pnum, TCmdPlrInfoHdr *cmd);
+void __fastcall multi_send_pinfo(int pnum, char cmd);
 int __fastcall InitNewSeed(int newseed);
 void __cdecl SetupLocalCoords();
 int __fastcall multi_init_single(_SNETPROGRAMDATA *client_info, _SNETPLAYERDATA *user_info, _SNETUIDATA *ui_info);


### PR DESCRIPTION
The second parameter was a byte, not a pointer to a struct.
(if you look at the definition of `dthread_send_delta`, you will see it is eventually assigned into an `unsigned char` array, so it can not be a pointer)

After fixing the declarations in IDA as well, it outputs code roughly equivalent to the one in this commit.