### PR TITLE
Speed up build with WIN32_LEAN_AND_MEAN

### DIFF
--- a/types.h
+++ b/types.h
@@ -3,9 +3,12 @@
 #ifndef _TYPES_H
 #define _TYPES_H
 
+#define WIN32_LEAN_AND_MEAN
+
 #include "resource.h"
 
 #include <windows.h>
+#include <mmsystem.h>
 #include <stdio.h>
 #include <ddraw.h>
 #include <dsound.h>
@@ -14,6 +17,7 @@
 #include <time.h>
 #include <process.h>
 #include <shlobj.h>
+#include <shellapi.h>
 
 #ifdef __GNUC__
 #include <ctype.h>


### PR DESCRIPTION
This disables including rarely used headers.

This takes a full re-build of the main project from:
```
3>     1001 ms  Link                                       1 calls
3>     7387 ms  CL                                         1 calls
```
to:
```
3>     1035 ms  Link                                       1 calls
3>     6466 ms  CL                                         1 calls
```