### PR TITLE
Fix dungeon generation of the Cathedral

### DIFF
--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -847,7 +847,7 @@ void __cdecl DRLG_L1Shadows()
 	do
 	{
 		v1 = &dungeon[0][v0 + 39];
-		v2 = 40;
+		v2 = 1;
 		do
 		{
 			v3 = &SPATS[0].s1;
@@ -884,10 +884,10 @@ void __cdecl DRLG_L1Shadows()
 				v3 += 7;
 			}
 			while ( (signed int)v3 < (signed int)&SPATS[37].s1 );
-			v2 += 40;
+			++v2;
 			v1 += 40;
 		}
-		while ( v2 < 1600 );
+		while ( v2 < 40 );
 		++v0;
 	}
 	while ( v0 < 40 );

--- a/Support/TODO.md
+++ b/Support/TODO.md
@@ -8,7 +8,9 @@ Serious bugs (crash/fault)
 - TBA
 
 Minor bugs (noticeable but can be avoided)
-- Generation of Cathedral/Catacombs walls and floors are slightly inaccurate
+- Generation of Catacombs walls and floors are slightly inaccurate
+- Monsters don't populate Catacombs' rooms all the time
+- Lighting of objects/items in dungeon is slightly lighter than it should be
 - Some tiles are drawn fully lit when they should be transparent `world.cpp`
 - Timed messages are broken and have been disabled `tmsg.cpp`
 - Server commands are broken and have been disabled `msgcmd.cpp`


### PR DESCRIPTION
Fixed the dungeon generation bug in the Cathedral that caused wrong palette and unreachable areas. A mere 3 numbers... caused because I didn't update the 2d-array pointers correctly after fixing them 5 months ago. :stuck_out_tongue_closed_eyes: 