### PR TITLE
Names from DX SDK

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -677,7 +677,7 @@ LRESULT __stdcall DisableInputWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			{
 				return 0;
 			}
-			return init_palette(hWnd, uMsg, wParam, lParam);
+			return MainWndProc(hWnd, uMsg, wParam, lParam);
 		}
 		if ( !sgbMouseDown )
 		{
@@ -703,7 +703,7 @@ LABEL_21:
 					sgbMouseDown = 0;
 				return 0;
 			}
-			return init_palette(hWnd, uMsg, wParam, lParam);
+			return MainWndProc(hWnd, uMsg, wParam, lParam);
 		}
 		v5 = sgbMouseDown == 2;
 LABEL_23:
@@ -781,7 +781,7 @@ LRESULT __stdcall GM_Game(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 					gbGameLoopStartup = 1;
 					return 0;
 				}
-				return init_palette(hWnd, uMsg, wParam, lParam);
+				return MainWndProc(hWnd, uMsg, wParam, lParam);
 			}
 			MouseX = (unsigned short)lParam;
 			MouseY = (unsigned int)lParam >> 16;
@@ -816,7 +816,7 @@ LRESULT __stdcall GM_Game(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		case WM_SYSKEYDOWN:
 			if ( PressSysKey(wParam) )
 				return 0;
-			return init_palette(hWnd, uMsg, wParam, lParam);
+			return MainWndProc(hWnd, uMsg, wParam, lParam);
 		case WM_SYSCOMMAND:
 			if ( wParam == SC_CLOSE )
 			{
@@ -824,10 +824,10 @@ LRESULT __stdcall GM_Game(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 				gbRunGameResult = 0;
 				return 0;
 			}
-			return init_palette(hWnd, uMsg, wParam, lParam);
+			return MainWndProc(hWnd, uMsg, wParam, lParam);
 	}
 	if ( uMsg != WM_MOUSEFIRST )
-		return init_palette(hWnd, uMsg, wParam, lParam);
+		return MainWndProc(hWnd, uMsg, wParam, lParam);
 	MouseX = (unsigned short)lParam;
 	MouseY = (unsigned int)lParam >> 16;
 	gmenu_on_mouse_move((unsigned short)lParam);

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -4,7 +4,7 @@
 
 _SNETVERSIONDATA fileinfo;
 int init_cpp_init_value; // weak
-int window_activated; // weak
+int gbActive; // weak
 char diablo_exe_path[260];
 void *unused_mpq;
 char patch_rt_mpq_path[260];
@@ -180,14 +180,14 @@ void __fastcall init_create_window(int nCmdShow)
 	memset(&wcex, 0, sizeof(wcex));
 	wcex.cbSize = sizeof(wcex);
 	wcex.style = CS_HREDRAW|CS_VREDRAW;
-	wcex.lpfnWndProc = init_redraw_window;
+	wcex.lpfnWndProc = WindowProc;
 	wcex.hInstance = ghInst;
-	wcex.hIcon = LoadIconA(ghInst, (LPCSTR)0x65);
-	wcex.hCursor = LoadCursorA(0, (LPCSTR)0x7F00);
+	wcex.hIcon = LoadIconA(ghInst, MAKEINTRESOURCE(IDI_ICON1));
+	wcex.hCursor = LoadCursorA(0, IDC_ARROW);
 	wcex.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
 	wcex.lpszMenuName = "DIABLO";
 	wcex.lpszClassName = "DIABLO";
-	wcex.hIconSm = (HICON)LoadImageA(ghInst, (LPCSTR)0x65, IMAGE_ICON, 16, 16, LR_DEFAULTCOLOR);
+	wcex.hIconSm = (HICON)LoadImageA(ghInst, MAKEINTRESOURCE(IDI_ICON1), IMAGE_ICON, 16, 16, LR_DEFAULTCOLOR);
 	if ( !RegisterClassExA(&wcex) )
 		TermMsg("Unable to register window class");
 	if ( GetSystemMetrics(SM_CXSCREEN) >= 640 )
@@ -435,7 +435,7 @@ void __cdecl init_get_file_info()
 	}
 }
 
-LRESULT __stdcall init_palette(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+LRESULT __stdcall MainWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
 	if ( Msg > WM_ERASEBKGND )
 	{
@@ -479,22 +479,22 @@ LRESULT __stdcall init_palette(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 }
 // 52571C: using guessed type int drawpanflag;
 
-void __fastcall init_activate_window(HWND hWnd, bool activated)
+void __fastcall init_activate_window(HWND hWnd, bool bActive)
 {
 	LONG dwNewLong; // eax
 
-	window_activated = activated;
-	UiAppActivate(activated);
+	gbActive = bActive;
+	UiAppActivate(bActive);
 	dwNewLong = GetWindowLongA(hWnd, GWL_STYLE);
 
-	if ( window_activated && fullscreen )
+	if ( gbActive && fullscreen )
 		dwNewLong &= ~WS_SYSMENU;
 	else
 		dwNewLong |= WS_SYSMENU;
 
 	SetWindowLongA(hWnd, GWL_STYLE, dwNewLong);
 
-	if ( window_activated )
+	if ( gbActive )
 	{
 		drawpanflag = 255;
 		ResetPal();
@@ -502,24 +502,24 @@ void __fastcall init_activate_window(HWND hWnd, bool activated)
 }
 // 484364: using guessed type int fullscreen;
 // 52571C: using guessed type int drawpanflag;
-// 634980: using guessed type int window_activated;
+// 634980: using guessed type int gbActive;
 
-LRESULT __stdcall init_redraw_window(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+LRESULT __stdcall WindowProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
 	LRESULT result; // eax
 
 	if ( CurrentProc )
 		result = CurrentProc(hWnd, Msg, wParam, lParam);
 	else
-		result = init_palette(hWnd, Msg, wParam, lParam);
+		result = MainWndProc(hWnd, Msg, wParam, lParam);
 	return result;
 }
 
-WNDPROC __stdcall SetWindowProc(WNDPROC func)
+WNDPROC __stdcall SetWindowProc(WNDPROC NewProc)
 {
-	WNDPROC result; // eax
+	WNDPROC OldProc; // eax
 
-	result = CurrentProc;
-	CurrentProc = func;
-	return result;
+	OldProc = CurrentProc;
+	CurrentProc = NewProc;
+	return OldProc;
 }

--- a/Source/init.h
+++ b/Source/init.h
@@ -4,7 +4,7 @@
 
 extern _SNETVERSIONDATA fileinfo;
 extern int init_cpp_init_value; // weak
-extern int window_activated; // weak
+extern int gbActive; // weak
 extern char diablo_exe_path[260];
 extern void *unused_mpq;
 extern char patch_rt_mpq_path[260];
@@ -29,10 +29,10 @@ void *__fastcall init_test_access(char *mpq_path, char *mpq_name, char *reg_loc,
 char *__fastcall init_strip_trailing_slash(char *path);
 int __fastcall init_read_test_file(char *mpq_path, char *mpq_name, int flags, void **archive);
 void __cdecl init_get_file_info();
-LRESULT __stdcall init_palette(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
-void __fastcall init_activate_window(HWND hWnd, bool activated);
-LRESULT __stdcall init_redraw_window(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
-WNDPROC __stdcall SetWindowProc(WNDPROC func);
+LRESULT __stdcall MainWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+void __fastcall init_activate_window(HWND hWnd, bool bActive);
+LRESULT __stdcall WindowProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+WNDPROC __stdcall SetWindowProc(WNDPROC NewProc);
 
 /* data */
 extern int init_inf; // weak

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -136,7 +136,7 @@ void __fastcall mainmenu_action(int option)
 					goto LABEL_16;
 				case MAINMENU_ATTRACT_MODE:
 LABEL_10:
-					if ( window_activated )
+					if ( gbActive )
 						mainmenu_play_intro();
 					break;
 			}
@@ -149,7 +149,7 @@ LABEL_15:
 LABEL_16:
 	music_stop();
 }
-// 634980: using guessed type int window_activated;
+// 634980: using guessed type int gbActive;
 
 int __cdecl mainmenu_single_player()
 {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -8400,7 +8400,7 @@ void __fastcall MissToMonst(int i, int x, int y)
 
 	v3 = i;
 	v30 = x;
-	if ( (unsigned int)i >= 0x7D )
+	if ( (unsigned int)i >= MAXMISSILES )
 		TermMsg("MissToMonst: Invalid missile %d", i);
 	v4 = &missile[v3];
 	v5 = v4->_misource;

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -29,7 +29,7 @@ void __fastcall play_movie(char *pszMovie, bool user_can_close)
 
 	v6 = user_can_close;
 	v2 = pszMovie;
-	if ( window_activated )
+	if ( gbActive )
 	{
 		saveProc = SetWindowProc(MovieWndProc);
 		InvalidateRect(ghMainWnd, 0, 0);
@@ -43,7 +43,7 @@ void __fastcall play_movie(char *pszMovie, bool user_can_close)
 		{
 			do
 			{
-				if ( !window_activated || v6 && !movie_playing )
+				if ( !gbActive || v6 && !movie_playing )
 					break;
 				while ( PeekMessageA(&Msg, NULL, 0, 0, PM_REMOVE) )
 				{
@@ -65,7 +65,7 @@ void __fastcall play_movie(char *pszMovie, bool user_can_close)
 		sound_disable_music(0);
 	}
 }
-// 634980: using guessed type int window_activated;
+// 634980: using guessed type int gbActive;
 // 659AF8: using guessed type int movie_playing;
 // 659AFC: using guessed type int loop_movie;
 
@@ -75,16 +75,16 @@ LRESULT __stdcall MovieWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 	{
 LABEL_6:
 		movie_playing = 0;
-		return init_palette(hWnd, Msg, wParam, lParam);
+		return MainWndProc(hWnd, Msg, wParam, lParam);
 	}
 	if ( Msg != WM_SYSCOMMAND )
 	{
 		if ( Msg != WM_LBUTTONDOWN && Msg != WM_RBUTTONDOWN )
-			return init_palette(hWnd, Msg, wParam, lParam);
+			return MainWndProc(hWnd, Msg, wParam, lParam);
 		goto LABEL_6;
 	}
 	if ( wParam != SC_CLOSE )
-		return init_palette(hWnd, Msg, wParam, lParam);
+		return MainWndProc(hWnd, Msg, wParam, lParam);
 	movie_playing = 0;
 	return 0;
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2270,7 +2270,7 @@ void __fastcall RespawnDeadItem(ItemStruct *itm, int x, int y)
 	//unsigned int v6; // ecx
 
 	v3 = itm;
-	if ( numitems < 127 )
+	if ( numitems < MAXITEMS )
 	{
 		if ( FindGetItem(itm->IDidx, itm->_iCreateInfo, itm->_iSeed) >= 0 )
 		{
@@ -2283,7 +2283,7 @@ void __fastcall RespawnDeadItem(ItemStruct *itm, int x, int y)
 		//v6 = 4 * numitems;
 		itemactive[numitems] = v4;
 		v4 *= 368;
-		itemavail[0] = itemavail[-numitems + 126]; /* double check */
+		itemavail[0] = itemavail[-numitems + 126]; /* double check, MAXITEMS */
 		qmemcpy((char *)item + v4, v3, sizeof(ItemStruct));
 		*(int *)((char *)&item[0]._ix + v4) = x;
 		*(int *)((char *)&item[0]._iy + v4) = y;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -3138,7 +3138,7 @@ void __fastcall DrawMain(int dwHgt, int draw_desc, int draw_hp, int draw_mana, i
 	signed int a4; // [esp+1Ch] [ebp-8h]
 
 	a4 = dwHgt;
-	if ( window_activated && lpDDSPrimary )
+	if ( gbActive && lpDDSPrimary )
 	{
 		if ( lpDDSPrimary->IsLost() == DDERR_SURFACELOST )
 		{
@@ -3226,7 +3226,7 @@ LABEL_17:
 #endif
 	}
 }
-// 634980: using guessed type int window_activated;
+// 634980: using guessed type int gbActive;
 // 679660: using guessed type char gbMaxPlayers;
 
 #ifdef _DEBUG
@@ -3237,7 +3237,7 @@ void __cdecl DrawFPS()
 	char String[12]; // [esp+8h] [ebp-10h]
 	HDC hdc; // [esp+14h] [ebp-4h]
 
-	if ( frameflag && window_activated )
+	if ( frameflag && gbActive )
 	{
 		++frameend;
 		v0 = GetTickCount();


### PR DESCRIPTION
Diablo was ported to directx later in development (July/August 1996). Funny enough they based things off the DX sdk examples. In particular, `DDEX5.CPP` is basically 95% the same as `diablo.cpp` in the PR demo. Even some of the names are the same based on assert strings. From this some names are changed to match the SDK examples, so should be closer to the original.

Also corrected the variables names in `SetWindowProc`, which exists on the PSX as `GRL_SetWindowProc(WNDPROC NewProc)`