### PR TITLE
Fix itemhold and add pfile def

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -8,8 +8,7 @@ int itemavail[MAXITEMS];
 ItemStruct curruitem;
 ItemGetRecordStruct itemrecord[MAXITEMS];
 ItemStruct item[MAXITEMS+1];
-char itemhold[3][3];
-char byte_641234[28]; /* check if part of above */
+int itemhold[3][3]; // BOOL
 unsigned char *Item2Frm[35];
 int UniqueItemFlag[128];
 int numitems;
@@ -1628,11 +1627,11 @@ bool __fastcall GetItemSpace(int x, int y, char inum)
 {
 	int v3; // eax
 	int v4; // edx
-	char (*v5)[3]; // edi
+	int (*v5)[3]; // edi
 	int v6; // ebx
-	char (*v7)[3]; // esi
+	int (*v7)[3]; // esi
 	signed int v9; // esi
-	char (*v10)[3]; // eax
+	int (*v10)[3]; // eax
 	int v11; // ecx
 	int v12; // eax
 	int v14; // ecx
@@ -1642,7 +1641,7 @@ bool __fastcall GetItemSpace(int x, int y, char inum)
 	int v18; // ecx
 	int v19; // [esp+8h] [ebp-Ch]
 	int v20; // [esp+Ch] [ebp-8h]
-	char (*v21)[3]; // [esp+10h] [ebp-4h]
+	int (*v21)[3]; // [esp+10h] [ebp-4h]
 
 	v3 = y;
 	v19 = y;
@@ -1660,15 +1659,15 @@ bool __fastcall GetItemSpace(int x, int y, char inum)
 				v7 = v21;
 				do
 				{
-					*(_DWORD *)v7 = ItemSpaceOk(v6, v4);
-					v7 += 4;
+					(*v7)[0] = ItemSpaceOk(v6, v4);
+					++v7;
 					++v6;
 				}
 				while ( v6 <= v20 + 1 );
 				v3 = v19;
 				x = v20;
 			}
-			v21 = (char (*)[3])((char *)v21 + 4);
+			v21 = (int (*)[3])((char *)v21 + 4);
 			++v4;
 		}
 		while ( v4 <= v3 + 1 );
@@ -1680,15 +1679,15 @@ bool __fastcall GetItemSpace(int x, int y, char inum)
 		v11 = 3;
 		do
 		{
-			if ( *(_DWORD *)v10 )
+			if ( (*v10)[0] )
 				v9 = 1;
-			v10 += 4;
+			++v10;
 			--v11;
 		}
 		while ( v11 );
-		v5 = (char (*)[3])((char *)v5 + 4);
+		v5 = (int (*)[3])((char *)v5 + 4);
 	}
-	while ( (signed int)v5 < (signed int)&itemhold[3][0] );
+	while ( (signed int)v5 < (signed int)itemhold[1] );
 	v12 = random(13, 15) + 1;
 	if ( !v9 )
 		return 0;
@@ -1698,7 +1697,7 @@ bool __fastcall GetItemSpace(int x, int y, char inum)
 	{
 		while ( 1 )
 		{
-			if ( *(_DWORD *)&itemhold[0][4 * (v15 + 2 * v14 + v14)] )
+			if ( itemhold[0][v15 + 2 * v14 + v14] )
 				--v12;
 			if ( v12 <= 0 )
 				break;

--- a/Source/items.h
+++ b/Source/items.h
@@ -8,8 +8,7 @@ extern int itemavail[MAXITEMS];
 extern ItemStruct curruitem;
 extern ItemGetRecordStruct itemrecord[MAXITEMS];
 extern ItemStruct item[MAXITEMS+1];
-extern char itemhold[3][3];
-extern char byte_641234[28]; /* check if part of above */
+extern int itemhold[3][3]; // BOOL
 extern unsigned char *Item2Frm[35];
 extern int UniqueItemFlag[128];
 extern int numitems;

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -3,7 +3,7 @@
 #include "../types.h"
 
 int pfile_cpp_init_value;
-char hero_names[320];
+char hero_names[MAX_CHARACTERS][PLR_NAME_LEN];
 bool gbValidSaveFile; // idb
 int save_prev_tc; // weak
 
@@ -91,19 +91,16 @@ int __fastcall pfile_get_save_num_from_name(char *name)
 {
 	char *v1; // ebx
 	unsigned int v2; // esi
-	char *v3; // edi
 
 	v1 = name;
 	v2 = 0;
-	v3 = hero_names;
 	do
 	{
-		if ( !_strcmpi(v3, v1) )
+		if ( !_strcmpi(hero_names[v2], v1) )
 			break;
 		++v2;
-		v3 += 32;
 	}
-	while ( v2 < 0xA );
+	while ( v2 < MAX_CHARACTERS );
 	return v2;
 }
 
@@ -225,7 +222,7 @@ int __fastcall pfile_create_save_file(char *name_1, char *name_2)
 
 	v2 = name_2;
 	v3 = name_1;
-	if ( pfile_get_save_num_from_name(name_2) != 10 )
+	if ( pfile_get_save_num_from_name(name_2) != MAX_CHARACTERS )
 		return 0;
 	v4 = 0;
 	v7 = plr[0]._pName;
@@ -237,9 +234,9 @@ int __fastcall pfile_create_save_file(char *name_1, char *name_2)
 			return 0;
 	}
 	v5 = pfile_get_save_num_from_name(v3);
-	if ( v5 == 10 )
+	if ( v5 == MAX_CHARACTERS )
 		return 0;
-	SStrCopy(&hero_names[32 * v5], v2, 32);
+	SStrCopy(hero_names[v5], v2, 32);
 	SStrCopy(plr[v4]._pName, v2, 32);
 	if ( !_strcmpi(chr_name_str, v3) )
 		SStrCopy(chr_name_str, v2, 16);
@@ -298,7 +295,6 @@ bool __stdcall pfile_ui_set_hero_infos(void (__stdcall *ui_add_hero_info)(_uiher
 	int v3; // eax
 	DWORD v4; // eax
 	unsigned int v5; // esi
-	char *v6; // ebx
 	void *v7; // eax
 	void *v8; // edi
 	//int v9; // eax
@@ -319,7 +315,7 @@ bool __stdcall pfile_ui_set_hero_infos(void (__stdcall *ui_add_hero_info)(_uiher
 		save_num = 0;
 		do
 		{
-			if ( (unsigned int)save_num >= 0xA )
+			if ( (unsigned int)save_num >= MAX_CHARACTERS )
 				break;
 			GetSaveDirectory(FileName, 260, (int)lpSrcStr);
 			v1 = strrchr(FileName, '\\') + 1;
@@ -333,7 +329,7 @@ bool __stdcall pfile_ui_set_hero_infos(void (__stdcall *ui_add_hero_info)(_uiher
 						pfile_get_save_path(NewFileName, 260, v3);
 						if ( OpenFile(NewFileName, &ReOpenBuff, 0x4000u) == -1 )
 							break;
-						if ( (unsigned int)save_num >= 0xA )
+						if ( (unsigned int)save_num >= MAX_CHARACTERS )
 							goto LABEL_13;
 					}
 					if ( CopyFileA(FileName, NewFileName, 1) )
@@ -351,11 +347,10 @@ bool __stdcall pfile_ui_set_hero_infos(void (__stdcall *ui_add_hero_info)(_uiher
 LABEL_13:
 			++lpSrcStr;
 		}
-		while ( (unsigned int)lpSrcStr < 0xA );
+		while ( (unsigned int)lpSrcStr < MAX_CHARACTERS );
 	}
 	unused = 1;
 	v5 = 0;
-	v6 = hero_names;
 	do
 	{
 		v7 = pfile_open_save_archive(&unused, v5);
@@ -364,7 +359,7 @@ LABEL_13:
 		{
 			if ( pfile_read_hero(v7, &pkplr) )
 			{
-				strcpy(v6, pkplr.pName);
+				strcpy(hero_names[v5], pkplr.pName);
 				UnPackPlayer(&pkplr, 0, 0);
 				v10 = pfile_archive_contains_game(v8);
 				game_2_ui_player(plr, &hero_info, v10);
@@ -373,9 +368,8 @@ LABEL_13:
 			pfile_SFileCloseArchive(v8);
 		}
 		++v5;
-		v6 += 32;
 	}
-	while ( v5 < 0xA );
+	while ( v5 < MAX_CHARACTERS );
 	return 1;
 }
 // 679660: using guessed type char gbMaxPlayers;
@@ -539,33 +533,30 @@ int __fastcall pfile_get_player_class(int player_class_nr)
 bool __stdcall pfile_ui_save_create(_uiheroinfo *heroinfo)
 {
 	unsigned int v1; // edi
-	char *v2; // eax
 	//int v3; // eax
 	char v5; // al
 	PkPlayerStruct pkplr; // [esp+8h] [ebp-4F4h]
 
 	v1 = pfile_get_save_num_from_name(heroinfo->name);
-	if ( v1 == 10 )
+	if ( v1 == MAX_CHARACTERS )
 	{
 		v1 = 0;
-		v2 = hero_names;
 		do
 		{
-			if ( !*v2 )
+			if ( !*hero_names[v1] )
 				break;
 			++v1;
-			v2 += 32;
 		}
-		while ( v1 < 0xA );
-		if ( v1 == 10 )
+		while ( v1 < MAX_CHARACTERS );
+		if ( v1 == MAX_CHARACTERS )
 			return 0;
 	}
 	//_LOBYTE(v3) = pfile_open_archive(0, v1);
 	if ( !pfile_open_archive(0, v1) )
 		return 0;
 	mpqapi_remove_hash_entries(pfile_get_file_name);
-	strncpy(&hero_names[32 * v1], heroinfo->name, 0x20u);
-	hero_names[32 * v1 + 31] = 0;
+	strncpy(hero_names[v1], heroinfo->name, 0x20u);
+	hero_names[v1][31] = 0;
 	v5 = pfile_get_player_class((unsigned char)heroinfo->heroclass);
 	CreatePlayer(0, v5);
 	strncpy(plr[0]._pName, heroinfo->name, 0x20u);
@@ -624,9 +615,9 @@ bool __stdcall pfile_delete_save(_uiheroinfo *hero_info)
 	char FileName[260]; // [esp+0h] [ebp-104h]
 
 	v1 = pfile_get_save_num_from_name(hero_info->name);
-	if ( v1 < 0xA )
+	if ( v1 < MAX_CHARACTERS )
 	{
-		hero_names[32 * v1] = 0;
+		hero_names[v1][0] = 0;
 		pfile_get_save_path(FileName, 260, v1);
 		DeleteFileA(FileName);
 	}

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -3,7 +3,7 @@
 #define __PFILE_H__
 
 extern int pfile_cpp_init_value;
-extern char hero_names[320];
+extern char hero_names[MAX_CHARACTERS][PLR_NAME_LEN];
 extern bool gbValidSaveFile; // idb
 extern int save_prev_tc; // weak
 

--- a/defs.h
+++ b/defs.h
@@ -36,6 +36,8 @@
 // from diablo 2 beta
 #define MAXEXP					2000000000
 
+#define PLR_NAME_LEN			32
+
 // Diablo uses a 256 color palette
 // Entry 0-127 (0x00-0x7F) are level specific
 // Entry 128-255 (0x80-0xFF) are global


### PR DESCRIPTION
`itemhold` was undoubtedly a `BOOL` on the PC version, as it's listed as `unsigned char` on the PSX. This could've caused issues if the compiler discarded it, as @squidcc pointed out.

Also added another def from the debug release and plugged it into pfile.cpp.