### PR TITLE
Fix invalid "unusable" spells

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -2721,8 +2721,8 @@ int __fastcall GetSBookTrans(int ii, unsigned char townok)
 
 void __cdecl DrawSpellBook()
 {
-	int v0; // edi
-	int v1; // ebp
+	__int64 v0; // edi
+	__int64 v1; // ebp
 	int v2; // esi
 	char v3; // al
 	int v4; // eax
@@ -2739,13 +2739,12 @@ void __cdecl DrawSpellBook()
 	CelDecodeOnly(76 * sbooktab + 391, 508, pSBkBtnCel, sbooktab + 1, 76);
 	v9 = 1;
 	v8 = 214;
-	v0 = plr[myplr]._pISpells[0] | plr[myplr]._pMemSpells[0] | plr[myplr]._pAblSpells[0];
-	v1 = plr[myplr]._pISpells[1] | plr[myplr]._pMemSpells[1] | plr[myplr]._pAblSpells[1];
+	v0 = plr[myplr]._pISpells64 | plr[myplr]._pMemSpells64 | plr[myplr]._pAblSpells64;
 	do
 	{
 		v2 = SpellPages[0][v9 + 7 * sbooktab - 1]; // *(&attribute_inc_rects[3].h + v9 + 7 * sbooktab); /* check */
-		if ( v2 != -1
-		  && v1 & ((unsigned __int64)((__int64)1 << ((unsigned char)v2 - 1)) >> 32) | v0 & (unsigned int)((__int64)1 << ((unsigned char)v2 - 1)) )
+		v1 = (__int64)1 << (v2 - 1);
+		if ( v2 != -1 && (v1 & v0) )
 		{
 			v7 = GetSBookTrans(v2, 1u);
 			SetSpellTrans(v7);

--- a/Support/TODO.md
+++ b/Support/TODO.md
@@ -8,7 +8,6 @@ Serious bugs (crash/fault)
 - TBA
 
 Minor bugs (noticeable but can be avoided)
-- Players sometimes have level 0 unusable skills
 - Server commands are broken and have been disabled `msgcmd.cpp`
 
 Code issues (incorrect code that still works)

--- a/structs.h
+++ b/structs.h
@@ -204,10 +204,18 @@ struct PlayerStruct
 	int _pSBkSpell;
 	char _pSBkSplType;
 	char _pSplLvl[64];
-	int remove_1; /* fix: remove and align 8 */
-	int _pMemSpells[2];
-	int _pAblSpells[2];
-	int _pScrlSpells[2];
+	union {
+		__int64 _pMemSpells64;
+		int _pMemSpells[2];
+	};
+	union {
+		__int64 _pAblSpells64;
+		int _pAblSpells[2];
+	};
+	union {
+		__int64 _pScrlSpells64;
+		int _pScrlSpells[2];
+	};
 	int _pSpellFlags;
 	int _pSplHotKey[4];
 	char _pSplTHotKey[4];
@@ -299,8 +307,10 @@ struct PlayerStruct
 	int _pIBonusToHit;
 	int _pIBonusAC;
 	int _pIBonusDamMod;
-	int remove_2; /* fix: remove and align 8 */
-	int _pISpells[2];
+	union {
+		__int64 _pISpells64;
+		int _pISpells[2];
+	};
 	int _pIFlags;
 	int _pIGetHit;
 	char _pISplLvlAdd;
@@ -1445,7 +1455,7 @@ struct PkPlayerStruct
 	int pManaBase;
 	int pMaxManaBase;
 	char pSplLvl[37];
-	int pMemSpells;
+	int pMemSpells; /* __int64 */
 	int pMemSpells2;
 	PkItemStruct InvBody[7];
 	PkItemStruct InvList[40];


### PR DESCRIPTION
This implements a temporary union for 64-bit access to spells. Eventually everything will get fixed/cleaned and the old members will be removed. This also aligns the struct (64 bit aligns 0x0/0x8) so those uneeded fillers were removed.