### PR TITLE
Fix type of screen_buf_end

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -231,7 +231,7 @@ void __cdecl DrawAutomap()
 
 	if ( leveltype != DTYPE_TOWN )
 	{
-		screen_buf_end = (int)gpBuffer->row[352].col_unused_1;
+		gpBufEnd = (unsigned char *)&gpBuffer->row[352];
 		v0 = AutoMapXOfs;
 		v1 = (ViewX - 16) >> 1;
 		v2 = AutoMapXOfs + v1;
@@ -379,7 +379,7 @@ void __cdecl DrawAutomap()
 // 4B8968: using guessed type int sbookflag;
 // 5BB1ED: using guessed type char leveltype;
 // 69BD04: using guessed type int questlog;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall DrawAutomapType(int screen_x, int screen_y, short automap_type)
 {

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -203,7 +203,7 @@ void __cdecl lock_buf_priv()
 		if ( v1 )
 			DDErrMsg(v1, 235, "C:\\Src\\Diablo\\Source\\dx.cpp");
 		v0 = (Screen *)v2.lpSurface;
-		screen_buf_end += (int)v2.lpSurface;
+		gpBufEnd += (unsigned int)v2.lpSurface;
 LABEL_8:
 		gpBuffer = v0;
 		goto LABEL_9;
@@ -213,7 +213,7 @@ LABEL_8:
 LABEL_9:
 	++sgdwLockCount;
 }
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __cdecl unlock_buf_priv()
 {
@@ -228,7 +228,7 @@ void __cdecl unlock_buf_priv()
 	{
 		v0 = gpBuffer;
 		gpBuffer = 0;
-		screen_buf_end -= (signed int)v0;
+		gpBufEnd -= (signed int)v0;
 		if ( !sgpBackBuf )
 		{
 			v1 = lpDDSBackBuf->Unlock(NULL);
@@ -238,7 +238,7 @@ void __cdecl unlock_buf_priv()
 	}
 	LeaveCriticalSection(&sgMemCrit);
 }
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __cdecl dx_cleanup()
 {

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -654,7 +654,7 @@ void __fastcall Cel2DecDatOnly(char *pDecodeTo, char *pRLEBytes, int frame_conte
 						goto LABEL_17;
 				}
 				v6 -= v7;
-				if ( (unsigned int)v5 < screen_buf_end )
+				if ( v5 < (char *)gpBufEnd )
 				{
 					v8 = v7 >> 1;
 					if ( !(v7 & 1) || (*v5 = *v4, ++v4, ++v5, v8) )
@@ -682,7 +682,7 @@ LABEL_17:
 		while ( &v11[frame_content_size] != v4 );
 	}
 }
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall Cel2DrawHdrOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int a6, int direction)
 {
@@ -783,7 +783,7 @@ void __fastcall Cel2DecDatLightOnly(char *pDecodeTo, char *pRLEBytes, int frame_
 						goto LABEL_13;
 				}
 				v7 -= v8;
-				if ( (unsigned int)v5 < screen_buf_end )
+				if ( v5 < (char *)gpBufEnd )
 				{
 					v9 = v7;
 					Cel2DecDatLightEntry(v8, a3, v5, v4);
@@ -803,7 +803,7 @@ LABEL_13:
 	}
 }
 // 69BEF8: using guessed type int light_table_index;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall Cel2DecDatLightEntry(unsigned char shift, char *LightIndex, char *&pDecodeTo, char *&pRLEBytes)
 {
@@ -898,7 +898,7 @@ void __fastcall Cel2DecDatLightTrans(char *pDecodeTo, char *pRLEBytes, int frame
 					v26 = v6;
 					_EBX = v27;
 					v7 -= v8;
-					if ( v5 < screen_buf_end )
+					if ( v5 < (unsigned int)gpBufEnd )
 					{
 						if ( (v5 & 1) == v28 )
 						{
@@ -1009,7 +1009,7 @@ LABEL_26:
 	}
 }
 // 69BEF8: using guessed type int light_table_index;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall Cel2DecodeHdrLight(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int a6, int direction)
 {
@@ -1175,7 +1175,7 @@ void __fastcall Cel2DrawHdrLightRed(int screen_x, int screen_y, char *pCelBuff, 
 								goto LABEL_21;
 						}
 						v18 -= v20;
-						if ( (unsigned int)v16 < screen_buf_end )
+						if ( v16 < gpBufEnd )
 						{
 							do
 							{
@@ -1203,7 +1203,7 @@ LABEL_21:
 	}
 }
 // 525728: using guessed type int light4flag;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall CelDecodeRect(char *pBuff, int always_0, int dst_height, int dst_width, char *pCelBuff, int frame, int frame_width)
 {
@@ -1403,9 +1403,9 @@ void __fastcall CelDrawHdrClrHL(char colour, int screen_x, int screen_y, char *p
 								goto LABEL_28;
 						}
 						v12 -= v13;
-						if ( (unsigned int)v11 < screen_buf_end )
+						if ( v11 < (char *)gpBufEnd )
 						{
-							if ( (unsigned int)v11 >= screen_buf_end - 768 )
+							if ( v11 >= (char *)gpBufEnd - 768 )
 							{
 								v16 = v13;
 								do
@@ -1456,7 +1456,7 @@ LABEL_28:
 		}
 	}
 }
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall ENG_set_pixel(int screen_x, int screen_y, char pixel)
 {
@@ -1465,11 +1465,11 @@ void __fastcall ENG_set_pixel(int screen_x, int screen_y, char pixel)
 	if ( screen_y >= 0 && screen_y < 640 && screen_x >= 64 && screen_x < 704 )
 	{
 		v3 = (char *)gpBuffer + screen_y_times_768[screen_y] + screen_x;
-		if ( (unsigned int)v3 < screen_buf_end )
+		if ( v3 < (char *)gpBufEnd )
 			*v3 = pixel;
 	}
 }
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall engine_draw_pixel(int x, int y)
 {
@@ -1487,7 +1487,7 @@ void __fastcall engine_draw_pixel(int x, int y)
 	{
 		v2 = (unsigned char *)gpBuffer + screen_y_times_768[y] + x;
 LABEL_14:
-		if ( (unsigned int)v2 < screen_buf_end )
+		if ( v2 < gpBufEnd )
 			*v2 = gbPixelCol;
 		return;
 	}
@@ -1495,7 +1495,7 @@ LABEL_14:
 // 52B96C: using guessed type char gbPixelCol;
 // 52B970: using guessed type int dword_52B970;
 // 52B99C: using guessed type int dword_52B99C;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall DrawLine(int x0, int y0, int x1, int y1, char col)
 {
@@ -2497,7 +2497,7 @@ void __fastcall Cl2DecDatFrm4(char *buffer, char *a2, int a3, int frame_width)
 			if ( (char)v6 <= 65 )
 			{
 				v8 -= v6;
-				if ( (signed int)v5 < screen_buf_end )
+				if ( v5 < (char *)gpBufEnd )
 				{
 					v7 -= v6;
 					do
@@ -2517,7 +2517,7 @@ void __fastcall Cl2DecDatFrm4(char *buffer, char *a2, int a3, int frame_width)
 				_LOBYTE(v6) = v6 - 65;
 				--v8;
 				v9 = *v4++;
-				if ( (signed int)v5 < screen_buf_end )
+				if ( v5 < (char *)gpBufEnd )
 				{
 					v7 -= v6;
 					do
@@ -2562,7 +2562,7 @@ LABEL_12:
 	}
 	while ( v8 );
 }
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall Cl2DecodeClrHL(char colour, int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a7, int a8)
 {
@@ -2588,20 +2588,20 @@ void __fastcall Cl2DecodeClrHL(char colour, int screen_x, int screen_y, char *pC
 				{
 					if ( a8 == 8 || (v11 = *(unsigned short *)&v9[a8], !*(_WORD *)&v9[a8]) )
 						v11 = *(_DWORD *)&pCelBuff[4 * nCel + 4] - v8;
-					screen_buf_end -= 768;
+					gpBufEnd -= 768;
 					Cl2DecDatClrHL(
 						(char *)gpBuffer + screen_y_times_768[screen_y - 16 * a7] + v12,
 						&v9[v10],
 						v11 - v10,
 						frame_width,
 						a5);
-					screen_buf_end += 768;
+					gpBufEnd += 768;
 				}
 			}
 		}
 	}
 }
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall Cl2DecDatClrHL(char *dst_buf, char *frame_content, int a3, int frame_width, char colour)
 {
@@ -2631,7 +2631,7 @@ void __fastcall Cl2DecDatClrHL(char *dst_buf, char *frame_content, int a3, int f
 			if ( (char)v7 <= 65 )
 			{
 				v9 -= v7;
-				if ( (signed int)v6 < screen_buf_end )
+				if ( v6 < (char *)gpBufEnd )
 				{
 					v8 -= v7;
 					do
@@ -2657,7 +2657,7 @@ void __fastcall Cl2DecDatClrHL(char *dst_buf, char *frame_content, int a3, int f
 				_LOBYTE(v7) = v7 - 65;
 				--v9;
 				v11 = *v5++;
-				if ( v11 && (signed int)v6 < screen_buf_end )
+				if ( v11 && v6 < (char *)gpBufEnd )
 				{
 					*(v6 - 1) = v10;
 					v8 -= v7;
@@ -2706,7 +2706,7 @@ LABEL_15:
 	}
 	while ( v9 );
 }
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall Cl2DecodeFrm5(int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a6, int a7, char a8)
 {
@@ -2785,7 +2785,7 @@ void __fastcall Cl2DecDatLightTbl2(char *dst_buf, char *a2, int a3, int frame_wi
 			if ( (char)v9 <= 65 )
 			{
 				v8 -= v9;
-				if ( (signed int)v6 < screen_buf_end )
+				if ( v6 < (char *)gpBufEnd )
 				{
 					v7 -= v9;
 					do
@@ -2806,7 +2806,7 @@ void __fastcall Cl2DecDatLightTbl2(char *dst_buf, char *a2, int a3, int frame_wi
 				--v8;
 				_LOBYTE(v10) = *v5++;
 				v11 = a5[v10];
-				if ( (signed int)v6 < screen_buf_end )
+				if ( v6 < (char *)gpBufEnd )
 				{
 					v7 -= v9;
 					do
@@ -2852,7 +2852,7 @@ LABEL_12:
 	while ( v8 );
 }
 // 52B978: using guessed type int sgnWidth;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall Cl2DecodeFrm6(int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a6, int a7)
 {

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -125,7 +125,7 @@ void __fastcall drawTopArchesUpperScreen(unsigned char *pbDst)
 					i = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 							break;
 						j = 8;
 						do
@@ -138,7 +138,7 @@ void __fastcall drawTopArchesUpperScreen(unsigned char *pbDst)
 						}
 						while ( j );
 						tmp_pbDst -= 800;
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 							break;
 						j = 8;
 						do
@@ -179,7 +179,7 @@ void __fastcall drawTopArchesUpperScreen(unsigned char *pbDst)
 								if ( !yy_32 )
 									goto LABEL_67;
 							}
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								return;
 							if ( ((unsigned char)tmp_pbDst & 1) == WorldBoolFlag )
 							{
@@ -298,7 +298,7 @@ LABEL_67:
 */
 					WorldBoolFlag = 0;
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= (char *)gpBufEnd )
 					{
 						tmp_pbDst += xx_32;
 						x_minus = 32 - xx_32;
@@ -411,7 +411,7 @@ LABEL_67:
 							yy_32 = 2;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 									break;
 								tmp_pbDst += yy_32;
 								y_minus = 32 - yy_32;
@@ -533,7 +533,7 @@ LABEL_67:
 */
 					WorldBoolFlag = 0;
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= (char *)gpBufEnd )
 					{
 						x_minus = 32 - xx_32;
 						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -645,7 +645,7 @@ LABEL_67:
 							yy_32 = 2;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 									break;
 								y_minus = 32 - yy_32;
 								WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -766,7 +766,7 @@ LABEL_67:
 */
 					WorldBoolFlag = 0;
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= (char *)gpBufEnd )
 					{
 						tmp_pbDst += xx_32;
 						x_minus = 32 - xx_32;
@@ -879,7 +879,7 @@ LABEL_67:
 							i = 8;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 									break;
 								j = 8;
 								do
@@ -892,7 +892,7 @@ LABEL_67:
 								}
 								while ( j );
 								tmp_pbDst -= 800;
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 									break;
 								j = 8;
 								do
@@ -920,7 +920,7 @@ LABEL_67:
 */
 					WorldBoolFlag = 0;
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= (char *)gpBufEnd )
 					{
 						x_minus = 32 - xx_32;
 						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -1032,7 +1032,7 @@ LABEL_67:
 							i = 8;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 									break;
 								j = 8;
 								do
@@ -1045,7 +1045,7 @@ LABEL_67:
 								}
 								while ( j );
 								tmp_pbDst -= 800;
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 									break;
 								j = 8;
 								do
@@ -1084,7 +1084,7 @@ LABEL_11:
 				i = 16;
 				do
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 						break;
 					j = 8;
 					do
@@ -1097,7 +1097,7 @@ LABEL_11:
 					}
 					while ( j );
 					tmp_pbDst -= 800;
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 						break;
 					j = 8;
 					do
@@ -1145,7 +1145,7 @@ LABEL_271:
 						}
 					}
 					xx_32 -= dung_and80;
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 						return;
 					if ( ((unsigned char)tmp_pbDst & 1) == WorldBoolFlag )
 					{
@@ -1223,7 +1223,7 @@ LABEL_268:
 */
 				WorldBoolFlag = 0;
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= (char *)gpBufEnd )
 				{
 					tmp_pbDst += xx_32;
 					x_minus = 32 - xx_32;
@@ -1279,7 +1279,7 @@ LABEL_268:
 						yy_32 = 2;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
 							tmp_pbDst += yy_32;
 							y_minus = 32 - yy_32;
@@ -1344,7 +1344,7 @@ LABEL_268:
 */
 				WorldBoolFlag = 0;
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= (char *)gpBufEnd )
 				{
 					x_minus = 32 - xx_32;
 					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -1387,7 +1387,7 @@ LABEL_268:
 						yy_32 = 2;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
 							y_minus = 32 - yy_32;
 							WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -1439,7 +1439,7 @@ LABEL_268:
 */
 				WorldBoolFlag = 0;
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= (char *)gpBufEnd )
 				{
 					tmp_pbDst += xx_32;
 					x_minus = 32 - xx_32;
@@ -1495,7 +1495,7 @@ LABEL_268:
 						i = 8;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
 							j = 8;
 							do
@@ -1508,7 +1508,7 @@ LABEL_268:
 							}
 							while ( j );
 							tmp_pbDst -= 800;
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
 							j = 8;
 							do
@@ -1536,7 +1536,7 @@ LABEL_268:
 */
 				WorldBoolFlag = 0;
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= (char *)gpBufEnd )
 				{
 					x_minus = 32 - xx_32;
 					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -1579,7 +1579,7 @@ LABEL_268:
 						i = 8;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
 							j = 8;
 							do
@@ -1592,7 +1592,7 @@ LABEL_268:
 							}
 							while ( j );
 							tmp_pbDst -= 800;
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
 							j = 8;
 							do
@@ -1631,7 +1631,7 @@ LABEL_268:
 			i = 16;
 			do
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					break;
 				j = 8;
 				do
@@ -1643,7 +1643,7 @@ LABEL_268:
 				}
 				while ( j );
 				tmp_pbDst -= 800;
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					break;
 				j = 8;
 				do
@@ -1678,7 +1678,7 @@ LABEL_268:
 						if ( (dung_and80 & 0x80u) != 0 )
 							break;
 						yy_32 -= dung_and80;
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 							return;
 						pdung_cels += dung_and80;
 						if ( ((unsigned char)tmp_pbDst & 1) == WorldBoolFlag )
@@ -1763,7 +1763,7 @@ LABEL_391:
 			WorldBoolFlag = 0;
 			for ( xx_32 = 30; ; xx_32 -= 2 )
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					return;
 				tmp_pbDst += xx_32;
 				x_minus = 32 - xx_32;
@@ -1815,7 +1815,7 @@ LABEL_391:
 			yy_32 = 2;
 			do
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					break;
 				tmp_pbDst += yy_32;
 				y_minus = 32 - yy_32;
@@ -1874,7 +1874,7 @@ LABEL_391:
 			WorldBoolFlag = 0;
 			for ( xx_32 = 30; ; xx_32 -= 2 )
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					return;
 				x_minus = 32 - xx_32;
 				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -1926,7 +1926,7 @@ LABEL_391:
 			yy_32 = 2;
 			do
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					break;
 				y_minus = 32 - yy_32;
 				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -1984,7 +1984,7 @@ LABEL_391:
 			WorldBoolFlag = 0;
 			for ( xx_32 = 30; ; xx_32 -= 2 )
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					return;
 				tmp_pbDst += xx_32;
 				x_minus = 32 - xx_32;
@@ -2036,7 +2036,7 @@ LABEL_391:
 			i = 8;
 			do
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					break;
 				j = 8;
 				do
@@ -2048,7 +2048,7 @@ LABEL_391:
 				}
 				while ( j );
 				tmp_pbDst -= 800;
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					break;
 				j = 8;
 				do
@@ -2073,7 +2073,7 @@ LABEL_391:
 			WorldBoolFlag = 0;
 			for ( xx_32 = 30; ; xx_32 -= 2 )
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					return;
 				x_minus = 32 - xx_32;
 				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -2125,7 +2125,7 @@ LABEL_391:
 			i = 8;
 			do
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					break;
 				j = 8;
 				do
@@ -2137,7 +2137,7 @@ LABEL_391:
 				}
 				while ( j );
 				tmp_pbDst -= 800;
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					break;
 				j = 8;
 				do
@@ -2192,7 +2192,7 @@ LABEL_12:
 				xx_32 = 32;
 				do
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 						break;
 					left_shift = *gpDrawMask;
 					i = 32;
@@ -2239,7 +2239,7 @@ LABEL_12:
 								goto LABEL_129;
 						}
 						yy_32 -= dung_and80;
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 							return;
 						left_shift = gdwCurrentMask;
 						and80_i = dung_and80;
@@ -2270,7 +2270,7 @@ LABEL_129:
 	 \-|
 */
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= (char *)gpBufEnd )
 				{
 					tmp_pbDst += xx_32;
 					n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
@@ -2298,7 +2298,7 @@ LABEL_129:
 						yy_32 = 2;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
 							tmp_pbDst += yy_32;
 							n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
@@ -2334,7 +2334,7 @@ LABEL_129:
 	|-/
 */
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= (char *)gpBufEnd )
 				{
 					for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 					{
@@ -2355,7 +2355,7 @@ LABEL_129:
 						yy_32 = 2;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
 							for ( n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift )
 							{
@@ -2384,7 +2384,7 @@ LABEL_129:
 	|__|
 */
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= (char *)gpBufEnd )
 				{
 					tmp_pbDst += xx_32;
 					n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
@@ -2413,7 +2413,7 @@ LABEL_129:
 						yy_32 = 16;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
 							left_shift = *gpDrawMask;
 							i = 32;
@@ -2443,7 +2443,7 @@ LABEL_129:
 	|__|
 */
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= (char *)gpBufEnd )
 				{
 					for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 					{
@@ -2465,7 +2465,7 @@ LABEL_129:
 						yy_32 = 16;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
 							left_shift = *gpDrawMask;
 							i = 32;
@@ -2510,7 +2510,7 @@ LABEL_129:
 					xx_32 = 32;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 							break;
 						left_shift = *gpDrawMask;
 						i = 32;
@@ -2557,7 +2557,7 @@ LABEL_129:
 									goto LABEL_50;
 							}
 							yy_32 -= dung_and80;
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 								return;
 							and80_i = dung_and80;
 							left_shift = gdwCurrentMask;
@@ -2588,7 +2588,7 @@ LABEL_50:
 	 \-|
 */
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= (char *)gpBufEnd )
 					{
 						tmp_pbDst += xx_32;
 						n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
@@ -2620,7 +2620,7 @@ LABEL_50:
 							yy_32 = 2;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 									break;
 								tmp_pbDst += yy_32;
 								n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
@@ -2660,7 +2660,7 @@ LABEL_50:
 	|-/
 */
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= (char *)gpBufEnd )
 					{
 						for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 						{
@@ -2685,7 +2685,7 @@ LABEL_50:
 							yy_32 = 2;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 									break;
 								for ( n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift )
 								{
@@ -2718,7 +2718,7 @@ LABEL_50:
 	|__|
 */
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= (char *)gpBufEnd )
 					{
 						tmp_pbDst += xx_32;
 						n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
@@ -2751,7 +2751,7 @@ LABEL_50:
 							yy_32 = 16;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 									break;
 								left_shift = *gpDrawMask;
 								i = 32;
@@ -2782,7 +2782,7 @@ LABEL_50:
 	|__|
 */
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= (char *)gpBufEnd )
 					{
 						for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 						{
@@ -2808,7 +2808,7 @@ LABEL_50:
 							yy_32 = 16;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 									break;
 								left_shift = *gpDrawMask;
 								i = 32;
@@ -2856,7 +2856,7 @@ LABEL_50:
 			xx_32 = 32;
 			do
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 					break;
 				left_shift = *gpDrawMask;
 				i = 32;
@@ -2902,7 +2902,7 @@ LABEL_50:
 							goto LABEL_208;
 					}
 					yy_32 -= dung_and80;
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 						return;
 					left_shift = gdwCurrentMask;
 					and80_i = dung_and80;
@@ -2933,7 +2933,7 @@ LABEL_208:
 	 \-|
 */
 			xx_32 = 30;
-			while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			while ( tmp_pbDst >= (char *)gpBufEnd )
 			{
 				tmp_pbDst += xx_32;
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
@@ -2958,7 +2958,7 @@ LABEL_208:
 					yy_32 = 2;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 							break;
 						tmp_pbDst += yy_32;
 						n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
@@ -2993,7 +2993,7 @@ LABEL_208:
 	|-/
 */
 			xx_32 = 30;
-			while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			while ( tmp_pbDst >= (char *)gpBufEnd )
 			{
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 				if ( (32 - xx_32) & 2 )
@@ -3017,7 +3017,7 @@ LABEL_208:
 					yy_32 = 2;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 							break;
 						n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
 						if ( (32 - yy_32) & 2 )
@@ -3052,7 +3052,7 @@ LABEL_208:
 	|__|
 */
 			xx_32 = 30;
-			while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			while ( tmp_pbDst >= (char *)gpBufEnd )
 			{
 				tmp_pbDst += xx_32;
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
@@ -3078,7 +3078,7 @@ LABEL_208:
 					yy_32 = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 							break;
 						left_shift = *gpDrawMask;
 						i = 32;
@@ -3108,7 +3108,7 @@ LABEL_208:
 	|__|
 */
 			xx_32 = 30;
-			while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			while ( tmp_pbDst >= (char *)gpBufEnd )
 			{
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 				if ( (32 - xx_32) & 2 )
@@ -3133,7 +3133,7 @@ LABEL_208:
 					yy_32 = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 							break;
 						left_shift = *gpDrawMask;
 						i = 32;
@@ -3222,7 +3222,7 @@ LABEL_22:
 				i = 32;
 				do
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < gpBufEnd )
 						break;
 					j = 8;
 					do
@@ -3262,7 +3262,7 @@ LABEL_22:
 								goto LABEL_133;
 						}
 						yy_32 -= dung_and80;
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 							return;
 						chk_sh_and = dung_and80 >> 1;
 						if ( dung_and80 & 1 )
@@ -3303,7 +3303,7 @@ LABEL_133:
 	 \-|
 */
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= gpBufEnd )
 				{
 					tmp_pbDst += xx_32;
 					n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
@@ -3331,7 +3331,7 @@ LABEL_133:
 						yy_32 = 2;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < gpBufEnd )
 								break;
 							tmp_pbDst += yy_32;
 							n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
@@ -3367,7 +3367,7 @@ LABEL_133:
 	|-/
 */
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= gpBufEnd )
 				{
 					for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 					{
@@ -3388,7 +3388,7 @@ LABEL_133:
 						yy_32 = 2;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < gpBufEnd )
 								break;
 							for ( n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift )
 							{
@@ -3417,7 +3417,7 @@ LABEL_133:
 	|__|
 */
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= gpBufEnd )
 				{
 					tmp_pbDst += xx_32;
 					n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
@@ -3445,7 +3445,7 @@ LABEL_133:
 						i = 16;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < gpBufEnd )
 								break;
 							j = 8;
 							do
@@ -3471,7 +3471,7 @@ LABEL_133:
 	|__|
 */
 				xx_32 = 30;
-				while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+				while ( tmp_pbDst >= gpBufEnd )
 				{
 					for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 					{
@@ -3492,7 +3492,7 @@ LABEL_133:
 						i = 16;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < gpBufEnd )
 								break;
 							j = 8;
 							do
@@ -3532,7 +3532,7 @@ LABEL_133:
 					xx_32 = 32;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 							break;
 						base_4 = 32;
 						do
@@ -3575,7 +3575,7 @@ LABEL_133:
 									goto LABEL_58;
 							}
 							yy_32 -= dung_and80;
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < gpBufEnd )
 								return;
 							for ( base_4 = dung_and80; base_4 >= 4; base_4 -= 4 )
 							{
@@ -3612,7 +3612,7 @@ LABEL_58:
 	 \-|
 */
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= gpBufEnd )
 					{
 						tmp_pbDst += xx_32;
 						x_minus = 32 - xx_32;
@@ -3645,7 +3645,7 @@ LABEL_58:
 							yy_32 = 2;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < gpBufEnd )
 									break;
 								tmp_pbDst += yy_32;
 								y_minus = 32 - yy_32;
@@ -3686,7 +3686,7 @@ LABEL_58:
 	|-/
 */
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= gpBufEnd )
 					{
 						for ( base_4 = 32 - xx_32; base_4 >= 4; base_4 -= 4 )
 						{
@@ -3712,7 +3712,7 @@ LABEL_58:
 							yy_32 = 2;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < gpBufEnd )
 									break;
 								for ( base_4 = 32 - yy_32; base_4 >= 4; base_4 -= 4 )
 								{
@@ -3746,7 +3746,7 @@ LABEL_58:
 	|__|
 */
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= gpBufEnd )
 					{
 						tmp_pbDst += xx_32;
 						x_minus = 32 - xx_32;
@@ -3779,7 +3779,7 @@ LABEL_58:
 							yy_32 = 16;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < gpBufEnd )
 									break;
 								base_4 = 32;
 								do
@@ -3808,7 +3808,7 @@ LABEL_58:
 	|__|
 */
 					xx_32 = 30;
-					while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					while ( tmp_pbDst >= gpBufEnd )
 					{
 						for ( base_4 = 32 - xx_32; base_4 >= 4; base_4 -= 4 )
 						{
@@ -3834,7 +3834,7 @@ LABEL_58:
 							yy_32 = 16;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < gpBufEnd )
 									break;
 								base_4 = 32;
 								do
@@ -3880,7 +3880,7 @@ LABEL_58:
 			i = 32;
 			do
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < gpBufEnd )
 					break;
 				j = 8;
 				do
@@ -3919,7 +3919,7 @@ LABEL_58:
 							goto LABEL_205;
 					}
 					yy_32 -= dung_and80;
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < gpBufEnd )
 						return;
 					pdung_cels += dung_and80;
 					chk_sh_and = dung_and80 >> 1;
@@ -3959,7 +3959,7 @@ LABEL_205:
 	 \-|
 */
 			xx_32 = 30;
-			while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			while ( tmp_pbDst >= gpBufEnd )
 			{
 				tmp_pbDst += xx_32;
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
@@ -3984,7 +3984,7 @@ LABEL_205:
 					yy_32 = 2;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 							break;
 						tmp_pbDst += yy_32;
 						n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
@@ -4019,7 +4019,7 @@ LABEL_205:
 	|-/
 */
 			xx_32 = 30;
-			while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			while ( tmp_pbDst >= gpBufEnd )
 			{
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 				if ( (32 - xx_32) & 2 )
@@ -4043,7 +4043,7 @@ LABEL_205:
 					yy_32 = 2;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 							break;
 						n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
 						if ( (32 - yy_32) & 2 )
@@ -4078,7 +4078,7 @@ LABEL_205:
 	|__|
 */
 			xx_32 = 30;
-			while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			while ( tmp_pbDst >= gpBufEnd )
 			{
 				tmp_pbDst += xx_32;
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
@@ -4103,7 +4103,7 @@ LABEL_205:
 					i = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 							break;
 						j = 8;
 						do
@@ -4129,7 +4129,7 @@ LABEL_205:
 	|__|
 */
 			xx_32 = 30;
-			while ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			while ( tmp_pbDst >= gpBufEnd )
 			{
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 				if ( (32 - xx_32) & 2 )
@@ -4153,7 +4153,7 @@ LABEL_205:
 					i = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 							break;
 						j = 8;
 						do
@@ -4224,7 +4224,7 @@ void __fastcall drawTopArchesLowerScreen(unsigned char *pbDst)
 				i = 16;
 				do
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						j = 8;
 						do
@@ -4242,7 +4242,7 @@ void __fastcall drawTopArchesLowerScreen(unsigned char *pbDst)
 						tmp_pbDst += 32;
 					}
 					tmp_pbDst -= 800;
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						j = 8;
 						do
@@ -4295,7 +4295,7 @@ LABEL_433:
 						}
 					}
 					yy_32 -= dung_and80;
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						pdung_cels += dung_and80;
 						if ( ((unsigned char)tmp_pbDst & 1) == WorldBoolFlag )
@@ -4376,7 +4376,7 @@ LABEL_430:
 				WorldBoolFlag = 0;
 				for ( xx_32 = 30; ; xx_32 -= 2 )
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						tmp_pbDst += xx_32;
 						x_minus = 32 - xx_32;
@@ -4434,7 +4434,7 @@ LABEL_430:
 				yy_32 = 2;
 				do
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						tmp_pbDst += yy_32;
 						y_minus = 32 - yy_32;
@@ -4499,7 +4499,7 @@ LABEL_430:
 				WorldBoolFlag = 0;
 				for ( xx_32 = 30; ; xx_32 -= 2 )
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						x_minus = 32 - xx_32;
 						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -4557,7 +4557,7 @@ LABEL_430:
 				yy_32 = 2;
 				do
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						y_minus = 32 - yy_32;
 						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -4621,7 +4621,7 @@ LABEL_430:
 				WorldBoolFlag = 0;
 				for ( xx_32 = 30; ; xx_32 -= 2 )
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						tmp_pbDst += xx_32;
 						x_minus = 32 - xx_32;
@@ -4679,7 +4679,7 @@ LABEL_430:
 				i = 8;
 				do
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						j = 8;
 						do
@@ -4697,7 +4697,7 @@ LABEL_430:
 						tmp_pbDst += 32;
 					}
 					tmp_pbDst -= 800;
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						j = 8;
 						do
@@ -4728,7 +4728,7 @@ LABEL_430:
 				WorldBoolFlag = 0;
 				for ( xx_32 = 30; ; xx_32 -= 2 )
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						x_minus = 32 - xx_32;
 						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
@@ -4786,7 +4786,7 @@ LABEL_430:
 				i = 8;
 				do
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						j = 8;
 						do
@@ -4804,7 +4804,7 @@ LABEL_430:
 						tmp_pbDst += 32;
 					}
 					tmp_pbDst -= 800;
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						j = 8;
 						do
@@ -4845,7 +4845,7 @@ LABEL_430:
 				i = 16;
 				do
 				{
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						j = 8;
 						do
@@ -4864,7 +4864,7 @@ LABEL_430:
 						tmp_pbDst += 32;
 					}
 					tmp_pbDst -= 800;
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < (char *)gpBufEnd )
 					{
 						j = 8;
 						do
@@ -4912,7 +4912,7 @@ LABEL_430:
 								goto LABEL_69;
 						}
 						yy_32 -= dung_and80;
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							if ( ((unsigned char)tmp_pbDst & 1) == WorldBoolFlag )
 							{
@@ -5036,18 +5036,18 @@ LABEL_69:
 */
 				WorldBoolFlag = 0;
 				xx_32 = 30;
-				if ( (unsigned int)pbDst >= screen_buf_end )
+				if ( pbDst >= gpBufEnd )
 				{
-					tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+					tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 					if ( tile_42_45 > 45 )
 					{
 						tmp_pbDst = (char *)(pbDst - 12288);
 						pdung_cels += 288;
 LABEL_98:
 						yy_32 = 2;
-						if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+						if ( tmp_pbDst >= (char *)gpBufEnd )
 						{
-							tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+							tile_42_45 = (unsigned int)(tmp_pbDst - (char *)gpBufEnd + 1023) >> 8;
 							if ( tile_42_45 > 42 )
 								return;
 							world_tbl = WorldTbl3x16[tile_42_45];
@@ -5297,18 +5297,18 @@ LABEL_98:
 */
 				WorldBoolFlag = 0;
 				xx_32 = 30;
-				if ( (unsigned int)pbDst >= screen_buf_end )
+				if ( pbDst >= gpBufEnd )
 				{
-					tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+					tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 					if ( tile_42_45 > 45 )
 					{
 						tmp_pbDst = (char *)(pbDst - 12288);
 						pdung_cels += 288;
 LABEL_154:
 						yy_32 = 2;
-						if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+						if ( tmp_pbDst >= (char *)gpBufEnd )
 						{
-							tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+							tile_42_45 = (unsigned int)(tmp_pbDst - (char *)gpBufEnd + 1023) >> 8;
 							if ( tile_42_45 > 42 )
 								return;
 							world_tbl = WorldTbl3x16[tile_42_45];
@@ -5556,9 +5556,9 @@ LABEL_154:
 */
 				WorldBoolFlag = 0;
 				xx_32 = 30;
-				if ( (unsigned int)pbDst >= screen_buf_end )
+				if ( pbDst >= gpBufEnd )
 				{
-					tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+					tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 					if ( tile_42_45 > 45 )
 					{
 						tmp_pbDst = (char *)(pbDst - 12288);
@@ -5567,7 +5567,7 @@ LABEL_210:
 						i = 8;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 							{
 								j = 8;
 								do
@@ -5586,7 +5586,7 @@ LABEL_210:
 								tmp_pbDst += 32;
 							}
 							tmp_pbDst -= 800;
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 							{
 								j = 8;
 								do
@@ -5737,9 +5737,9 @@ LABEL_210:
 */
 				WorldBoolFlag = 0;
 				xx_32 = 30;
-				if ( (unsigned int)pbDst >= screen_buf_end )
+				if ( pbDst >= gpBufEnd )
 				{
-					tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+					tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 					if ( tile_42_45 > 45 )
 					{
 						tmp_pbDst = (char *)(pbDst - 12288);
@@ -5748,7 +5748,7 @@ LABEL_249:
 						i = 8;
 						do
 						{
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 							{
 								j = 8;
 								do
@@ -5767,7 +5767,7 @@ LABEL_249:
 								tmp_pbDst += 32;
 							}
 							tmp_pbDst -= 800;
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < (char *)gpBufEnd )
 							{
 								j = 8;
 								do
@@ -5926,7 +5926,7 @@ LABEL_11:
 			i = 16;
 			do
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 				{
 					j = 8;
 					do
@@ -5945,7 +5945,7 @@ LABEL_11:
 					tmp_pbDst += 32;
 				}
 				tmp_pbDst -= 800;
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 				{
 					j = 8;
 					do
@@ -5987,7 +5987,7 @@ LABEL_11:
 						if ( (dung_and80 & 0x80u) != 0 )
 							break;
 						yy_32 -= dung_and80;
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							if ( ((unsigned char)tmp_pbDst & 1) == WorldBoolFlag )
 							{
@@ -6081,18 +6081,18 @@ LABEL_293:
 */
 			WorldBoolFlag = 0;
 			xx_32 = 30;
-			if ( (unsigned int)pbDst >= screen_buf_end )
+			if ( pbDst >= gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 45 )
 				{
 					tmp_pbDst = (char *)(pbDst - 12288);
 					pdung_cels += 288;
 LABEL_308:
 					yy_32 = 2;
-					if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					if ( tmp_pbDst >= (char *)gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(tmp_pbDst - (char *)gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 42 )
 							return;
 						world_tbl = WorldTbl3x16[tile_42_45];
@@ -6229,9 +6229,9 @@ LABEL_308:
 */
 			WorldBoolFlag = 0;
 			xx_32 = 30;
-			if ( (unsigned int)pbDst < screen_buf_end )
+			if ( pbDst < gpBufEnd )
 				goto LABEL_326;
-			tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+			tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 			if ( tile_42_45 <= 45 )
 			{
 				world_tbl = WorldTbl3x16[tile_42_45];
@@ -6288,9 +6288,9 @@ LABEL_326:
 			pdung_cels += 288;
 LABEL_336:
 			yy_32 = 2;
-			if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			if ( tmp_pbDst >= (char *)gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(tmp_pbDst - (char *)gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 42 )
 					return;
 				world_tbl = WorldTbl3x16[tile_42_45];
@@ -6350,9 +6350,9 @@ LABEL_336:
 */
 			WorldBoolFlag = 0;
 			xx_32 = 30;
-			if ( (unsigned int)pbDst >= screen_buf_end )
+			if ( pbDst >= gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 45 )
 				{
 					tmp_pbDst = (char *)(pbDst - 12288);
@@ -6361,7 +6361,7 @@ LABEL_364:
 					i = 8;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							j = 8;
 							do
@@ -6380,7 +6380,7 @@ LABEL_364:
 							tmp_pbDst += 32;
 						}
 						tmp_pbDst -= 800;
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							j = 8;
 							do
@@ -6474,9 +6474,9 @@ LABEL_364:
 */
 			WorldBoolFlag = 0;
 			xx_32 = 30;
-			if ( (unsigned int)pbDst >= screen_buf_end )
+			if ( pbDst >= gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 45 )
 				{
 					tmp_pbDst = (char *)(pbDst - 12288);
@@ -6485,7 +6485,7 @@ LABEL_389:
 					i = 8;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							j = 8;
 							do
@@ -6504,7 +6504,7 @@ LABEL_389:
 							tmp_pbDst += 32;
 						}
 						tmp_pbDst -= 800;
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							j = 8;
 							do
@@ -6619,7 +6619,7 @@ void __fastcall drawBottomArchesLowerScreen(unsigned char *pbDst, unsigned int *
 					yy_32 = 32;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							left_shift = *gpDrawMask;
 							i = 32;
@@ -6663,7 +6663,7 @@ void __fastcall drawBottomArchesLowerScreen(unsigned char *pbDst, unsigned int *
 								if ( (dung_and80 & 0x80u) != 0 )
 									break;
 								yy_32 -= dung_and80;
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 								{
 									and80_i = dung_and80;
 									pdung_cels += dung_and80;
@@ -6709,7 +6709,7 @@ LABEL_252:
 */
 					for ( i = 30; ; i -= 2 )
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							tmp_pbDst += i;
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
@@ -6741,7 +6741,7 @@ LABEL_252:
 					i = 2;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							tmp_pbDst += i;
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
@@ -6779,7 +6779,7 @@ LABEL_252:
 */
 					for ( i = 30; ; i -= 2 )
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
 							if ( (32 - i) & 2 )
@@ -6811,7 +6811,7 @@ LABEL_252:
 					i = 2;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
 							if ( (32 - i) & 2 )
@@ -6848,7 +6848,7 @@ LABEL_252:
 */
 					for ( i = 30; ; i -= 2 )
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							tmp_pbDst += i;
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
@@ -6881,7 +6881,7 @@ LABEL_252:
 					yy_32 = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							left_shift = *gpDrawMask;
 							i = 32;
@@ -6914,7 +6914,7 @@ LABEL_252:
 */
 					for ( i = 30; ; i -= 2 )
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
 							if ( (32 - i) & 2 )
@@ -6947,7 +6947,7 @@ LABEL_252:
 					yy_32 = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							left_shift = *gpDrawMask;
 							i = 32;
@@ -6991,7 +6991,7 @@ LABEL_252:
 					yy_32 = 32;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							left_shift = *gpDrawMask;
 							i = 32;
@@ -7036,7 +7036,7 @@ LABEL_252:
 								if ( (dung_and80 & 0x80u) != 0 )
 									break;
 								yy_32 -= dung_and80;
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 								{
 									and80_i = dung_and80;
 									left_shift = gdwCurrentMask;
@@ -7081,18 +7081,18 @@ LABEL_52:
 	 \-|
 */
 					xx_32 = 30;
-					if ( (unsigned int)pbDst >= screen_buf_end )
+					if ( pbDst >= gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 45 )
 						{
 							tmp_pbDst = (char *)(pbDst - 12288);
 							pdung_cels += 288;
 LABEL_62:
 							yy_32 = 2;
-							if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+							if ( tmp_pbDst >= (char *)gpBufEnd )
 							{
-								tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+								tile_42_45 = (unsigned int)(tmp_pbDst - (char *)gpBufEnd + 1023) >> 8;
 								if ( tile_42_45 > 42 )
 									return;
 								world_tbl = WorldTbl3x16[tile_42_45];
@@ -7173,18 +7173,18 @@ LABEL_62:
 	|-/
 */
 					xx_32 = 30;
-					if ( (unsigned int)pbDst >= screen_buf_end )
+					if ( pbDst >= gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 45 )
 						{
 							tmp_pbDst = (char *)(pbDst - 12288);
 							pdung_cels += 288;
 LABEL_80:
 							yy_32 = 2;
-							if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+							if ( tmp_pbDst >= (char *)gpBufEnd )
 							{
-								tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+								tile_42_45 = (unsigned int)(tmp_pbDst - (char *)gpBufEnd + 1023) >> 8;
 								if ( tile_42_45 > 42 )
 									return;
 								world_tbl = WorldTbl3x16[tile_42_45];
@@ -7251,9 +7251,9 @@ LABEL_80:
 	|__|
 */
 					xx_32 = 30;
-					if ( (unsigned int)pbDst >= screen_buf_end )
+					if ( pbDst >= gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 45 )
 						{
 							tmp_pbDst = (char *)(pbDst - 12288);
@@ -7263,7 +7263,7 @@ LABEL_98:
 							yy_32 = 16;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 								{
 									left_shift = *gpDrawMask;
 									i = 32;
@@ -7332,9 +7332,9 @@ LABEL_98:
 	|__|
 */
 					xx_32 = 30;
-					if ( (unsigned int)pbDst >= screen_buf_end )
+					if ( pbDst >= gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 45 )
 						{
 							tmp_pbDst = (char *)(pbDst - 12288);
@@ -7344,7 +7344,7 @@ LABEL_117:
 							yy_32 = 16;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < (char *)gpBufEnd )
 								{
 									left_shift = *gpDrawMask;
 									i = 32;
@@ -7426,7 +7426,7 @@ LABEL_117:
 			yy_32 = 32;
 			do
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < (char *)gpBufEnd )
 				{
 					left_shift = *gpDrawMask;
 					i = 32;
@@ -7471,7 +7471,7 @@ LABEL_117:
 						if ( (dung_and80 & 0x80u) != 0 )
 							break;
 						yy_32 -= dung_and80;
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							and80_i = dung_and80;
 							left_shift = gdwCurrentMask;
@@ -7516,18 +7516,18 @@ LABEL_152:
 	 \-|
 */
 			xx_32 = 30;
-			if ( (unsigned int)pbDst >= screen_buf_end )
+			if ( pbDst >= gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 45 )
 				{
 					tmp_pbDst = (char *)(pbDst - 12288);
 					pdung_cels += 288;
 LABEL_162:
 					yy_32 = 2;
-					if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					if ( tmp_pbDst >= (char *)gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(tmp_pbDst - (char *)gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 42 )
 							return;
 						world_tbl = WorldTbl3x16[tile_42_45];
@@ -7600,9 +7600,9 @@ LABEL_162:
 	|-/
 */
 			xx_32 = 30;
-			if ( (unsigned int)pbDst < screen_buf_end )
+			if ( pbDst < gpBufEnd )
 				goto LABEL_175;
-			tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+			tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 			if ( tile_42_45 <= 45 )
 			{
 				world_tbl = WorldTbl3x16[tile_42_45];
@@ -7634,9 +7634,9 @@ LABEL_175:
 			pdung_cels += 288;
 LABEL_180:
 			yy_32 = 2;
-			if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			if ( tmp_pbDst >= (char *)gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(tmp_pbDst - (char *)gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 42 )
 					return;
 				world_tbl = WorldTbl3x16[tile_42_45];
@@ -7670,9 +7670,9 @@ LABEL_180:
 	|__|
 */
 			xx_32 = 30;
-			if ( (unsigned int)pbDst >= screen_buf_end )
+			if ( pbDst >= gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 45 )
 				{
 					tmp_pbDst = (char *)(pbDst - 12288);
@@ -7682,7 +7682,7 @@ LABEL_198:
 					yy_32 = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							left_shift = *gpDrawMask;
 							i = 32;
@@ -7747,9 +7747,9 @@ LABEL_198:
 	|__|
 */
 			xx_32 = 30;
-			if ( (unsigned int)pbDst >= screen_buf_end )
+			if ( pbDst >= gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 45 )
 				{
 					tmp_pbDst = (char *)(pbDst - 12288);
@@ -7759,7 +7759,7 @@ LABEL_217:
 					yy_32 = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < (char *)gpBufEnd )
 						{
 							left_shift = *gpDrawMask;
 							i = 32;
@@ -7879,7 +7879,7 @@ void __fastcall drawLowerScreen(unsigned char *pbDst)
 					i = 32;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							j = 8;
 							do
@@ -7924,7 +7924,7 @@ void __fastcall drawLowerScreen(unsigned char *pbDst)
 									goto LABEL_232;
 							}
 							yy_32 -= dung_and80;
-							if ( (unsigned int)tmp_pbDst < screen_buf_end )
+							if ( tmp_pbDst < gpBufEnd )
 							{
 								pdung_cels += dung_and80;
 								chk_sh_and = dung_and80 >> 1;
@@ -7974,7 +7974,7 @@ LABEL_232:
 */
 					for ( i = 30; ; i -= 2 )
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							tmp_pbDst += i;
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
@@ -8006,7 +8006,7 @@ LABEL_232:
 					i = 2;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							tmp_pbDst += i;
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
@@ -8044,7 +8044,7 @@ LABEL_232:
 */
 					for ( i = 30; ; i -= 2 )
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
 							if ( (32 - i) & 2 )
@@ -8076,7 +8076,7 @@ LABEL_232:
 					i = 2;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
 							if ( (32 - i) & 2 )
@@ -8113,7 +8113,7 @@ LABEL_232:
 */
 					for ( i = 30; ; i -= 2 )
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							tmp_pbDst += i;
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
@@ -8145,7 +8145,7 @@ LABEL_232:
 					i = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							j = 8;
 							do
@@ -8174,7 +8174,7 @@ LABEL_232:
 */
 					for ( i = 30; ; i -= 2 )
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							n_draw_shift = (unsigned int)(32 - i) >> 2;
 							if ( (32 - i) & 2 )
@@ -8206,7 +8206,7 @@ LABEL_232:
 					i = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							j = 8;
 							do
@@ -8246,7 +8246,7 @@ LABEL_232:
 					xx_32 = 32;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							j = 8;
 							do
@@ -8287,7 +8287,7 @@ LABEL_232:
 							if ( (dung_and80 & 0x80u) == 0 )
 							{
 								yy_32 -= dung_and80;
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < gpBufEnd )
 								{
 									for ( block_4 = dung_and80; block_4 >= 4; block_4 -= 4 )
 									{
@@ -8336,18 +8336,18 @@ LABEL_232:
 	 \-|
 */
 					xx_32 = 30;
-					if ( (unsigned int)pbDst >= screen_buf_end )
+					if ( pbDst >= gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 45 )
 						{
 							tmp_pbDst = pbDst - 12288;
 							pdung_cels += 288;
 LABEL_68:
 							yy_32 = 2;
-							if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+							if ( tmp_pbDst >= gpBufEnd )
 							{
-								tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+								tile_42_45 = (unsigned int)(tmp_pbDst - gpBufEnd + 1023) >> 8;
 								if ( tile_42_45 > 42 )
 									return;
 								world_tbl = WorldTbl3x16[tile_42_45];
@@ -8400,18 +8400,18 @@ LABEL_68:
 	|-/
 */
 					xx_32 = 30;
-					if ( (unsigned int)pbDst >= screen_buf_end )
+					if ( pbDst >= gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 45 )
 						{
 							tmp_pbDst = pbDst - 12288;
 							pdung_cels += 288;
 LABEL_83:
 							yy_32 = 2;
-							if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+							if ( tmp_pbDst >= gpBufEnd )
 							{
-								tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+								tile_42_45 = (unsigned int)(tmp_pbDst - gpBufEnd + 1023) >> 8;
 								if ( tile_42_45 > 42 )
 									return;
 								world_tbl = WorldTbl3x16[tile_42_45];
@@ -8462,9 +8462,9 @@ LABEL_83:
 	|__|
 */
 					xx_32 = 30;
-					if ( (unsigned int)pbDst >= screen_buf_end )
+					if ( pbDst >= gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 45 )
 						{
 							tmp_pbDst = pbDst - 12288;
@@ -8473,7 +8473,7 @@ LABEL_100:
 							i = 16;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < gpBufEnd )
 								{
 									block_4 = 32;
 									do
@@ -8542,9 +8542,9 @@ LABEL_100:
 	|__|
 */
 					xx_32 = 30;
-					if ( (unsigned int)pbDst >= screen_buf_end )
+					if ( pbDst >= gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 45 )
 						{
 							tmp_pbDst = pbDst - 12288;
@@ -8553,7 +8553,7 @@ LABEL_116:
 							j = 16;
 							do
 							{
-								if ( (unsigned int)tmp_pbDst < screen_buf_end )
+								if ( tmp_pbDst < gpBufEnd )
 								{
 									block_4 = 32;
 									do
@@ -8634,7 +8634,7 @@ LABEL_116:
 			i = 32;
 			do
 			{
-				if ( (unsigned int)tmp_pbDst < screen_buf_end )
+				if ( tmp_pbDst < gpBufEnd )
 				{
 					j = 8;
 					do
@@ -8680,7 +8680,7 @@ LABEL_116:
 							goto LABEL_143;
 					}
 					yy_32 -= dung_and80;
-					if ( (unsigned int)tmp_pbDst < screen_buf_end )
+					if ( tmp_pbDst < gpBufEnd )
 					{
 						chk_sh_and = dung_and80 >> 1;
 						if ( dung_and80 & 1 )
@@ -8731,18 +8731,18 @@ LABEL_143:
 	 \-|
 */
 			xx_32 = 30;
-			if ( (unsigned int)pbDst >= screen_buf_end )
+			if ( pbDst >= gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 45 )
 				{
 					tmp_pbDst = pbDst - 12288;
 					pdung_cels += 288;
 LABEL_153:
 					yy_32 = 2;
-					if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+					if ( tmp_pbDst >= gpBufEnd )
 					{
-						tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+						tile_42_45 = (unsigned int)(tmp_pbDst - gpBufEnd + 1023) >> 8;
 						if ( tile_42_45 > 42 )
 							return;
 						world_tbl = WorldTbl3x16[tile_42_45];
@@ -8815,9 +8815,9 @@ LABEL_153:
 	|-/
 */
 			xx_32 = 30;
-			if ( (unsigned int)pbDst < screen_buf_end )
+			if ( pbDst < gpBufEnd )
 				goto LABEL_166;
-			tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+			tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 			if ( tile_42_45 <= 45 )
 			{
 				world_tbl = WorldTbl3x16[tile_42_45];
@@ -8849,9 +8849,9 @@ LABEL_166:
 			pdung_cels += 288;
 LABEL_171:
 			yy_32 = 2;
-			if ( (unsigned int)tmp_pbDst >= screen_buf_end )
+			if ( tmp_pbDst >= gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&tmp_pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(tmp_pbDst - gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 42 )
 					return;
 				world_tbl = WorldTbl3x16[tile_42_45];
@@ -8886,9 +8886,9 @@ LABEL_171:
 	|__|
 */
 			xx_32 = 30;
-			if ( (unsigned int)pbDst >= screen_buf_end )
+			if ( pbDst >= gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 45 )
 				{
 					tmp_pbDst = pbDst - 12288;
@@ -8897,7 +8897,7 @@ LABEL_189:
 					i = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							j = 8;
 							do
@@ -8958,9 +8958,9 @@ LABEL_189:
 	|__|
 */
 			xx_32 = 30;
-			if ( (unsigned int)pbDst >= screen_buf_end )
+			if ( pbDst >= gpBufEnd )
 			{
-				tile_42_45 = (unsigned int)&pbDst[-screen_buf_end + 1023] >> 8;
+				tile_42_45 = (unsigned int)(pbDst - gpBufEnd + 1023) >> 8;
 				if ( tile_42_45 > 45 )
 				{
 					tmp_pbDst = pbDst - 12288;
@@ -8969,7 +8969,7 @@ LABEL_205:
 					i = 16;
 					do
 					{
-						if ( (unsigned int)tmp_pbDst < screen_buf_end )
+						if ( tmp_pbDst < gpBufEnd )
 						{
 							j = 8;
 							do

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -8,7 +8,7 @@ int scrollrt_cpp_init_value; // weak
 unsigned int sgdwCursWdtOld; // idb
 int sgdwCursX; // idb
 int sgdwCursY; // idb
-int screen_buf_end; // weak
+unsigned char *gpBufEnd; // weak
 int sgdwCursHgt;
 int level_cel_block; // weak
 int sgdwCursXOld; // idb
@@ -619,7 +619,7 @@ LABEL_15:
 			break;
 	}
 	a6 = 0;
-	screen_buf_end = (int)gpBuffer + screen_y_times_768[160];
+	gpBufEnd = (unsigned char *)gpBuffer + screen_y_times_768[160];
 	do
 	{
 		scrollrt_draw_upper(v3, ya++, v2, v4, a5, a6, 0);
@@ -631,7 +631,7 @@ LABEL_15:
 		++a6;
 	}
 	while ( a6 < 4 );
-	screen_buf_end = (int)gpBuffer + screen_y_times_768[512];
+	gpBufEnd = (unsigned char *)gpBuffer + screen_y_times_768[512];
 	if ( v11 > 0 )
 	{
 		do
@@ -666,7 +666,7 @@ LABEL_15:
 // 5C3000: using guessed type int scr_pix_width;
 // 5C3004: using guessed type int scr_pix_height;
 // 69BD04: using guessed type int questlog;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 // 69CF20: using guessed type char arch_draw_type;
 
 void __fastcall scrollrt_draw_lower(int x, int y, int sx, int sy, int a5, int some_flag)
@@ -2732,7 +2732,7 @@ LABEL_9:
 			break;
 	}
 	a6 = 0;
-	screen_buf_end = (int)gpBuffer + screen_y_times_768[143];
+	gpBufEnd = (unsigned char *)gpBuffer + screen_y_times_768[143];
 	do
 	{
 		scrollrt_draw_upper(v3, ya++, v2, v4, a5, a6, 0);
@@ -2744,7 +2744,7 @@ LABEL_9:
 		++a6;
 	}
 	while ( a6 < 4 );
-	screen_buf_end = (int)gpBuffer + screen_y_times_768[320];
+	gpBufEnd = (unsigned char *)gpBuffer + screen_y_times_768[320];
 	if ( v18 > 0 )
 	{
 		do
@@ -2821,7 +2821,7 @@ LABEL_24:
 // 5C3000: using guessed type int scr_pix_width;
 // 5C3004: using guessed type int scr_pix_height;
 // 69BD04: using guessed type int questlog;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 // 69CF20: using guessed type char arch_draw_type;
 
 void __cdecl ClearScreenBuffer()
@@ -3102,7 +3102,7 @@ void __cdecl scrollrt_draw_cursor_item()
 				}
 				v9 = v2 + 1;
 				v10 = v3 + 1;
-				screen_buf_end = (int)gpBuffer + screen_y_times_768[640] - v0 - 2;
+				gpBufEnd = (unsigned char *)gpBuffer + screen_y_times_768[640] - v0 - 2;
 				if ( pcurs < 12 )
 				{
 					Cel2DrawHdrOnly(v9 + 64, v1 + v10 + 159, (char *)pCursCels, pcurs, v0, 0, 8);
@@ -3127,7 +3127,7 @@ void __cdecl scrollrt_draw_cursor_item()
 	}
 }
 // 4B8C9C: using guessed type int cursH;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall DrawMain(int dwHgt, int draw_desc, int draw_hp, int draw_mana, int draw_sbar, int draw_btn)
 {

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -8,7 +8,7 @@ extern int scrollrt_cpp_init_value; // weak
 extern unsigned int sgdwCursWdtOld; // idb
 extern int sgdwCursX; // idb
 extern int sgdwCursY; // idb
-extern int screen_buf_end; // weak
+extern unsigned char *gpBufEnd; // weak
 extern int sgdwCursHgt;
 extern int level_cel_block; // weak
 extern int sgdwCursXOld; // idb

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -2,35 +2,35 @@
 
 #include "../types.h"
 
-void __fastcall town_clear_upper_buf(int a1)
+void __fastcall town_clear_upper_buf(unsigned char *a1)
 {
-	unsigned int v1; // edi
+	unsigned char *v1; // edi
 	signed int v2; // edx
 	signed int v3; // ebx
-	char *v4; // edi
+	unsigned char *v4; // edi
 	signed int v5; // edx
 	signed int v6; // ebx
-	char *v7; // edi
+	unsigned char *v7; // edi
 
 	v1 = a1;
 	v2 = 30;
 	v3 = 1;
-	while ( v1 >= screen_buf_end )
+	while ( v1 >= gpBufEnd )
 	{
-		v4 = (char *)(v2 + v1);
+		v4 = &v1[v2];
 		memset(v4, 0, 4 * v3);
-		v1 = (unsigned int)&v4[4 * v3 - 832 + v2];
+		v1 = &v4[4 * v3 - 832 + v2];
 		if ( !v2 )
 		{
 			v5 = 2;
 			v6 = 15;
 			do
 			{
-				if ( v1 < screen_buf_end )
+				if ( v1 < gpBufEnd )
 					break;
-				v7 = (char *)(v5 + v1);
+				v7 = &v1[v5];
 				memset(v7, 0, 4 * v6);
-				v1 = (unsigned int)&v7[4 * v6-- - 832 + v5];
+				v1 = &v7[4 * v6-- - 832 + v5];
 				v5 += 2;
 			}
 			while ( v5 != 32 );
@@ -40,29 +40,29 @@ void __fastcall town_clear_upper_buf(int a1)
 		++v3;
 	}
 }
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
-void __fastcall town_clear_low_buf(int y_related)
+void __fastcall town_clear_low_buf(unsigned char *y_related)
 {
-	unsigned int v1; // edi
+	unsigned char *v1; // edi
 	signed int v2; // edx
 	signed int i; // ebx
-	int v4; // edi
-	char *v5; // edi
+	unsigned char *v4; // edi
+	unsigned char *v5; // edi
 	signed int v6; // edx
 	signed int v7; // ebx
-	int v8; // edi
-	char *v9; // edi
+	unsigned char *v8; // edi
+	unsigned char *v9; // edi
 
 	v1 = y_related;
 	v2 = 30;
 	for ( i = 1; ; ++i )
 	{
-		if ( v1 < screen_buf_end )
+		if ( v1 < gpBufEnd )
 		{
-			v5 = (char *)(v2 + v1);
+			v5 = &v1[v2];
 			memset(v5, 0, 4 * i);
-			v4 = (int)&v5[4 * i + v2];
+			v4 = &v5[4 * i + v2];
 		}
 		else
 		{
@@ -77,11 +77,11 @@ void __fastcall town_clear_low_buf(int y_related)
 	v7 = 15;
 	do
 	{
-		if ( v1 < screen_buf_end )
+		if ( v1 < gpBufEnd )
 		{
-			v9 = (char *)(v6 + v1);
+			v9 = &v1[v6];
 			memset(v9, 0, 4 * v7);
-			v8 = (int)&v9[4 * v7 + v6];
+			v8 = &v9[4 * v7 + v6];
 		}
 		else
 		{
@@ -93,7 +93,7 @@ void __fastcall town_clear_low_buf(int y_related)
 	}
 	while ( v6 != 32 );
 }
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall town_draw_clipped_e_flag(void *buffer, int x, int y, int sx, int sy)
 {
@@ -299,7 +299,7 @@ void __fastcall town_draw_lower(int x, int y, int sx, int sy, int a5, int some_f
 		}
 		else
 		{
-			town_clear_low_buf((int)gpBuffer + screen_y_times_768[sy] + sx);
+			town_clear_low_buf((unsigned char *)gpBuffer + screen_y_times_768[sy] + sx);
 			v6 = sy;
 		}
 		++xa;
@@ -344,7 +344,7 @@ void __fastcall town_draw_lower(int x, int y, int sx, int sy, int a5, int some_f
 			}
 			else
 			{
-				town_clear_low_buf((int)gpBuffer + *v11 + sx);
+				town_clear_low_buf((unsigned char *)gpBuffer + *v11 + sx);
 			}
 			++xa;
 			sx += 64;
@@ -379,7 +379,7 @@ void __fastcall town_draw_lower(int x, int y, int sx, int sy, int a5, int some_f
 		}
 		else
 		{
-			town_clear_low_buf((int)gpBuffer + screen_y_times_768[v6] + sx);
+			town_clear_low_buf((unsigned char *)gpBuffer + screen_y_times_768[v6] + sx);
 		}
 	}
 }
@@ -616,7 +616,7 @@ void __fastcall town_draw_lower_2(int x, int y, int sx, int sy, int a5, int a6, 
 				goto LABEL_16;
 			}
 		}
-		town_clear_low_buf((int)gpBuffer + screen_y_times_768[sy] + v7);
+		town_clear_low_buf((unsigned char *)gpBuffer + screen_y_times_768[sy] + v7);
 		v8 = sy;
 LABEL_16:
 		++xa;
@@ -666,7 +666,7 @@ LABEL_18:
 			}
 			else
 			{
-				town_clear_low_buf((int)gpBuffer + *v13 + v11);
+				town_clear_low_buf((unsigned char *)gpBuffer + *v13 + v11);
 			}
 			++xa;
 			v14 += 112;
@@ -705,7 +705,7 @@ LABEL_18:
 		}
 		else
 		{
-			town_clear_low_buf((int)gpBuffer + screen_y_times_768[v8] + v11);
+			town_clear_low_buf((unsigned char *)gpBuffer + screen_y_times_768[v8] + v11);
 		}
 	}
 }
@@ -885,7 +885,7 @@ void __fastcall town_draw_upper(int x, int y, int sx, int sy, int a5, int a6, in
 				goto LABEL_17;
 			}
 		}
-		town_clear_upper_buf((int)gpBuffer + screen_y_times_768[v11] + v8);
+		town_clear_upper_buf((unsigned char *)gpBuffer + screen_y_times_768[v11] + v8);
 LABEL_17:
 		++xa;
 		ya = --v7;
@@ -939,7 +939,7 @@ LABEL_19:
 					goto LABEL_36;
 				}
 			}
-			town_clear_upper_buf((int)v17 + v14 + screen_y_times_768[sy]);
+			town_clear_upper_buf((unsigned char *)v17 + v14 + screen_y_times_768[sy]);
 LABEL_36:
 			++xa;
 			v15 += 112;
@@ -986,7 +986,7 @@ LABEL_36:
 				return;
 			}
 		}
-		town_clear_upper_buf((int)gpBuffer + screen_y_times_768[v23] + v14);
+		town_clear_upper_buf((unsigned char *)gpBuffer + screen_y_times_768[v23] + v14);
 	}
 }
 // 69CF14: using guessed type int level_cel_block;
@@ -1075,7 +1075,7 @@ LABEL_15:
 			break;
 	}
 	a6 = 0;
-	screen_buf_end = (int)gpBuffer + screen_y_times_768[160];
+	gpBufEnd = (unsigned char *)gpBuffer + screen_y_times_768[160];
 	do
 	{
 		town_draw_upper(v3, ya++, v2, v4, a5, a6, 0);
@@ -1087,7 +1087,7 @@ LABEL_15:
 		++a6;
 	}
 	while ( a6 < 7 );
-	screen_buf_end = (int)gpBuffer + screen_y_times_768[512];
+	gpBufEnd = (unsigned char *)gpBuffer + screen_y_times_768[512];
 	if ( v11 > 0 )
 	{
 		do
@@ -1121,7 +1121,7 @@ LABEL_15:
 // 5C3000: using guessed type int scr_pix_width;
 // 5C3004: using guessed type int scr_pix_height;
 // 69BD04: using guessed type int questlog;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall T_DrawZoom(int x, int y)
 {
@@ -1203,7 +1203,7 @@ LABEL_9:
 			break;
 	}
 	a6 = 0;
-	screen_buf_end = (int)gpBuffer + screen_y_times_768[143];
+	gpBufEnd = (unsigned char *)gpBuffer + screen_y_times_768[143];
 	do
 	{
 		town_draw_upper(v3, ya++, v2, v4, a5, a6, 0);
@@ -1215,7 +1215,7 @@ LABEL_9:
 		++a6;
 	}
 	while ( a6 < 7 );
-	screen_buf_end = (int)gpBuffer + screen_y_times_768[320];
+	gpBufEnd = (unsigned char *)gpBuffer + screen_y_times_768[320];
 	if ( v18 > 0 )
 	{
 		do
@@ -1291,7 +1291,7 @@ LABEL_24:
 // 5C3000: using guessed type int scr_pix_width;
 // 5C3004: using guessed type int scr_pix_height;
 // 69BD04: using guessed type int questlog;
-// 69CF0C: using guessed type int screen_buf_end;
+// 69CF0C: using guessed type int gpBufEnd;
 
 void __fastcall T_DrawView(int StartX, int StartY)
 {

--- a/Source/town.h
+++ b/Source/town.h
@@ -2,8 +2,8 @@
 #ifndef __TOWN_H__
 #define __TOWN_H__
 
-void __fastcall town_clear_upper_buf(int a1);
-void __fastcall town_clear_low_buf(int y_related);
+void __fastcall town_clear_upper_buf(unsigned char *a1);
+void __fastcall town_clear_low_buf(unsigned char *y_related);
 void __fastcall town_draw_clipped_e_flag(void *buffer, int x, int y, int sx, int sy);
 void __fastcall town_draw_clipped_town(void *unused, int x, int y, int sx, int sy, int some_flag);
 void __fastcall town_draw_lower(int x, int y, int sx, int sy, int a5, int some_flag);


### PR DESCRIPTION
Also renamed to `gpBufEnd` to be consistent with the typical naming convention.