### PR TITLE
render.cpp -> undo memset/memcpy

### DIFF
--- a/Diablo.dsp
+++ b/Diablo.dsp
@@ -358,7 +358,6 @@ SOURCE=.\Source\wave.cpp
 # Begin Source File
 
 SOURCE=.\Source\render.cpp
-# ADD CPP /O2
 # End Source File
 # End Group
 # Begin Group "Resource Files"

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -2282,9 +2282,14 @@ LABEL_129:
 					}
 					if ( n_draw_shift )
 					{
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						do
+						{
+							*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+							pdung_cels += 4;
+							tmp_pbDst += 4;
+							--n_draw_shift;
+						}
+						while ( n_draw_shift );
 					}
 					tmp_pbDst -= 800;
 					xx_32 -= 2;
@@ -2305,9 +2310,14 @@ LABEL_129:
 							}
 							if ( n_draw_shift )
 							{
-								qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-								pdung_cels += 4 * n_draw_shift;
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+									pdung_cels += 4;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 							tmp_pbDst -= 800;
 							yy_32 += 2;
@@ -2326,12 +2336,11 @@ LABEL_129:
 				xx_32 = 30;
 				while ( tmp_pbDst >= (char *)gpBufEnd )
 				{
-					n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
-					if ( n_draw_shift )
+					for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 					{
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
 					}
 					if ( (32 - (_BYTE)xx_32) & 2 )
 					{
@@ -2348,12 +2357,11 @@ LABEL_129:
 						{
 							if ( tmp_pbDst < (char *)gpBufEnd )
 								break;
-							n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
-							if ( n_draw_shift )
+							for ( n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift )
 							{
-								qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-								pdung_cels += 4 * n_draw_shift;
-								tmp_pbDst += 4 * n_draw_shift;
+								*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+								pdung_cels += 4;
+								tmp_pbDst += 4;
 							}
 							if ( (32 - (_BYTE)yy_32) & 2 )
 							{
@@ -2388,9 +2396,14 @@ LABEL_129:
 					}
 					if ( n_draw_shift )
 					{
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						do
+						{
+							*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+							pdung_cels += 4;
+							tmp_pbDst += 4;
+							--n_draw_shift;
+						}
+						while ( n_draw_shift );
 					}
 					tmp_pbDst -= 800;
 					xx_32 -= 2;
@@ -2432,12 +2445,11 @@ LABEL_129:
 				xx_32 = 30;
 				while ( tmp_pbDst >= (char *)gpBufEnd )
 				{
-					n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
-					if ( n_draw_shift )
+					for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 					{
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
 					}
 					if ( (32 - (_BYTE)xx_32) & 2 )
 					{
@@ -2932,8 +2944,13 @@ LABEL_208:
 				}
 				if ( n_draw_shift )
 				{
-					memset(tmp_pbDst, 0, 4 * n_draw_shift);
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = 0;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				if ( !xx_32 )
@@ -2952,8 +2969,13 @@ LABEL_208:
 						}
 						if ( n_draw_shift )
 						{
-							memset(tmp_pbDst, 0, 4 * n_draw_shift);
-							tmp_pbDst += 4 * n_draw_shift;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = 0;
+								tmp_pbDst += 4;
+								--n_draw_shift;
+							}
+							while ( n_draw_shift );
 						}
 						tmp_pbDst -= 800;
 						yy_32 += 2;
@@ -2981,8 +3003,13 @@ LABEL_208:
 				}
 				if ( n_draw_shift )
 				{
-					memset(tmp_pbDst, 0, 4 * n_draw_shift);
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = 0;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				if ( !xx_32 )
@@ -3000,8 +3027,13 @@ LABEL_208:
 						}
 						if ( n_draw_shift )
 						{
-							memset(tmp_pbDst, 0, 4 * n_draw_shift);
-							tmp_pbDst += 4 * n_draw_shift;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = 0;
+								tmp_pbDst += 4;
+								--n_draw_shift;
+							}
+							while ( n_draw_shift );
 						}
 						tmp_pbDst = &tmp_pbDst[yy_32 - 800];
 						yy_32 += 2;
@@ -3031,8 +3063,13 @@ LABEL_208:
 				}
 				if ( n_draw_shift )
 				{
-					memset(tmp_pbDst, 0, 4 * n_draw_shift);
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = 0;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				if ( !xx_32 )
@@ -3081,8 +3118,13 @@ LABEL_208:
 				}
 				if ( n_draw_shift )
 				{
-					memset(tmp_pbDst, 0, 4 * n_draw_shift);
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = 0;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				if ( !xx_32 )
@@ -3133,6 +3175,7 @@ void __fastcall drawUpperScreen(unsigned char *pbDst)
 	unsigned int chk_sh_and; // ecx MAPDST
 	unsigned int n_draw_shift; // ecx MAPDST
 	signed int i; // edx MAPDST
+	signed int j; // ecx MAPDST
 
 	if ( cel_transparency_active )
 	{
@@ -3181,9 +3224,16 @@ LABEL_22:
 				{
 					if ( tmp_pbDst < gpBufEnd )
 						break;
-					qmemcpy(tmp_pbDst, pdung_cels, 32);
-					pdung_cels += 32;
-					tmp_pbDst -= 768;
+					j = 8;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
+						--j;
+					}
+					while ( j );
+					tmp_pbDst -= 800;
 					--i;
 				}
 				while ( i );
@@ -3230,9 +3280,14 @@ LABEL_22:
 							if ( !n_draw_shift )
 								continue;
 						}
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						do
+						{
+							*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+							pdung_cels += 4;
+							tmp_pbDst += 4;
+							--n_draw_shift;
+						}
+						while ( n_draw_shift );
 					}
 					while ( yy_32 );
 LABEL_133:
@@ -3260,9 +3315,14 @@ LABEL_133:
 					}
 					if ( n_draw_shift )
 					{
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						do
+						{
+							*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+							pdung_cels += 4;
+							tmp_pbDst += 4;
+							--n_draw_shift;
+						}
+						while ( n_draw_shift );
 					}
 					tmp_pbDst -= 800;
 					xx_32 -= 2;
@@ -3283,9 +3343,14 @@ LABEL_133:
 							}
 							if ( n_draw_shift )
 							{
-								qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-								pdung_cels += 4 * n_draw_shift;
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+									pdung_cels += 4;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 							tmp_pbDst -= 800;
 							yy_32 += 2;
@@ -3304,12 +3369,11 @@ LABEL_133:
 				xx_32 = 30;
 				while ( tmp_pbDst >= gpBufEnd )
 				{
-					n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
-					if ( n_draw_shift )
+					for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 					{
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
 					}
 					if ( (32 - (_BYTE)xx_32) & 2 )
 					{
@@ -3326,12 +3390,11 @@ LABEL_133:
 						{
 							if ( tmp_pbDst < gpBufEnd )
 								break;
-							n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
-							if ( n_draw_shift )
+							for ( n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift )
 							{
-								qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-								pdung_cels += 4 * n_draw_shift;
-								tmp_pbDst += 4 * n_draw_shift;
+								*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+								pdung_cels += 4;
+								tmp_pbDst += 4;
 							}
 							if ( (32 - (_BYTE)yy_32) & 2 )
 							{
@@ -3366,9 +3429,14 @@ LABEL_133:
 					}
 					if ( n_draw_shift )
 					{
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						do
+						{
+							*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+							pdung_cels += 4;
+							tmp_pbDst += 4;
+							--n_draw_shift;
+						}
+						while ( n_draw_shift );
 					}
 					tmp_pbDst -= 800;
 					xx_32 -= 2;
@@ -3379,9 +3447,16 @@ LABEL_133:
 						{
 							if ( tmp_pbDst < gpBufEnd )
 								break;
-							qmemcpy(tmp_pbDst, pdung_cels, 32);
-							pdung_cels += 32;
-							tmp_pbDst -= 768;
+							j = 8;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+								pdung_cels += 4;
+								tmp_pbDst += 4;
+								--j;
+							}
+							while ( j );
+							tmp_pbDst -= 800;
 							--i;
 						}
 						while ( i );
@@ -3398,12 +3473,11 @@ LABEL_133:
 				xx_32 = 30;
 				while ( tmp_pbDst >= gpBufEnd )
 				{
-					n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
-					if ( n_draw_shift )
+					for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 					{
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
 					}
 					if ( (32 - (_BYTE)xx_32) & 2 )
 					{
@@ -3420,9 +3494,16 @@ LABEL_133:
 						{
 							if ( tmp_pbDst < gpBufEnd )
 								break;
-							qmemcpy(tmp_pbDst, pdung_cels, 32);
-							pdung_cels += 32;
-							tmp_pbDst -= 768;
+							j = 8;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+								pdung_cels += 4;
+								tmp_pbDst += 4;
+								--j;
+							}
+							while ( j );
+							tmp_pbDst -= 800;
 							--i;
 						}
 						while ( i );
@@ -3801,8 +3882,15 @@ LABEL_58:
 			{
 				if ( tmp_pbDst < gpBufEnd )
 					break;
-				memset(tmp_pbDst, 0, 32);
-				tmp_pbDst -= 768;
+				j = 8;
+				do
+				{
+					*(_DWORD *)tmp_pbDst = 0;
+					tmp_pbDst += 4;
+					--j;
+				}
+				while ( j );
+				tmp_pbDst -= 800;
 				--i;
 			}
 			while ( i );
@@ -3849,8 +3937,13 @@ LABEL_58:
 						if ( !n_draw_shift )
 							continue;
 					}
-					memset(tmp_pbDst, 0, 4 * n_draw_shift);
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = 0;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				while ( yy_32 );
 LABEL_205:
@@ -3877,8 +3970,13 @@ LABEL_205:
 				}
 				if ( n_draw_shift )
 				{
-					memset(tmp_pbDst, 0, 4 * n_draw_shift);
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = 0;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				if ( !xx_32 )
@@ -3897,8 +3995,13 @@ LABEL_205:
 						}
 						if ( n_draw_shift )
 						{
-							memset(tmp_pbDst, 0, 4 * n_draw_shift);
-							tmp_pbDst += 4 * n_draw_shift;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = 0;
+								tmp_pbDst += 4;
+								--n_draw_shift;
+							}
+							while ( n_draw_shift );
 						}
 						tmp_pbDst -= 800;
 						yy_32 += 2;
@@ -3926,8 +4029,13 @@ LABEL_205:
 				}
 				if ( n_draw_shift )
 				{
-					memset(tmp_pbDst, 0, 4 * n_draw_shift);
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = 0;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				if ( !xx_32 )
@@ -3945,8 +4053,13 @@ LABEL_205:
 						}
 						if ( n_draw_shift )
 						{
-							memset(tmp_pbDst, 0, 4 * n_draw_shift);
-							tmp_pbDst += 4 * n_draw_shift;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = 0;
+								tmp_pbDst += 4;
+								--n_draw_shift;
+							}
+							while ( n_draw_shift );
 						}
 						tmp_pbDst = &tmp_pbDst[yy_32 - 800];
 						yy_32 += 2;
@@ -3976,8 +4089,13 @@ LABEL_205:
 				}
 				if ( n_draw_shift )
 				{
-					memset(tmp_pbDst, 0, 4 * n_draw_shift);
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = 0;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				if ( !xx_32 )
@@ -3987,8 +4105,15 @@ LABEL_205:
 					{
 						if ( tmp_pbDst < gpBufEnd )
 							break;
-						memset(tmp_pbDst, 0, 32);
-						tmp_pbDst -= 768;
+						j = 8;
+						do
+						{
+							*(_DWORD *)tmp_pbDst = 0;
+							tmp_pbDst += 4;
+							--j;
+						}
+						while ( j );
+						tmp_pbDst -= 800;
 						--i;
 					}
 					while ( i );
@@ -4014,8 +4139,13 @@ LABEL_205:
 				}
 				if ( n_draw_shift )
 				{
-					memset(tmp_pbDst, 0, 4 * n_draw_shift);
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = 0;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				if ( !xx_32 )
@@ -4025,8 +4155,15 @@ LABEL_205:
 					{
 						if ( tmp_pbDst < gpBufEnd )
 							break;
-						memset(tmp_pbDst, 0, 32);
-						tmp_pbDst -= 768;
+						j = 8;
+						do
+						{
+							*(_DWORD *)tmp_pbDst = 0;
+							tmp_pbDst += 4;
+							--j;
+						}
+						while ( j );
+						tmp_pbDst -= 800;
 						--i;
 					}
 					while ( i );
@@ -6583,8 +6720,13 @@ LABEL_252:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -6610,8 +6752,13 @@ LABEL_252:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -6642,8 +6789,13 @@ LABEL_252:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -6669,8 +6821,13 @@ LABEL_252:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -6702,8 +6859,13 @@ LABEL_252:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -6762,8 +6924,13 @@ LABEL_252:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -7380,9 +7547,14 @@ LABEL_162:
 						}
 						if ( n_draw_shift )
 						{
-							qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-							pdung_cels += 4 * n_draw_shift;
-							tmp_pbDst += 4 * n_draw_shift;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+								pdung_cels += 4;
+								tmp_pbDst += 4;
+								--n_draw_shift;
+							}
+							while ( n_draw_shift );
 						}
 						tmp_pbDst -= 800;
 						yy_32 += 2;
@@ -7407,9 +7579,14 @@ LABEL_162:
 				}
 				if ( n_draw_shift )
 				{
-					qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-					pdung_cels += 4 * n_draw_shift;
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				xx_32 -= 2;
@@ -7435,12 +7612,11 @@ LABEL_162:
 				do
 				{
 LABEL_175:
-					n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
-					if ( n_draw_shift )
+					for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 					{
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
 					}
 					if ( (32 - (_BYTE)xx_32) & 2 )
 					{
@@ -7470,12 +7646,11 @@ LABEL_180:
 			}
 			do
 			{
-				n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
-				if ( n_draw_shift )
+				for ( n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift )
 				{
-					qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-					pdung_cels += 4 * n_draw_shift;
-					tmp_pbDst += 4 * n_draw_shift;
+					*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+					pdung_cels += 4;
+					tmp_pbDst += 4;
 				}
 				if ( (32 - (_BYTE)yy_32) & 2 )
 				{
@@ -7551,9 +7726,14 @@ LABEL_198:
 				}
 				if ( n_draw_shift )
 				{
-					qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-					pdung_cels += 4 * n_draw_shift;
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				xx_32 -= 2;
@@ -7614,12 +7794,11 @@ LABEL_217:
 			}
 			do
 			{
-				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
-				if ( n_draw_shift )
+				for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 				{
-					qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-					pdung_cels += 4 * n_draw_shift;
-					tmp_pbDst += 4 * n_draw_shift;
+					*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+					pdung_cels += 4;
+					tmp_pbDst += 4;
 				}
 				if ( (32 - (_BYTE)xx_32) & 2 )
 				{
@@ -7701,10 +7880,22 @@ void __fastcall drawLowerScreen(unsigned char *pbDst)
 					do
 					{
 						if ( tmp_pbDst < gpBufEnd )
-							memset(tmp_pbDst, 0, 32);
+						{
+							j = 8;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = 0;
+								tmp_pbDst += 4;
+								--j;
+							}
+							while ( j );
+						}
 						else
+						{
 							pdung_cels += 32;
-						tmp_pbDst -= 768;
+							tmp_pbDst += 32;
+						}
+						tmp_pbDst -= 800;
 						--i;
 					}
 					while ( i );
@@ -7752,8 +7943,13 @@ void __fastcall drawLowerScreen(unsigned char *pbDst)
 									}
 									if ( n_draw_shift )
 									{
-										memset(tmp_pbDst, 0, 4 * n_draw_shift);
-										tmp_pbDst += 4 * n_draw_shift;
+										do
+										{
+											*(_DWORD *)tmp_pbDst = 0;
+											tmp_pbDst += 4;
+											--n_draw_shift;
+										}
+										while ( n_draw_shift );
 									}
 								}
 							}
@@ -7789,8 +7985,13 @@ LABEL_232:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -7816,8 +8017,13 @@ LABEL_232:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -7848,8 +8054,13 @@ LABEL_232:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -7875,8 +8086,13 @@ LABEL_232:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -7908,8 +8124,13 @@ LABEL_232:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -7925,10 +8146,22 @@ LABEL_232:
 					do
 					{
 						if ( tmp_pbDst < gpBufEnd )
-							memset(tmp_pbDst, 0, 32);
+						{
+							j = 8;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = 0;
+								tmp_pbDst += 4;
+								--j;
+							}
+							while ( j );
+						}
 						else
+						{
 							pdung_cels += 32;
-						tmp_pbDst -= 768;
+							tmp_pbDst += 32;
+						}
+						tmp_pbDst -= 800;
 						--i;
 					}
 					while ( i );
@@ -7951,8 +8184,13 @@ LABEL_232:
 							}
 							if ( n_draw_shift )
 							{
-								memset(tmp_pbDst, 0, 4 * n_draw_shift);
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = 0;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 						else
@@ -7969,10 +8207,22 @@ LABEL_232:
 					do
 					{
 						if ( tmp_pbDst < gpBufEnd )
-							memset(tmp_pbDst, 0, 32);
+						{
+							j = 8;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = 0;
+								tmp_pbDst += 4;
+								--j;
+							}
+							while ( j );
+						}
 						else
+						{
 							pdung_cels += 32;
-						tmp_pbDst -= 768;
+							tmp_pbDst += 32;
+						}
+						tmp_pbDst -= 800;
 						--i;
 					}
 					while ( i );
@@ -8385,9 +8635,23 @@ LABEL_116:
 			do
 			{
 				if ( tmp_pbDst < gpBufEnd )
-					qmemcpy(tmp_pbDst, pdung_cels, 32);
-				pdung_cels += 32;
-				tmp_pbDst -= 768;
+				{
+					j = 8;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
+						--j;
+					}
+					while ( j );
+				}
+				else
+				{
+					pdung_cels += 32;
+					tmp_pbDst += 32;
+				}
+				tmp_pbDst -= 800;
 				--i;
 			}
 			while ( i );
@@ -8436,9 +8700,14 @@ LABEL_116:
 							}
 							if ( n_draw_shift )
 							{
-								qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-								pdung_cels += 4 * n_draw_shift;
-								tmp_pbDst += 4 * n_draw_shift;
+								do
+								{
+									*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+									pdung_cels += 4;
+									tmp_pbDst += 4;
+									--n_draw_shift;
+								}
+								while ( n_draw_shift );
 							}
 						}
 					}
@@ -8493,9 +8762,14 @@ LABEL_153:
 						}
 						if ( n_draw_shift )
 						{
-							qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-							pdung_cels += 4 * n_draw_shift;
-							tmp_pbDst += 4 * n_draw_shift;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+								pdung_cels += 4;
+								tmp_pbDst += 4;
+								--n_draw_shift;
+							}
+							while ( n_draw_shift );
 						}
 						yy_32 += 2;
 						tmp_pbDst -= 800;
@@ -8520,9 +8794,14 @@ LABEL_153:
 				}
 				if ( n_draw_shift )
 				{
-					qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-					pdung_cels += 4 * n_draw_shift;
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				xx_32 -= 2;
@@ -8548,12 +8827,11 @@ LABEL_153:
 				do
 				{
 LABEL_166:
-					n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
-					if ( n_draw_shift )
+					for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 					{
-						qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-						pdung_cels += 4 * n_draw_shift;
-						tmp_pbDst += 4 * n_draw_shift;
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
 					}
 					if ( (32 - (_BYTE)xx_32) & 2 )
 					{
@@ -8583,12 +8861,11 @@ LABEL_171:
 			}
 			do
 			{
-				n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
-				if ( n_draw_shift )
+				for ( n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift )
 				{
-					qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-					pdung_cels += 4 * n_draw_shift;
-					tmp_pbDst += 4 * n_draw_shift;
+					*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+					pdung_cels += 4;
+					tmp_pbDst += 4;
 				}
 				if ( (32 - (_BYTE)yy_32) & 2 )
 				{
@@ -8621,9 +8898,23 @@ LABEL_189:
 					do
 					{
 						if ( tmp_pbDst < gpBufEnd )
-							qmemcpy(tmp_pbDst, pdung_cels, 32);
-						pdung_cels += 32;
-						tmp_pbDst -= 768;
+						{
+							j = 8;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+								pdung_cels += 4;
+								tmp_pbDst += 4;
+								--j;
+							}
+							while ( j );
+						}
+						else
+						{
+							pdung_cels += 32;
+							tmp_pbDst += 32;
+						}
+						tmp_pbDst -= 800;
 						--i;
 					}
 					while ( i );
@@ -8646,9 +8937,14 @@ LABEL_189:
 				}
 				if ( n_draw_shift )
 				{
-					qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-					pdung_cels += 4 * n_draw_shift;
-					tmp_pbDst += 4 * n_draw_shift;
+					do
+					{
+						*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+						pdung_cels += 4;
+						tmp_pbDst += 4;
+						--n_draw_shift;
+					}
+					while ( n_draw_shift );
 				}
 				tmp_pbDst -= 800;
 				xx_32 -= 2;
@@ -8674,9 +8970,23 @@ LABEL_205:
 					do
 					{
 						if ( tmp_pbDst < gpBufEnd )
-							qmemcpy(tmp_pbDst, pdung_cels, 32);
-						pdung_cels += 32;
-						tmp_pbDst -= 768;
+						{
+							j = 8;
+							do
+							{
+								*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+								pdung_cels += 4;
+								tmp_pbDst += 4;
+								--j;
+							}
+							while ( j );
+						}
+						else
+						{
+							pdung_cels += 32;
+							tmp_pbDst += 32;
+						}
+						tmp_pbDst -= 800;
 						--i;
 					}
 					while ( i );
@@ -8689,12 +8999,11 @@ LABEL_205:
 			}
 			do
 			{
-				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
-				if ( n_draw_shift )
+				for ( n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift )
 				{
-					qmemcpy(tmp_pbDst, pdung_cels, 4 * n_draw_shift);
-					pdung_cels += 4 * n_draw_shift;
-					tmp_pbDst += 4 * n_draw_shift;
+					*(_DWORD *)tmp_pbDst = *(_DWORD *)pdung_cels;
+					pdung_cels += 4;
+					tmp_pbDst += 4;
 				}
 				if ( (32 - (_BYTE)xx_32) & 2 )
 				{
@@ -8715,6 +9024,7 @@ void __fastcall world_draw_black_tile(unsigned char *pbDst)
 	unsigned char *tmp_pbDst; // edi MAPDST
 	signed int xx_32; // edx
 	signed int i; // ebx MAPDST
+	signed int j; // ecx MAPDST
 	signed int yy_32; // edx
 
 	tmp_pbDst = pbDst;
@@ -8722,8 +9032,15 @@ void __fastcall world_draw_black_tile(unsigned char *pbDst)
 	for ( i = 1; ; ++i )
 	{
 		tmp_pbDst += xx_32;
-		memset(tmp_pbDst, 0, 4 * i);
-		tmp_pbDst = &tmp_pbDst[4 * i - 832 + xx_32];
+		j = i;
+		do
+		{
+			*(_DWORD *)tmp_pbDst = 0;
+			tmp_pbDst += 4;
+			--j;
+		}
+		while ( j );
+		tmp_pbDst = &tmp_pbDst[xx_32 - 832];
 		if ( !xx_32 )
 			break;
 		xx_32 -= 2;
@@ -8733,8 +9050,15 @@ void __fastcall world_draw_black_tile(unsigned char *pbDst)
 	do
 	{
 		tmp_pbDst += yy_32;
-		memset(tmp_pbDst, 0, 4 * i);
-		tmp_pbDst = &tmp_pbDst[4 * i - 832 + yy_32];
+		j = i;
+		do
+		{
+			*(_DWORD *)tmp_pbDst = 0;
+			tmp_pbDst += 4;
+			--j;
+		}
+		while ( j );
+		tmp_pbDst = &tmp_pbDst[yy_32 - 832];
 		--i;
 		yy_32 += 2;
 	}


### PR DESCRIPTION
It turns out I wasn't right about `render.cpp` using these functions, but rather that was the way the decompiler interpreted the code. It appears in the Demo this file may have actually been written in C, but they later changed it to ASM for speed optimization.

There should still be inlined calls for each CEL type though.