### PR TITLE
Add 'const' to data to match original binary

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -57,7 +57,7 @@ int panbtndown; // weak
 void *pTalkPanel; // idb
 int spselflag; // weak
 
-unsigned char fontframe[127] =
+const unsigned char fontframe[127] =
 {
 	0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
 	0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
@@ -73,7 +73,7 @@ unsigned char fontframe[127] =
    14,  15,  16,  17,  18,  19,  20,  21,  22,  23,
    24,  25,  26,  40,  66,  41,  67
 };
-unsigned char fontkern[68] =
+const unsigned char fontkern[68] =
 {
 	8,  10,   7,   9,   8,   7,   6,   8,   8,   3,
 	3,   8,   6,  11,   9,  10,   6,   9,   9,   6,
@@ -83,7 +83,7 @@ unsigned char fontkern[68] =
 	3,   2,   7,   6,   3,  10,  10,   6,   6,   7,
 	4,   4,   9,   6,   6,  12,   3,   7
 };
-int lineoffset[25] =
+const int lineoffset[25] =
 {
   456433,
   24576,
@@ -111,7 +111,7 @@ int lineoffset[25] =
   465649,
   474097
 };
-unsigned char fontidx[256] =
+const unsigned char fontidx[256] =
 {
 	0,   1,   1,   1,   1,   1,   1,   1,   1,   1,
 	1,   1,   1,   1,   1,   1,   1,   1,   1,   1,
@@ -141,7 +141,7 @@ unsigned char fontidx[256] =
   117, 117, 117, 121,  98, 121
 };
 
-/* rdata */
+/* data */
 
 unsigned char SpellITbl[37] =
 {

--- a/Source/control.h
+++ b/Source/control.h
@@ -123,13 +123,13 @@ int __fastcall control_presskeys(int a1);
 void __cdecl control_press_enter();
 void __fastcall control_up_down(char a1);
 
-/* data */
-extern unsigned char fontframe[127];
-extern unsigned char fontkern[68];
-extern int lineoffset[25];
-extern unsigned char fontidx[256];
-
 /* rdata */
+extern const unsigned char fontframe[127];
+extern const unsigned char fontkern[68];
+extern const int lineoffset[25];
+extern const unsigned char fontidx[256];
+
+/* data */
 
 extern unsigned char SpellITbl[37];
 extern int PanBtnPos[8][5];

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -20,8 +20,8 @@ int dword_4B8CCC; // weak
 int pcurs; // idb
 
 
-/* data */
-int InvItemWidth[180] =
+/* rdata */
+const int InvItemWidth[180] =
 {
   0,
   33,
@@ -204,7 +204,7 @@ int InvItemWidth[180] =
   56,
   56
 };
-int InvItemHeight[180] =
+const int InvItemHeight[180] =
 {
   0,
   29,

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -29,8 +29,8 @@ void __cdecl CheckTown();
 void __cdecl CheckRportal();
 void __cdecl CheckCursMove();
 
-/* data */
-extern int InvItemWidth[180];
-extern int InvItemHeight[180];
+/* rdata */
+extern const int InvItemWidth[180];
+extern const int InvItemHeight[180];
 
 #endif /* __CURSOR_H__ */

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -13,7 +13,7 @@ int VR2;
 int VR3;
 void *pSetPiece; // idb
 
-ShadowStruct SPATS[37] =
+const ShadowStruct SPATS[37] =
 {
   { 7, 13, 0, 13, 144, 0, 142 },
   { 16, 13, 0, 13, 144, 0, 142 },
@@ -53,7 +53,7 @@ ShadowStruct SPATS[37] =
   { 12, 13, 11, 0, 140, 147, 0 },
   { 3, 13, 11, 12, 150, 0, 0 }
 };
-unsigned char BSTYPES[206] =
+const unsigned char BSTYPES[206] =
 {
 	0,   1,   2,   3,   4,   5,   6,   7,   8,   9,
    10,  11,  12,  13,  14,  15,  16,  17,   0,   0,
@@ -77,7 +77,7 @@ unsigned char BSTYPES[206] =
    28,   1,   2,  25,  26,  22,  22,  25,  26,   0,
 	0,   0,   0,   0,   0,   0
 };
-unsigned char L5BTYPES[206] =
+const unsigned char L5BTYPES[206] =
 {
 	0,   1,   2,   3,   4,   5,   6,   7,   8,   9,
    10,  11,  12,  13,  14,  15,  16,  17,   0,   0,
@@ -101,13 +101,13 @@ unsigned char L5BTYPES[206] =
 	0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
 	0,   0,   0,   0,   0,   0
 };
-unsigned char STAIRSUP[] = { 4, 4, 13, 13, 13, 13, 2, 2, 2, 2, 13, 13, 13, 13, 13, 13, 13, 13, 0, 66, 6, 0, 63, 64, 65, 0, 0, 67, 68, 0, 0, 0, 0, 0 };
-unsigned char L5STAIRSUP[] = { 4, 4, 22, 22, 22, 22, 2, 2, 2, 2, 13, 13, 13, 13, 13, 13, 13, 13, 0, 66, 23, 0, 63, 64, 65, 0, 0, 67, 68, 0, 0, 0, 0, 0 };
-unsigned char STAIRSDOWN[] = { 4, 3, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 62, 57, 58, 0, 61, 59, 60, 0, 0, 0, 0, 0 };
-unsigned char LAMPS[] = { 2, 2, 13, 0, 13, 13, 129, 0, 130, 128 };
-unsigned char PWATERIN[] = { 6, 6, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 0, 0, 0, 0, 0, 0, 0, 202, 200, 200, 84, 0, 0, 199, 203, 203, 83, 0, 0, 85, 206, 80, 81, 0, 0, 0, 134, 135, 0, 0, 0, 0, 0, 0, 0, 0 };
+const unsigned char STAIRSUP[] = { 4, 4, 13, 13, 13, 13, 2, 2, 2, 2, 13, 13, 13, 13, 13, 13, 13, 13, 0, 66, 6, 0, 63, 64, 65, 0, 0, 67, 68, 0, 0, 0, 0, 0 };
+const unsigned char L5STAIRSUP[] = { 4, 4, 22, 22, 22, 22, 2, 2, 2, 2, 13, 13, 13, 13, 13, 13, 13, 13, 0, 66, 23, 0, 63, 64, 65, 0, 0, 67, 68, 0, 0, 0, 0, 0 };
+const unsigned char STAIRSDOWN[] = { 4, 3, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 62, 57, 58, 0, 61, 59, 60, 0, 0, 0, 0, 0 };
+const unsigned char LAMPS[] = { 2, 2, 13, 0, 13, 13, 129, 0, 130, 128 };
+const unsigned char PWATERIN[] = { 6, 6, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 0, 0, 0, 0, 0, 0, 0, 202, 200, 200, 84, 0, 0, 199, 203, 203, 83, 0, 0, 85, 206, 80, 81, 0, 0, 0, 134, 135, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-/* rdata */
+/* data */
 unsigned char L5ConvTbl[16] = { 22u, 13u, 1u, 13u, 2u, 13u, 13u, 13u, 4u, 13u, 1u, 13u, 2u, 13u, 16u, 13u };
 
 void __cdecl DRLG_Init_Globals()
@@ -615,11 +615,11 @@ void __fastcall DRLG_L5(int entry)
 		{
 			if ( v13 )
 			{
-				if ( DRLG_PlaceMiniSet(PWATERIN, 1, 1, 0, 0, 0, -1, 0) < 0 )
+				if ( DRLG_PlaceMiniSet((unsigned char *)PWATERIN, 1, 1, 0, 0, 0, -1, 0) < 0 )
 					v2 = 0;
 				--ViewY;
 			}
-			else if ( DRLG_PlaceMiniSet(PWATERIN, 1, 1, 0, 0, 1, -1, 0) < 0 )
+			else if ( DRLG_PlaceMiniSet((unsigned char *)PWATERIN, 1, 1, 0, 0, 1, -1, 0) < 0 )
 			{
 				v2 = 0;
 			}
@@ -628,10 +628,10 @@ void __fastcall DRLG_L5(int entry)
 		{
 			if ( !v13 )
 			{
-				v5 = DRLG_PlaceMiniSet(STAIRSUP, 1, 1, 0, 0, 1, -1, 0);
+				v5 = DRLG_PlaceMiniSet((unsigned char *)STAIRSUP, 1, 1, 0, 0, 1, -1, 0);
 				goto LABEL_21;
 			}
-			if ( DRLG_PlaceMiniSet(STAIRSUP, 1, 1, 0, 0, 0, -1, 0) < 0 )
+			if ( DRLG_PlaceMiniSet((unsigned char *)STAIRSUP, 1, 1, 0, 0, 0, -1, 0) < 0 )
 				v2 = 0;
 			if ( v13 == 1 )
 			{
@@ -645,16 +645,16 @@ LABEL_33:
 		}
 		if ( v13 )
 		{
-			if ( DRLG_PlaceMiniSet(L5STAIRSUP, 1, 1, 0, 0, 0, -1, 0) < 0
-			  || DRLG_PlaceMiniSet(STAIRSDOWN, 1, 1, 0, 0, 1, -1, 1) < 0 )
+			if ( DRLG_PlaceMiniSet((unsigned char *)L5STAIRSUP, 1, 1, 0, 0, 0, -1, 0) < 0
+			  || DRLG_PlaceMiniSet((unsigned char *)STAIRSDOWN, 1, 1, 0, 0, 1, -1, 1) < 0 )
 			{
 				v2 = 0;
 			}
 			goto LABEL_33;
 		}
-		if ( DRLG_PlaceMiniSet(L5STAIRSUP, 1, 1, 0, 0, 1, -1, 0) >= 0 )
+		if ( DRLG_PlaceMiniSet((unsigned char *)L5STAIRSUP, 1, 1, 0, 0, 1, -1, 0) >= 0 )
 		{
-			v5 = DRLG_PlaceMiniSet(STAIRSDOWN, 1, 1, 0, 0, 0, -1, 1);
+			v5 = DRLG_PlaceMiniSet((unsigned char *)STAIRSDOWN, 1, 1, 0, 0, 0, -1, 1);
 LABEL_21:
 			if ( v5 < 0 )
 				v2 = 0;
@@ -705,7 +705,7 @@ LABEL_34:
 	while ( v8 < 40 );
 	DRLG_L5Subs();
 	DRLG_L1Shadows();
-	DRLG_PlaceMiniSet(LAMPS, 5, 10, 0, 0, 0, -1, 4);
+	DRLG_PlaceMiniSet((unsigned char *)LAMPS, 5, 10, 0, 0, 0, -1, 4);
 	DRLG_L1Floor();
 	do
 	{
@@ -850,7 +850,7 @@ void __cdecl DRLG_L1Shadows()
 		v2 = 1;
 		do
 		{
-			v3 = &SPATS[0].s1;
+			v3 = (unsigned char *)&SPATS[0].s1;
 			sd[0][0] = BSTYPES[(unsigned char)v1[1]];
 			sd[1][0] = BSTYPES[(unsigned char)*(v1 - 39)];
 			sd[0][1] = BSTYPES[(unsigned char)*v1];

--- a/Source/drlg_l1.h
+++ b/Source/drlg_l1.h
@@ -52,17 +52,17 @@ void __cdecl DRLG_L5TransFix();
 void __cdecl DRLG_L5DirtFix();
 void __cdecl DRLG_L5CornerFix();
 
-/* data */
-extern ShadowStruct SPATS[37];
-extern unsigned char BSTYPES[206];
-extern unsigned char L5BTYPES[206];
-extern unsigned char STAIRSUP[];
-extern unsigned char L5STAIRSUP[];
-extern unsigned char STAIRSDOWN[];
-extern unsigned char LAMPS[];
-extern unsigned char PWATERIN[];
-
 /* rdata */
+extern const ShadowStruct SPATS[37];
+extern const unsigned char BSTYPES[206];
+extern const unsigned char L5BTYPES[206];
+extern const unsigned char STAIRSUP[];
+extern const unsigned char L5STAIRSUP[];
+extern const unsigned char STAIRSDOWN[];
+extern const unsigned char LAMPS[];
+extern const unsigned char PWATERIN[];
+
+/* data */
 extern unsigned char L5ConvTbl[16];
 
 #endif /* __DRLG_L1_H__ */

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -7,43 +7,43 @@ int abyssx; // weak
 int lockoutcnt; // weak
 char lockout[40][40];
 
-unsigned char L3ConvTbl[16] = { 8, 11, 3, 10, 1, 9, 12, 12, 6, 13, 4, 13, 2, 14, 5, 7 };
-unsigned char L3UP[20] = { 3, 3, 8, 8, 0, 10, 10, 0, 7, 7, 0, 51, 50, 0, 48, 49, 0, 0, 0, 0 };
-unsigned char L3DOWN[20] = { 3, 3, 8, 9, 7, 8, 9, 7, 0, 0, 0, 0, 47, 0, 0, 46, 0, 0, 0, 0 };
-unsigned char L3HOLDWARP[20] = { 3, 3, 8, 8, 0, 10, 10, 0, 7, 7, 0, 125, 125, 0, 125, 125, 0, 0, 0, 0 };
-unsigned char L3TITE1[34] = { 4, 4, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 57, 58, 0, 0, 56, 55, 0, 0, 0, 0, 0 };
-unsigned char L3TITE2[34] = { 4, 4, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 61, 62, 0, 0, 60, 59, 0, 0, 0, 0, 0 };
-unsigned char L3TITE3[34] = { 4, 4, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 65, 66, 0, 0, 64, 63, 0, 0, 0, 0, 0 };
-unsigned char L3TITE6[42] = { 5, 4, 7, 7, 7, 7, 7, 7, 7, 7, 0, 7, 7, 7, 7, 0, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 0, 77, 78, 0, 0, 0, 76, 74, 75, 0, 0, 0, 0, 0, 0 };
-unsigned char L3TITE7[42] = { 4, 5, 7, 7, 7, 7, 7, 7, 0, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 83, 0, 0, 0, 82, 80, 0, 0, 81, 79, 0, 0, 0, 0, 0 };
-unsigned char L3TITE8[20] = { 3, 3, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 52, 0, 0, 0, 0 };
-unsigned char L3TITE9[20] = { 3, 3, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 53, 0, 0, 0, 0 };
-unsigned char L3TITE10[20] = { 3, 3, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 54, 0, 0, 0, 0 };
-unsigned char L3TITE11[20] = { 3, 3, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 67, 0, 0, 0, 0 };
-unsigned char L3TITE12[6] = { 2u, 1u, 9u, 7u, 68u, 0u };
-unsigned char L3TITE13[6] = { 1u, 2u, 10u, 7u, 69u, 0u };
-unsigned char L3CREV1[6] = { 2u, 1u, 8u, 7u, 84u, 85u };
-unsigned char L3CREV2[6] = { 2u, 1u, 8u, 11u, 86u, 87u };
-unsigned char L3CREV3[6] = { 1u, 2u, 8u, 10u, 89u, 88u };
-unsigned char L3CREV4[6] = { 2u, 1u, 8u, 7u, 90u, 91u };
-unsigned char L3CREV5[6] = { 1u, 2u, 8u, 11u, 92u, 93u };
-unsigned char L3CREV6[6] = { 1u, 2u, 8u, 10u, 95u, 94u };
-unsigned char L3CREV7[6] = { 2u, 1u, 8u, 7u, 96u, 101u };
-unsigned char L3CREV8[6] = { 1u, 2u, 2u, 8u, 102u, 97u };
-unsigned char L3CREV9[6] = { 2u, 1u, 3u, 8u, 103u, 98u };
-unsigned char L3CREV10[6] = { 2u, 1u, 4u, 8u, 104u, 99u };
-unsigned char L3CREV11[6] = { 1u, 2u, 6u, 8u, 105u, 100u };
-unsigned char L3ISLE1[14] = { 2u, 3u, 5u, 14u, 4u, 9u, 13u, 12u, 7u, 7u, 7u, 7u, 7u, 7u };
-unsigned char L3ISLE2[14] = { 3u, 2u, 5u, 2u, 14u, 13u, 10u, 12u, 7u, 7u, 7u, 7u, 7u, 7u };
-unsigned char L3ISLE3[14] = { 2u, 3u, 5u, 14u, 4u, 9u, 13u, 12u, 29u, 30u, 25u, 28u, 31u, 32u };
-unsigned char L3ISLE4[14] = { 3u, 2u, 5u, 2u, 14u, 13u, 10u, 12u, 29u, 26u, 30u, 31u, 27u, 32u };
-unsigned char L3ISLE5[10] = { 2u, 2u, 5u, 14u, 13u, 12u, 7u, 7u, 7u, 7u };
-unsigned char L3XTRA1[4] = { 1u, 1u, 7u, 106u };
-unsigned char L3XTRA2[4] = { 1u, 1u, 7u, 107u };
-unsigned char L3XTRA3[4] = { 1u, 1u, 7u, 108u };
-unsigned char L3XTRA4[4] = { 1u, 1u, 9u, 109u };
-unsigned char L3XTRA5[4] = { 1u, 1u, 10u, 110u };
-unsigned char L3ANVIL[244] =
+const unsigned char L3ConvTbl[16] = { 8, 11, 3, 10, 1, 9, 12, 12, 6, 13, 4, 13, 2, 14, 5, 7 };
+const unsigned char L3UP[20] = { 3, 3, 8, 8, 0, 10, 10, 0, 7, 7, 0, 51, 50, 0, 48, 49, 0, 0, 0, 0 };
+const unsigned char L3DOWN[20] = { 3, 3, 8, 9, 7, 8, 9, 7, 0, 0, 0, 0, 47, 0, 0, 46, 0, 0, 0, 0 };
+const unsigned char L3HOLDWARP[20] = { 3, 3, 8, 8, 0, 10, 10, 0, 7, 7, 0, 125, 125, 0, 125, 125, 0, 0, 0, 0 };
+const unsigned char L3TITE1[34] = { 4, 4, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 57, 58, 0, 0, 56, 55, 0, 0, 0, 0, 0 };
+const unsigned char L3TITE2[34] = { 4, 4, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 61, 62, 0, 0, 60, 59, 0, 0, 0, 0, 0 };
+const unsigned char L3TITE3[34] = { 4, 4, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 65, 66, 0, 0, 64, 63, 0, 0, 0, 0, 0 };
+const unsigned char L3TITE6[42] = { 5, 4, 7, 7, 7, 7, 7, 7, 7, 7, 0, 7, 7, 7, 7, 0, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 0, 77, 78, 0, 0, 0, 76, 74, 75, 0, 0, 0, 0, 0, 0 };
+const unsigned char L3TITE7[42] = { 4, 5, 7, 7, 7, 7, 7, 7, 0, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 83, 0, 0, 0, 82, 80, 0, 0, 81, 79, 0, 0, 0, 0, 0 };
+const unsigned char L3TITE8[20] = { 3, 3, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 52, 0, 0, 0, 0 };
+const unsigned char L3TITE9[20] = { 3, 3, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 53, 0, 0, 0, 0 };
+const unsigned char L3TITE10[20] = { 3, 3, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 54, 0, 0, 0, 0 };
+const unsigned char L3TITE11[20] = { 3, 3, 7, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0, 67, 0, 0, 0, 0 };
+const unsigned char L3TITE12[6] = { 2u, 1u, 9u, 7u, 68u, 0u };
+const unsigned char L3TITE13[6] = { 1u, 2u, 10u, 7u, 69u, 0u };
+const unsigned char L3CREV1[6] = { 2u, 1u, 8u, 7u, 84u, 85u };
+const unsigned char L3CREV2[6] = { 2u, 1u, 8u, 11u, 86u, 87u };
+const unsigned char L3CREV3[6] = { 1u, 2u, 8u, 10u, 89u, 88u };
+const unsigned char L3CREV4[6] = { 2u, 1u, 8u, 7u, 90u, 91u };
+const unsigned char L3CREV5[6] = { 1u, 2u, 8u, 11u, 92u, 93u };
+const unsigned char L3CREV6[6] = { 1u, 2u, 8u, 10u, 95u, 94u };
+const unsigned char L3CREV7[6] = { 2u, 1u, 8u, 7u, 96u, 101u };
+const unsigned char L3CREV8[6] = { 1u, 2u, 2u, 8u, 102u, 97u };
+const unsigned char L3CREV9[6] = { 2u, 1u, 3u, 8u, 103u, 98u };
+const unsigned char L3CREV10[6] = { 2u, 1u, 4u, 8u, 104u, 99u };
+const unsigned char L3CREV11[6] = { 1u, 2u, 6u, 8u, 105u, 100u };
+const unsigned char L3ISLE1[14] = { 2u, 3u, 5u, 14u, 4u, 9u, 13u, 12u, 7u, 7u, 7u, 7u, 7u, 7u };
+const unsigned char L3ISLE2[14] = { 3u, 2u, 5u, 2u, 14u, 13u, 10u, 12u, 7u, 7u, 7u, 7u, 7u, 7u };
+const unsigned char L3ISLE3[14] = { 2u, 3u, 5u, 14u, 4u, 9u, 13u, 12u, 29u, 30u, 25u, 28u, 31u, 32u };
+const unsigned char L3ISLE4[14] = { 3u, 2u, 5u, 2u, 14u, 13u, 10u, 12u, 29u, 26u, 30u, 31u, 27u, 32u };
+const unsigned char L3ISLE5[10] = { 2u, 2u, 5u, 14u, 13u, 12u, 7u, 7u, 7u, 7u };
+const unsigned char L3XTRA1[4] = { 1u, 1u, 7u, 106u };
+const unsigned char L3XTRA2[4] = { 1u, 1u, 7u, 107u };
+const unsigned char L3XTRA3[4] = { 1u, 1u, 7u, 108u };
+const unsigned char L3XTRA4[4] = { 1u, 1u, 9u, 109u };
+const unsigned char L3XTRA5[4] = { 1u, 1u, 10u, 110u };
+const unsigned char L3ANVIL[244] =
 {
    11,  11,   7,   7,   7,   7,   7,   7,   7,   7,
 	7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
@@ -71,9 +71,9 @@ unsigned char L3ANVIL[244] =
    32,   0,   0,   0,   0,   0,   0,   0,   0,   0,
 	0,   0,   0,   0
 };
-unsigned char L3SpawnTbl1[15] = { 0u, 10u, 67u, 5u, 44u, 6u, 9u, 0u, 0u, 28u, 131u, 6u, 9u, 10u, 5u }; /* local spawntable? */
-unsigned char L3SpawnTbl2[15] = { 0u, 10u, 3u, 5u, 12u, 6u, 9u, 0u, 0u, 12u, 3u, 6u, 9u, 10u, 5u }; /* local spawntable? */
-unsigned char L3PoolSub[15] = { 0u, 35u, 26u, 36u, 25u, 29u, 34u, 7u, 33u, 28u, 27u, 37u, 32u, 31u, 30u }; /* local poolsub? */
+const unsigned char L3SpawnTbl1[15] = { 0u, 10u, 67u, 5u, 44u, 6u, 9u, 0u, 0u, 28u, 131u, 6u, 9u, 10u, 5u }; /* local spawntable? */
+const unsigned char L3SpawnTbl2[15] = { 0u, 10u, 3u, 5u, 12u, 6u, 9u, 0u, 0u, 12u, 3u, 6u, 9u, 10u, 5u }; /* local spawntable? */
+const unsigned char L3PoolSub[15] = { 0u, 35u, 26u, 36u, 25u, 29u, 34u, 7u, 33u, 28u, 27u, 37u, 32u, 31u, 30u }; /* local poolsub? */
 
 void __cdecl AddFenceDoors()
 {
@@ -542,23 +542,23 @@ void __fastcall DRLG_L3(int entry)
 			DRLG_L3MakeMegas();
 			if ( !entry )
 			{
-				genok = DRLG_L3PlaceMiniSet(L3UP, 1, 1, -1, -1, 1, 0);
+				genok = DRLG_L3PlaceMiniSet((unsigned char *)L3UP, 1, 1, -1, -1, 1, 0);
 				if ( genok )
 					continue;
-				genok = DRLG_L3PlaceMiniSet(L3DOWN, 1, 1, -1, -1, 0, 1);
+				genok = DRLG_L3PlaceMiniSet((unsigned char *)L3DOWN, 1, 1, -1, -1, 0, 1);
 				if ( genok )
 					continue;
 				if ( currlevel != 9 )
 					goto LABEL_24;
-				genok = DRLG_L3PlaceMiniSet(L3HOLDWARP, 1, 1, -1, -1, 0, 6);
+				genok = DRLG_L3PlaceMiniSet((unsigned char *)L3HOLDWARP, 1, 1, -1, -1, 0, 6);
 				goto LABEL_23;
 			}
-			genok = DRLG_L3PlaceMiniSet(L3UP, 1, 1, -1, -1, 0, 0);
+			genok = DRLG_L3PlaceMiniSet((unsigned char *)L3UP, 1, 1, -1, -1, 0, 0);
 			if ( entry == 1 )
 			{
 				if ( genok )
 					continue;
-				genok = DRLG_L3PlaceMiniSet(L3DOWN, 1, 1, -1, -1, 1, 1);
+				genok = DRLG_L3PlaceMiniSet((unsigned char *)L3DOWN, 1, 1, -1, -1, 1, 1);
 				ViewX += 2;
 				ViewY -= 2;
 				if ( genok )
@@ -567,7 +567,7 @@ void __fastcall DRLG_L3(int entry)
 					goto LABEL_24;
 				v24 = 0;
 LABEL_22:
-				genok = DRLG_L3PlaceMiniSet(L3HOLDWARP, 1, 1, -1, -1, v24, 6);
+				genok = DRLG_L3PlaceMiniSet((unsigned char *)L3HOLDWARP, 1, 1, -1, -1, v24, 6);
 LABEL_23:
 				if ( genok )
 					continue;
@@ -575,7 +575,7 @@ LABEL_23:
 			}
 			if ( genok )
 				continue;
-			genok = DRLG_L3PlaceMiniSet(L3DOWN, 1, 1, -1, -1, 0, 1);
+			genok = DRLG_L3PlaceMiniSet((unsigned char *)L3DOWN, 1, 1, -1, -1, 0, 1);
 			if ( genok )
 				continue;
 			if ( currlevel == 9 )
@@ -594,13 +594,13 @@ LABEL_24:
 	while ( !lavapool );
 	DRLG_L3PoolFix();
 	FixL3Warp();
-	DRLG_L3PlaceRndSet(L3ISLE1, 70);
-	DRLG_L3PlaceRndSet(L3ISLE2, 70);
-	DRLG_L3PlaceRndSet(L3ISLE3, 30);
-	DRLG_L3PlaceRndSet(L3ISLE4, 30);
-	DRLG_L3PlaceRndSet(L3ISLE1, 100);
-	DRLG_L3PlaceRndSet(L3ISLE2, 100);
-	DRLG_L3PlaceRndSet(L3ISLE5, 90);
+	DRLG_L3PlaceRndSet((unsigned char *)L3ISLE1, 70);
+	DRLG_L3PlaceRndSet((unsigned char *)L3ISLE2, 70);
+	DRLG_L3PlaceRndSet((unsigned char *)L3ISLE3, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3ISLE4, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3ISLE1, 100);
+	DRLG_L3PlaceRndSet((unsigned char *)L3ISLE2, 100);
+	DRLG_L3PlaceRndSet((unsigned char *)L3ISLE5, 90);
 	FixL3HallofHeroes();
 	DRLG_L3River();
 
@@ -616,33 +616,33 @@ LABEL_24:
 
 	DRLG_PlaceThemeRooms(5, 10, 7, 0, 0);
 	DRLG_L3Wood();
-	DRLG_L3PlaceRndSet(L3TITE1, 10);
-	DRLG_L3PlaceRndSet(L3TITE2, 10);
-	DRLG_L3PlaceRndSet(L3TITE3, 10);
-	DRLG_L3PlaceRndSet(L3TITE6, 20);
-	DRLG_L3PlaceRndSet(L3TITE7, 20);
-	DRLG_L3PlaceRndSet(L3TITE8, 20);
-	DRLG_L3PlaceRndSet(L3TITE9, 20);
-	DRLG_L3PlaceRndSet(L3TITE10, 20);
-	DRLG_L3PlaceRndSet(L3TITE11, 30);
-	DRLG_L3PlaceRndSet(L3TITE12, 20);
-	DRLG_L3PlaceRndSet(L3TITE13, 20);
-	DRLG_L3PlaceRndSet(L3CREV1, 30);
-	DRLG_L3PlaceRndSet(L3CREV2, 30);
-	DRLG_L3PlaceRndSet(L3CREV3, 30);
-	DRLG_L3PlaceRndSet(L3CREV4, 30);
-	DRLG_L3PlaceRndSet(L3CREV5, 30);
-	DRLG_L3PlaceRndSet(L3CREV6, 30);
-	DRLG_L3PlaceRndSet(L3CREV7, 30);
-	DRLG_L3PlaceRndSet(L3CREV8, 30);
-	DRLG_L3PlaceRndSet(L3CREV9, 30);
-	DRLG_L3PlaceRndSet(L3CREV10, 30);
-	DRLG_L3PlaceRndSet(L3CREV11, 30);
-	DRLG_L3PlaceRndSet(L3XTRA1, 25);
-	DRLG_L3PlaceRndSet(L3XTRA2, 25);
-	DRLG_L3PlaceRndSet(L3XTRA3, 25);
-	DRLG_L3PlaceRndSet(L3XTRA4, 25);
-	DRLG_L3PlaceRndSet(L3XTRA5, 25);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE1, 10);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE2, 10);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE3, 10);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE6, 20);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE7, 20);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE8, 20);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE9, 20);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE10, 20);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE11, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE12, 20);
+	DRLG_L3PlaceRndSet((unsigned char *)L3TITE13, 20);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV1, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV2, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV3, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV4, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV5, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV6, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV7, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV8, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV9, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV10, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3CREV11, 30);
+	DRLG_L3PlaceRndSet((unsigned char *)L3XTRA1, 25);
+	DRLG_L3PlaceRndSet((unsigned char *)L3XTRA2, 25);
+	DRLG_L3PlaceRndSet((unsigned char *)L3XTRA3, 25);
+	DRLG_L3PlaceRndSet((unsigned char *)L3XTRA4, 25);
+	DRLG_L3PlaceRndSet((unsigned char *)L3XTRA5, 25);
 
 	for(i = 0; i < 40; i++)
 	{

--- a/Source/drlg_l3.h
+++ b/Source/drlg_l3.h
@@ -42,46 +42,46 @@ void __cdecl DRLG_L3Pass3();
 void __fastcall LoadL3Dungeon(char *sFileName, int vx, int vy);
 void __fastcall LoadPreL3Dungeon(char *sFileName, int vx, int vy);
 
-/* data */
-extern unsigned char L3ConvTbl[16];
-extern unsigned char L3UP[20];
-extern unsigned char L3DOWN[20];
-extern unsigned char L3HOLDWARP[20];
-extern unsigned char L3TITE1[34];
-extern unsigned char L3TITE2[34];
-extern unsigned char L3TITE3[34];
-extern unsigned char L3TITE6[42];
-extern unsigned char L3TITE7[42];
-extern unsigned char L3TITE8[20];
-extern unsigned char L3TITE9[20];
-extern unsigned char L3TITE10[20];
-extern unsigned char L3TITE11[20];
-extern unsigned char L3TITE12[6];
-extern unsigned char L3TITE13[6];
-extern unsigned char L3CREV1[6];
-extern unsigned char L3CREV2[6];
-extern unsigned char L3CREV3[6];
-extern unsigned char L3CREV4[6];
-extern unsigned char L3CREV5[6];
-extern unsigned char L3CREV6[6];
-extern unsigned char L3CREV7[6];
-extern unsigned char L3CREV8[6];
-extern unsigned char L3CREV9[6];
-extern unsigned char L3CREV10[6];
-extern unsigned char L3CREV11[6];
-extern unsigned char L3ISLE1[14];
-extern unsigned char L3ISLE2[14];
-extern unsigned char L3ISLE3[14];
-extern unsigned char L3ISLE4[14];
-extern unsigned char L3ISLE5[10];
-extern unsigned char L3XTRA1[4];
-extern unsigned char L3XTRA2[4];
-extern unsigned char L3XTRA3[4];
-extern unsigned char L3XTRA4[4];
-extern unsigned char L3XTRA5[4];
-extern unsigned char L3ANVIL[244];
-extern unsigned char L3SpawnTbl1[15]; /* local spawntable? */
-extern unsigned char L3SpawnTbl2[15]; /* local spawntable? */
-extern unsigned char L3PoolSub[15]; /* local poolsub? */
+/* rdata */
+extern const unsigned char L3ConvTbl[16];
+extern const unsigned char L3UP[20];
+extern const unsigned char L3DOWN[20];
+extern const unsigned char L3HOLDWARP[20];
+extern const unsigned char L3TITE1[34];
+extern const unsigned char L3TITE2[34];
+extern const unsigned char L3TITE3[34];
+extern const unsigned char L3TITE6[42];
+extern const unsigned char L3TITE7[42];
+extern const unsigned char L3TITE8[20];
+extern const unsigned char L3TITE9[20];
+extern const unsigned char L3TITE10[20];
+extern const unsigned char L3TITE11[20];
+extern const unsigned char L3TITE12[6];
+extern const unsigned char L3TITE13[6];
+extern const unsigned char L3CREV1[6];
+extern const unsigned char L3CREV2[6];
+extern const unsigned char L3CREV3[6];
+extern const unsigned char L3CREV4[6];
+extern const unsigned char L3CREV5[6];
+extern const unsigned char L3CREV6[6];
+extern const unsigned char L3CREV7[6];
+extern const unsigned char L3CREV8[6];
+extern const unsigned char L3CREV9[6];
+extern const unsigned char L3CREV10[6];
+extern const unsigned char L3CREV11[6];
+extern const unsigned char L3ISLE1[14];
+extern const unsigned char L3ISLE2[14];
+extern const unsigned char L3ISLE3[14];
+extern const unsigned char L3ISLE4[14];
+extern const unsigned char L3ISLE5[10];
+extern const unsigned char L3XTRA1[4];
+extern const unsigned char L3XTRA2[4];
+extern const unsigned char L3XTRA3[4];
+extern const unsigned char L3XTRA4[4];
+extern const unsigned char L3XTRA5[4];
+extern const unsigned char L3ANVIL[244];
+extern const unsigned char L3SpawnTbl1[15]; /* local spawntable? */
+extern const unsigned char L3SpawnTbl2[15]; /* local spawntable? */
+extern const unsigned char L3PoolSub[15]; /* local poolsub? */
 
 #endif /* __DRLG_L3_H__ */

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -21,8 +21,8 @@ char L4dungeon[80][80];
 char dung[20][20];
 //int dword_52A4DC; // weak
 
-unsigned char L4ConvTbl[16] = { 30u, 6u, 1u, 6u, 2u, 6u, 6u, 6u, 9u, 6u, 1u, 6u, 2u, 6u, 3u, 6u };
-unsigned char L4USTAIRS[42] =
+const unsigned char L4ConvTbl[16] = { 30u, 6u, 1u, 6u, 2u, 6u, 6u, 6u, 9u, 6u, 1u, 6u, 2u, 6u, 3u, 6u };
+const unsigned char L4USTAIRS[42] =
 {
   4u,
   5u,
@@ -67,7 +67,7 @@ unsigned char L4USTAIRS[42] =
   0u,
   0u
 };
-unsigned char L4TWARP[42] =
+const unsigned char L4TWARP[42] =
 {
   4u,
   5u,
@@ -112,7 +112,7 @@ unsigned char L4TWARP[42] =
   0u,
   0u
 };
-unsigned char L4DSTAIRS[52] =
+const unsigned char L4DSTAIRS[52] =
 {
   5u,
   5u,
@@ -167,7 +167,7 @@ unsigned char L4DSTAIRS[52] =
   0u,
   0u
 };
-unsigned char L4PENTA[52] =
+const unsigned char L4PENTA[52] =
 {
   5u,
   5u,
@@ -222,7 +222,7 @@ unsigned char L4PENTA[52] =
   0u,
   0u
 };
-unsigned char L4PENTA2[52] =
+const unsigned char L4PENTA2[52] =
 {
   5u,
   5u,
@@ -277,7 +277,7 @@ unsigned char L4PENTA2[52] =
   0u,
   0u
 };
-unsigned char L4BTYPES[140] =
+const unsigned char L4BTYPES[140] =
 {
 	0,   1,   2,   3,   4,   5,   6,   7,   8,   9,
    10,  11,  12,  13,  14,  15,  16,  17,   0,   0,
@@ -688,20 +688,20 @@ void __fastcall DRLG_L4(int entry)
 			{
 				if ( !v23 )
 				{
-					v10 = DRLG_L4PlaceMiniSet(L4USTAIRS, 1, 1, -1, -1, 1, 0);
+					v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4USTAIRS, 1, 1, -1, -1, 1, 0);
 					if ( v10 )
 					{
-						if ( gbMaxPlayers != 1 || (v11 = L4PENTA, quests[5]._qactive == 2) )
-							v11 = L4PENTA2;
+						if ( gbMaxPlayers != 1 || (v11 = (unsigned char *)L4PENTA, quests[5]._qactive == 2) )
+							v11 = (unsigned char *)L4PENTA2;
 						v10 = DRLG_L4PlaceMiniSet(v11, 1, 1, -1, -1, 0, 1);
 					}
 					goto LABEL_35;
 				}
-				v10 = DRLG_L4PlaceMiniSet(L4USTAIRS, 1, 1, -1, -1, 0, 0);
+				v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4USTAIRS, 1, 1, -1, -1, 0, 0);
 				if ( v10 )
 				{
-					if ( gbMaxPlayers != 1 || (v12 = L4PENTA, quests[5]._qactive == 2) )
-						v12 = L4PENTA2;
+					if ( gbMaxPlayers != 1 || (v12 = (unsigned char *)L4PENTA, quests[5]._qactive == 2) )
+						v12 = (unsigned char *)L4PENTA2;
 					v10 = DRLG_L4PlaceMiniSet(v12, 1, 1, -1, -1, 1, 1);
 				}
 			}
@@ -709,24 +709,24 @@ void __fastcall DRLG_L4(int entry)
 			{
 				if ( !v23 )
 				{
-					v10 = DRLG_L4PlaceMiniSet(L4USTAIRS, 1, 1, -1, -1, 1, 0);
+					v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4USTAIRS, 1, 1, -1, -1, 1, 0);
 					if ( v10 )
 					{
 						if ( currlevel != 16 )
-							v10 = DRLG_L4PlaceMiniSet(L4DSTAIRS, 1, 1, -1, -1, 0, 1);
+							v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4DSTAIRS, 1, 1, -1, -1, 0, 1);
 						goto LABEL_31;
 					}
 LABEL_35:
 					++ViewX;
 					continue;
 				}
-				v10 = DRLG_L4PlaceMiniSet(L4USTAIRS, 1, 1, -1, -1, 0, 0);
+				v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4USTAIRS, 1, 1, -1, -1, 0, 0);
 				if ( v23 != 1 )
 				{
 					if ( v10 )
 					{
 						if ( currlevel != 16 )
-							v10 = DRLG_L4PlaceMiniSet(L4DSTAIRS, 1, 1, -1, -1, 0, 1);
+							v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4DSTAIRS, 1, 1, -1, -1, 0, 1);
 LABEL_46:
 						if ( v10 )
 						{
@@ -734,7 +734,7 @@ LABEL_46:
 							{
 								v22 = 1;
 LABEL_34:
-								v10 = DRLG_L4PlaceMiniSet(L4TWARP, 1, 1, -1, -1, v22, 6);
+								v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4TWARP, 1, 1, -1, -1, v22, 6);
 								goto LABEL_35;
 							}
 						}
@@ -744,9 +744,9 @@ LABEL_34:
 				if ( v10 )
 				{
 					if ( currlevel != 16 )
-						v10 = DRLG_L4PlaceMiniSet(L4DSTAIRS, 1, 1, -1, -1, 1, 1);
+						v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4DSTAIRS, 1, 1, -1, -1, 1, 1);
 					if ( v10 && currlevel == 13 )
-						v10 = DRLG_L4PlaceMiniSet(L4TWARP, 1, 1, -1, -1, 0, 6);
+						v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4TWARP, 1, 1, -1, -1, 0, 6);
 				}
 			}
 			++ViewY;
@@ -754,18 +754,18 @@ LABEL_34:
 		}
 		if ( !v23 )
 		{
-			v10 = DRLG_L4PlaceMiniSet(L4USTAIRS, 1, 1, -1, -1, 1, 0);
+			v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4USTAIRS, 1, 1, -1, -1, 1, 0);
 LABEL_31:
 			if ( !v10 || currlevel != 13 )
 				goto LABEL_35;
 			v22 = 0;
 			goto LABEL_34;
 		}
-		v10 = DRLG_L4PlaceMiniSet(L4USTAIRS, 1, 1, -1, -1, 0, 0);
+		v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4USTAIRS, 1, 1, -1, -1, 0, 0);
 		if ( v23 != 1 )
 			goto LABEL_46;
 		if ( v10 && currlevel == 13 )
-			v10 = DRLG_L4PlaceMiniSet(L4TWARP, 1, 1, -1, -1, 0, 6);
+			v10 = DRLG_L4PlaceMiniSet((unsigned char *)L4TWARP, 1, 1, -1, -1, 0, 6);
 		ViewX = 2 * setpc_x + 22;
 		ViewY = 2 * setpc_y + 22;
 	}

--- a/Source/drlg_l4.h
+++ b/Source/drlg_l4.h
@@ -57,13 +57,13 @@ void __cdecl DRLG_L4TransFix();
 void __cdecl DRLG_L4Corners();
 void __cdecl DRLG_L4Pass3();
 
-/* data */
-extern unsigned char L4ConvTbl[16];
-extern unsigned char L4USTAIRS[42];
-extern unsigned char L4TWARP[42];
-extern unsigned char L4DSTAIRS[52];
-extern unsigned char L4PENTA[52];
-extern unsigned char L4PENTA2[52];
-extern unsigned char L4BTYPES[140];
+/* rdata */
+extern const unsigned char L4ConvTbl[16];
+extern const unsigned char L4USTAIRS[42];
+extern const unsigned char L4TWARP[42];
+extern const unsigned char L4DSTAIRS[52];
+extern const unsigned char L4PENTA[52];
+extern const unsigned char L4PENTA2[52];
+extern const unsigned char L4BTYPES[140];
 
 #endif /* __DRLG_L4_H__ */

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -8,10 +8,10 @@ int sfxdnum;
 void *sfx_stream;
 TSFX *sfx_data_cur;
 
-int effects_inf = 0x7F800000; // weak
-char monster_action_sounds[] = { 'a', 'h', 'd', 's' }; // idb
+const int effects_inf = 0x7F800000; // weak
+const char monster_action_sounds[] = { 'a', 'h', 'd', 's' }; // idb
 
-/* rdata */
+/* data */
 
 TSFX sgSFX[NUM_SFX] =
 {

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -29,12 +29,12 @@ void __fastcall priv_sound_init(int bLoadMask);
 void __cdecl sound_init();
 void __stdcall effects_play_sound(char *snd_file);
 
-/* data */
-
-extern int effects_inf; // weak
-extern char monster_action_sounds[]; // idb
-
 /* rdata */
+
+extern const int effects_inf; // weak
+extern const char monster_action_sounds[]; // idb
+
+/* data */
 
 extern TSFX sgSFX[NUM_SFX];
 

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -12,7 +12,9 @@ static CRITICAL_SECTION sgMemCrit;
 int SeedCount; // weak
 int dword_52B99C; // bool valid - if x/y are in bounds
 
-int engine_inf = 0x7F800000; // weak
+const int engine_inf = 0x7F800000; // weak
+const int rand_increment = 1; // unused
+const int rand_multiplier = 0x015A4E35; // unused
 
 struct engine_cpp_init_1
 {

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -71,8 +71,10 @@ void __fastcall Cl2DecDatLightTbl2(char *dst_buf, char *a2, int a3, int frame_wi
 void __fastcall Cl2DecodeFrm6(int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a6, int a7);
 void __fastcall PlayInGameMovie(char *pszMovie);
 
-/* data */
+/* rdata */
 
-extern int engine_inf; // weak
+extern const int engine_inf; // weak
+extern const int rand_increment; // unused
+extern const int rand_multiplier; // unused
 
 #endif /* __ENGINE_H__ */

--- a/Source/gmenu.h
+++ b/Source/gmenu.h
@@ -36,9 +36,9 @@ void __fastcall gmenu_slider_1(TMenuItem *pItem, int min, int max, int gamma);
 int __fastcall gmenu_slider_get(TMenuItem *pItem, int min, int max);
 void __fastcall gmenu_slider_3(TMenuItem *pItem, int dwTicks);
 
-/* data */
+/* rdata */
 
-extern unsigned char lfontframe[127];
-extern unsigned char lfontkern[56];
+extern const unsigned char lfontframe[127];
+extern const unsigned char lfontkern[56];
 
 #endif /* __GMENU_H__ */

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -7,9 +7,9 @@ float interfac_cpp_init_value;
 int sgdwProgress;
 int progress_id; // idb
 
-int interfac_inf = 0x7F800000; // weak
-unsigned char progress_bar_colours[3] = { 138u, 43u, 254u };
-int progress_bar_screen_pos[3][2] = { { 53, 37 }, { 53, 421 }, { 53, 37 } };
+const int interfac_inf = 0x7F800000; // weak
+const unsigned char progress_bar_colours[3] = { 138u, 43u, 254u };
+const int progress_bar_screen_pos[3][2] = { { 53, 37 }, { 53, 421 }, { 53, 37 } };
 
 struct interfac_cpp_init
 {

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -16,10 +16,10 @@ void __fastcall ShowProgress(int uMsg);
 void __cdecl FreeInterface();
 void __fastcall InitCutscene(int uMsg);
 
-/* data */
+/* rdata */
 
-extern int interfac_inf; // weak
-extern unsigned char progress_bar_colours[3];
-extern int progress_bar_screen_pos[3][2];
+extern const int interfac_inf; // weak
+extern const unsigned char progress_bar_colours[3];
+extern const int progress_bar_screen_pos[3][2];
 
 #endif /* __INTERFAC_H__ */

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -7,7 +7,7 @@ void *pInvCels;
 int drawsbarflag; // idb
 int sgdwLastTime; // check name
 
-InvXY InvRect[73] =
+const InvXY InvRect[73] =
 {
   { 452, 31 },  // helmet
   { 480, 31 },  // helmet
@@ -84,7 +84,7 @@ InvXY InvRect[73] =
   { 408, 385 }  // belt
 };
 
-/* rdata */
+/* data */
 
 int AP2x2Tbl[10] = { 8, 28, 6, 26, 4, 24, 2, 22, 0, 20 }; // weak
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -48,11 +48,11 @@ void __cdecl DoTelekinesis();
 int __fastcall CalculateGold(int pnum);
 int __cdecl DropItemBeforeTrig();
 
-/* data */
-
-extern InvXY InvRect[73];
-
 /* rdata */
+
+extern const InvXY InvRect[73];
+
+/* data */
 
 extern int AP2x2Tbl[10]; // weak
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -15,7 +15,7 @@ int numitems;
 int gnNumGetRecords;
 
 
-PLStruct PL_Prefix[84] =
+const PLStruct PL_Prefix[84] =
 {
   { "Tin", IPL_TOHIT_CURSE, 6, 10, 3, PLT_WEAP|PLT_BOW|PLT_MISC, 0, 1, 0, 0, 0, -3 },
   { "Brass", IPL_TOHIT_CURSE, 1, 5, 1, PLT_WEAP|PLT_BOW|PLT_MISC, 0, 1, 0, 0, 0, -2 },
@@ -102,7 +102,7 @@ PLStruct PL_Prefix[84] =
   { "Lightning", IPL_LIGHTDAM, 2, 20, 18, PLT_WEAP|PLT_STAFF, 0, 0, 1, 10000, 10000, 2 },
   { &empty_string, IPL_INVALID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 };
-PLStruct PL_Suffix[96] =
+const PLStruct PL_Suffix[96] =
 {
   { "quality", IPL_DAMMOD, 1, 2, 2, PLT_WEAP|PLT_BOW, 0, 0, 1, 100, 200, 2 },
   { "maiming", IPL_DAMMOD, 3, 5, 7, PLT_WEAP|PLT_BOW, 0, 0, 1, 1300, 1500, 3 },
@@ -201,7 +201,7 @@ PLStruct PL_Suffix[96] =
   { "blocking", IPL_FASTBLOCK, 1, 1, 5, PLT_SHLD, 0, 0, 1, 4000, 4000, 4 },
   { &empty_string, IPL_INVALID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 };
-UItemStruct UniqueItemList[91] =
+const UItemStruct UniqueItemList[91] =
 {
   { "The Butcher's Cleaver", UITYPE_CLEAVER, 1u, 3u, 3650, IPL_STR, 10, 10, IPL_SETDAM, 4, 24, IPL_SETDUR, 10, 10, IPL_TOHIT, 0, 0, IPL_TOHIT, 0, 0, IPL_TOHIT, 0, 0 },
   { "The Undead Crown", UITYPE_SKCROWN, 1u, 3u, 16650, IPL_RNDSTEALLIFE, 0, 0, IPL_SETAC, 8, 8, IPL_INVCURS, 77, 0, IPL_TOHIT, 0, 0, IPL_TOHIT, 0, 0, IPL_TOHIT, 0, 0 },
@@ -296,7 +296,7 @@ UItemStruct UniqueItemList[91] =
   { &empty_string, UITYPE_INVALID, 0u, 0u, 0, IPL_TOHIT, 0, 0, IPL_TOHIT, 0, 0, IPL_TOHIT, 0, 0, IPL_TOHIT, 0, 0, IPL_TOHIT, 0, 0, IPL_TOHIT, 0, 0 }
 };
 
-/* rdata */
+/* data */
 
 
 ItemDataStruct AllItemsList[157] =

--- a/Source/items.h
+++ b/Source/items.h
@@ -125,13 +125,13 @@ void __fastcall NextItemRecord(int i);
 void __fastcall SetItemRecord(int dwSeed, int CI, int indx);
 void __fastcall PutItemRecord(int seed, int ci, int index);
 
-/* data */
-
-extern PLStruct PL_Prefix[84];
-extern PLStruct PL_Suffix[96];
-extern UItemStruct UniqueItemList[91];
-
 /* rdata */
+
+extern const PLStruct PL_Prefix[84];
+extern const PLStruct PL_Suffix[96];
+extern const UItemStruct UniqueItemList[91];
+
+/* data */
 
 
 extern ItemDataStruct AllItemsList[157];

--- a/Source/logging.cpp
+++ b/Source/logging.cpp
@@ -9,9 +9,9 @@ char log_buffer[388];
 LPCVOID lpAddress; // idb
 DWORD nNumberOfBytesToWrite; // idb
 
-int log_inf = 0x7F800000; // weak
+const int log_inf = 0x7F800000; // weak
 
-/* rdata */
+/* data */
 
 int log_not_created = 1; // weak
 HANDLE log_file = (HANDLE)0xFFFFFFFF; // idb

--- a/Source/logging.h
+++ b/Source/logging.h
@@ -19,11 +19,11 @@ void __fastcall log_get_version(VS_FIXEDFILEINFO *file_info);
 void log_printf(const char *pszFmt, ...); // LogMessage
 void __cdecl log_dump_computer_info();
 
-/* data */
-
-extern int log_inf; // weak
-
 /* rdata */
+
+extern const int log_inf; // weak
+
+/* data */
 
 extern int log_not_created; // weak
 extern HANDLE log_file; // idb

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -5,9 +5,9 @@
 int mainmenu_cpp_init_value; // weak
 char chr_name_str[16];
 
-int mainmenu_inf = 0x7F800000; // weak
+const int mainmenu_inf = 0x7F800000; // weak
 
-/* rdata */
+/* data */
 
 int menu_music_track_id = 5; // idb
 

--- a/Source/mainmenu.h
+++ b/Source/mainmenu.h
@@ -15,11 +15,11 @@ int __fastcall mainmenu_init_menu(int a1);
 int __cdecl mainmenu_multi_player();
 void __cdecl mainmenu_play_intro();
 
-/* data */
-
-extern int mainmenu_inf; // weak
-
 /* rdata */
+
+extern const int mainmenu_inf; // weak
+
+/* data */
 
 extern int menu_music_track_id; // idb
 

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -11,7 +11,7 @@ int sgLastScroll; // weak
 void *pMedTextCels;
 void *pTextBoxCels;
 
-unsigned char mfontframe[127] =
+const unsigned char mfontframe[127] =
 {
 	0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
 	0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
@@ -27,7 +27,7 @@ unsigned char mfontframe[127] =
    14,  15,  16,  17,  18,  19,  20,  21,  22,  23,
    24,  25,  26,  48,   0,  49,   0
 };
-unsigned char mfontkern[56] =
+const unsigned char mfontkern[56] =
 {
 	5,  15,  10,  13,  14,  10,   9,  13,  11,   5,
 	5,  11,  10,  16,  13,  16,  10,  15,  12,  10,
@@ -37,7 +37,7 @@ unsigned char mfontkern[56] =
 	5,   5,   5,   5,  11,  12
 };
 
-/* rdata */
+/* data */
 
 int qscroll_spd_tbl[9] = { 2, 4, 6, 8, 0, -1, -2, -3, -4 };
 

--- a/Source/minitext.h
+++ b/Source/minitext.h
@@ -18,12 +18,12 @@ void __cdecl DrawQTextBack();
 void __fastcall PrintQTextChr(int screen_x, int screen_y, char *cel_buf, int frame);
 void __cdecl DrawQText();
 
-/* data */
-
-extern unsigned char mfontframe[127];
-extern unsigned char mfontkern[56];
-
 /* rdata */
+
+extern const unsigned char mfontframe[127];
+extern const unsigned char mfontkern[56];
+
+/* data */
 
 extern int qscroll_spd_tbl[9];
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -16,11 +16,11 @@ int monstimgtot; // weak
 int uniquetrans;
 int nummtypes;
 
-int monster_inf = 0x7F800000; // weak
-char plr2monst[9] = { 0, 5, 3, 7, 1, 4, 6, 0, 2 };
-unsigned char counsmiss[4] = { MIS_FIREBOLT, MIS_CBOLT, MIS_LIGHTCTRL, MIS_FIREBALL };
+const int monster_inf = 0x7F800000; // weak
+const char plr2monst[9] = { 0, 5, 3, 7, 1, 4, 6, 0, 2 };
+const unsigned char counsmiss[4] = { MIS_FIREBOLT, MIS_CBOLT, MIS_LIGHTCTRL, MIS_FIREBALL };
 
-/* rdata */
+/* data */
 
 MonsterData monsterdata[112] =
 {

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -163,13 +163,13 @@ bool __fastcall CheckMonsterHit(int m, bool *ret);
 int __fastcall encode_enemy(int m);
 void __fastcall decode_enemy(int m, int enemy);
 
-/* data */
-
-extern int monster_inf; // weak
-extern char plr2monst[9];
-extern unsigned char counsmiss[4];
-
 /* rdata */
+
+extern const int monster_inf; // weak
+extern const char plr2monst[9];
+extern const unsigned char counsmiss[4];
+
+/* data */
 
 extern MonsterData monsterdata[112];
 extern char MonstConvTbl[128];

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -6,7 +6,7 @@ int movie_cpp_init_value; // weak
 char movie_playing; // weak
 int loop_movie; // weak
 
-int movie_inf = 0x7F800000; // weak
+const int movie_inf = 0x7F800000; // weak
 
 struct movie_cpp_init
 {

--- a/Source/movie.h
+++ b/Source/movie.h
@@ -10,8 +10,8 @@ void __cdecl movie_cpp_init();
 void __fastcall play_movie(char *pszMovie, bool user_can_close);
 LRESULT __stdcall MovieWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 
-/* data */
+/* rdata */
 
-extern int movie_inf; // weak
+extern const int movie_inf; // weak
 
 #endif /* __MOVIE_H__ */

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -10,11 +10,11 @@ bool save_archive_modified; // weak
 _BLOCKENTRY *sgpBlockTbl;
 bool save_archive_open; // weak
 
-int mpqapi_inf = 0x7F800000; // weak
+const int mpqapi_inf = 0x7F800000; // weak
 
 //note: 32872 = 32768 + 104 (sizeof(TMPQHEADER))
 
-/* rdata */
+/* data */
 
 HANDLE sghArchive = (HANDLE)0xFFFFFFFF; // idb
 

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -39,11 +39,11 @@ bool __cdecl mpqapi_write_block_table();
 bool __cdecl mpqapi_write_hash_table();
 bool __cdecl mpqapi_can_seek();
 
-/* data */
-
-extern int mpqapi_inf; // weak
-
 /* rdata */
+
+extern const int mpqapi_inf; // weak
+
+/* data */
 
 extern HANDLE sghArchive; // idb
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -21,7 +21,7 @@ char gbBufferMsgs; // weak
 int dword_676198; // weak
 int msg_err_timer; // weak
 
-int msg_inf = 0x7F800000; // weak
+const int msg_inf = 0x7F800000; // weak
 
 struct msg_cpp_init
 {

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -158,8 +158,8 @@ int __fastcall On_NOVA(struct TCmdLoc *pCmd, int pnum);
 int __fastcall On_SETSHIELD(int unused, int pnum);
 int __fastcall On_REMSHIELD(int unused, int pnum);
 
-/* data */
+/* rdata */
 
-extern int msg_inf; // weak
+extern const int msg_inf; // weak
 
 #endif /* __MSG_H__ */

--- a/Source/msgcmd.cpp
+++ b/Source/msgcmd.cpp
@@ -8,7 +8,7 @@ int msgcmd_cpp_init_value; // weak
 ChatCmd sgChat_Cmd;
 int sgdwMsgCmdTimer;
 
-int msgcmd_inf = 0x7F800000; // weak
+const int msgcmd_inf = 0x7F800000; // weak
 
 struct msgcmd_cpp_init_1
 {

--- a/Source/msgcmd.h
+++ b/Source/msgcmd.h
@@ -24,8 +24,8 @@ void __fastcall msgcmd_event_type(ChatCmd *a1, int a2, int *a3, int a4, int a5);
 void __fastcall msgcmd_cleanup_chatcmd_1(ChatCmd *a1);
 void __fastcall msgcmd_cleanup_extern_msg(ServerCommand **extern_msgs);
 
-/* data */
+/* rdata */
 
-extern int msgcmd_inf; // weak
+extern const int msgcmd_inf; // weak
 
 #endif /* __MSGCMD_H__ */

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -28,8 +28,8 @@ char gbDeltaSender; // weak
 int sgbNetInited; // weak
 int player_state[MAX_PLRS];
 
-int multi_inf = 0x7F800000; // weak
-event_type event_types[3] =
+const int multi_inf = 0x7F800000; // weak
+const int event_types[3] =
 {
   EVENT_TYPE_PLAYER_LEAVE_GAME,
   EVENT_TYPE_PLAYER_CREATE_GAME,

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -66,9 +66,9 @@ int __fastcall multi_init_multi(_SNETPROGRAMDATA *client_info, _SNETPLAYERDATA *
 int __fastcall multi_upgrade(int *a1);
 void __fastcall multi_player_joins(int pnum, TCmdPlrInfoHdr *cmd, int a3);
 
-/* data */
+/* rdata */
 
-extern int multi_inf; // weak
-extern event_type event_types[3];
+extern const int multi_inf; // weak
+extern const int event_types[3];
 
 #endif /* __MULTI_H__ */

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -20,9 +20,9 @@ int gdwLargestMsgSize; // weak
 int gdwNormalMsgSize; // weak
 int dword_679764; // weak
 
-int nthread_inf = 0x7F800000; // weak
+const int nthread_inf = 0x7F800000; // weak
 
-/* rdata */
+/* data */
 static HANDLE sghThread = (HANDLE)0xFFFFFFFF; // idb
 
 struct nthread_cpp_init_1

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -34,8 +34,8 @@ void __cdecl nthread_cleanup();
 void __fastcall nthread_ignore_mutex(bool bStart);
 bool __cdecl nthread_has_500ms_passed();
 
-/* data */
+/* rdata */
 
-extern int nthread_inf; // weak
+extern const int nthread_inf; // weak
 
 #endif /* __NTHREAD_H__ */

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -4,7 +4,7 @@
 
 int pack_cpp_init_value; // weak
 
-int pack_inf = 0x7F800000; // weak
+const int pack_inf = 0x7F800000; // weak
 
 struct pack_cpp_init
 {

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -11,8 +11,8 @@ void __fastcall VerifyGoldSeeds(PlayerStruct *pPlayer);
 void __fastcall UnPackPlayer(PkPlayerStruct *pPack, int pnum, bool killok);
 void __fastcall UnPackItem(PkItemStruct *is, ItemStruct *id);
 
-/* data */
+/* rdata */
 
-extern int pack_inf; // weak
+extern const int pack_inf; // weak
 
 #endif /* __PACK_H__ */

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -8,9 +8,9 @@ PALETTEENTRY system_palette[256];
 PALETTEENTRY orig_palette[256];
 UINT gdwPalEntries;
 
-int palette_inf = 0x7F800000; // weak
+const int palette_inf = 0x7F800000; // weak
 
-/* rdata */
+/* data */
 
 int gamma_correction = 100; // idb
 int color_cycling_enabled = 1; // idb

--- a/Source/palette.h
+++ b/Source/palette.h
@@ -30,11 +30,11 @@ void __fastcall palette_update_quest_palette(int n);
 bool __cdecl palette_get_colour_cycling();
 void __fastcall palette_set_color_cycling(bool enabled);
 
-/* data */
-
-extern int palette_inf; // weak
-
 /* rdata */
+
+extern const int palette_inf; // weak
+
+/* data */
 
 extern int gamma_correction; // idb
 extern int color_cycling_enabled; // idb

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -20,10 +20,11 @@ PATHNODE *pnode_tblptr[300];
 PATHNODE *path_2_nodes;
 
 // for iterating over the 8 possible movement directions
-char pathxdir[8] = { -1, -1, 1, 1, -1, 0, 1, 0 };
-char pathydir[8] = { -1, 1, -1, 1, 0, -1, 0, 1 };
+const char pathxdir[8] = { -1, -1, 1, 1, -1, 0, 1, 0 };
+const char pathydir[8] = { -1, 1, -1, 1, 0, -1, 0, 1 };
 
-/* rdata */
+/* data */
+
 /* each step direction is assigned a number like this:
  *       dx
  *     -1 0 1

--- a/Source/path.h
+++ b/Source/path.h
@@ -25,12 +25,12 @@ void __fastcall path_push_active_step(PATHNODE *pPath);
 PATHNODE *__cdecl path_pop_active_step();
 PATHNODE *__cdecl path_new_step();
 
-/* data */
-
-extern char pathxdir[8];
-extern char pathydir[8];
-
 /* rdata */
+
+extern const char pathxdir[8];
+extern const char pathydir[8];
+
+/* data */
 extern char path_directions[9];
 
 #endif /* __PATH_H__ */

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -7,7 +7,7 @@ char hero_names[MAX_CHARACTERS][PLR_NAME_LEN];
 bool gbValidSaveFile; // idb
 int save_prev_tc; // weak
 
-int pfile_inf = 0x7F800000; // weak
+const int pfile_inf = 0x7F800000; // weak
 
 struct pfile_cpp_init
 {

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -45,8 +45,8 @@ void __fastcall pfile_strcpy(char *dst, char *src);
 char *__fastcall pfile_read(char *pszName, int *pdwLen);
 void __fastcall pfile_update(bool force_save);
 
-/* data */
+/* rdata */
 
-extern int pfile_inf; // weak
+extern const int pfile_inf; // weak
 
 #endif /* __PFILE_H__ */

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -19,12 +19,12 @@ int plr_sframe_size; // idb
 int deathdelay; // weak
 int plr_dframe_size; // idb
 
-int player_inf = 0x7F800000; // weak
-char ArmourChar[4] = { 'L', 'M', 'H', 0 };
-char WepChar[10] = { 'N', 'U', 'S', 'D', 'B', 'A', 'M', 'H', 'T', 0 };
-char CharChar[4] = { 'W', 'R', 'S', 0 };
+const int player_inf = 0x7F800000; // weak
+const char ArmourChar[4] = { 'L', 'M', 'H', 0 };
+const char WepChar[10] = { 'N', 'U', 'S', 'D', 'B', 'A', 'M', 'H', 'T', 0 };
+const char CharChar[4] = { 'W', 'R', 'S', 0 };
 
-/* rdata */
+/* data */
 
 int plrxoff[9] = { 0, 2, 0, 2, 1, 0, 1, 2, 1 };
 int plryoff[9] = { 0, 2, 2, 0, 1, 1, 0, 1, 2 };
@@ -438,10 +438,10 @@ int __fastcall GetPlrGFXSize(char *szCel)
 	v10 = ClassStrTbl;
 	do
 	{
-		v2 = ArmourChar;
+		v2 = (char *)ArmourChar;
 		do
 		{
-			v3 = WepChar;
+			v3 = (char *)WepChar;
 			do
 			{
 				sprintf(v6, "%c%c%c", CharChar[v1], *v2, *v3);

--- a/Source/player.h
+++ b/Source/player.h
@@ -110,14 +110,14 @@ void __fastcall SetPlrVit(int pnum, int v);
 void __fastcall InitDungMsgs(int pnum);
 void __cdecl PlayDungMsgs();
 
-/* data */
-
-extern int player_inf;
-extern char ArmourChar[4];
-extern char WepChar[10];
-extern char CharChar[4];
-
 /* rdata */
+
+extern const int player_inf;
+extern const char ArmourChar[4];
+extern const char WepChar[10];
+extern const char CharChar[4];
+
+/* data */
 
 extern int plrxoff[9];
 extern int plryoff[9];

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -6,7 +6,7 @@ int plrmsg_ticks; // weak
 char plr_msg_slot; // weak
 _plrmsg plr_msgs[8];
 
-text_color text_color_from_player_num[2] = { COL_WHITE, COL_GOLD };
+const text_color text_color_from_player_num[2] = { COL_WHITE, COL_GOLD }; /* char [4] */
 
 void __fastcall plrmsg_delay(int a1)
 {

--- a/Source/plrmsg.h
+++ b/Source/plrmsg.h
@@ -15,8 +15,8 @@ void __cdecl InitPlrMsg();
 void __cdecl DrawPlrMsg();
 void __fastcall PrintPlrMsg(int no, int x, int y, char *str, int just);
 
-/* data */
+/* rdata */
 
-extern text_color text_color_from_player_num[2];
+extern const text_color text_color_from_player_num[2];
 
 #endif /* __PLRMSG_H__ */

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -23,9 +23,9 @@ char sgSaveBack[8192];
 int draw_monster_num; // weak
 int sgdwCursHgtOld; // idb
 
-int scrollrt_inf = 0x7F800000; // weak
+const int scrollrt_inf = 0x7F800000; // weak
 
-/* rdata */
+/* data */
 
 /* used in 1.00 debug */
 char *szMonModeAssert[18] =

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -61,11 +61,11 @@ void __cdecl DrawFPS();
 void __fastcall DoBlitScreen(int dwX, int dwY, int dwWdt, int dwHgt);
 void __cdecl DrawAndBlit();
 
-/* data */
-
-extern int scrollrt_inf; // weak
-
 /* rdata */
+
+extern const int scrollrt_inf; // weak
+
+/* data */
 
 /* used in 1.00 debug */
 extern char *szMonModeAssert[18];

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -12,9 +12,9 @@ HMODULE hDsound_dll; // idb
 void *sgpMusicTrack;
 IDirectSoundBuffer *sglpDSB;
 
-int sound_inf = 0x7F800000; // weak
+const int sound_inf = 0x7F800000; // weak
 
-/* rdata */
+/* data */
 
 char gbMusicOn = 1; // weak
 char gbSoundOn = 1; // weak

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -34,11 +34,11 @@ void __fastcall sound_disable_music(bool disable);
 int __fastcall sound_get_or_set_music_volume(int volume);
 int __fastcall sound_get_or_set_sound_volume(int volume);
 
-/* data */
-
-extern int sound_inf; // weak
-
 /* rdata */
+
+extern const int sound_inf; // weak
+
+/* data */
 
 extern char gbMusicOn; // weak
 extern char gbSoundOn; // weak

--- a/Source/textdat.cpp
+++ b/Source/textdat.cpp
@@ -4,7 +4,7 @@
 
 /* todo: move text out of struct */
 
-TextDataStruct alltext[259] =
+const TextDataStruct alltext[259] =
 {
   { " Ahh, the story of our King, is it? The tragic fall of Leoric was a harsh blow to this land. The people always loved the King, and now they live in mortal fear of him. The question that I keep asking myself is how he could have fallen so far from the Light, as Leoric had always been the holiest of men. Only the vilest powers of Hell could so utterly destroy a man from within... |",
 	1, 5, TSFX_STORY1 },
@@ -509,4 +509,4 @@ TextDataStruct alltext[259] =
   { "Thank goodness you've returned!\nMuch has changed since you lived here, my friend. All was peaceful until the dark riders came and destroyed our village. Many were cut down where they stood, and those who took up arms were slain or dragged away to become slaves - or worse. The church at the edge of town has been desecrated and is being used for dark rituals. The screams that echo in the night are inhuman, but some of our townsfolk may yet survive. Follow the path that lies between my tavern and the blacksmith shop to find the church and save who you can. \n \nPerhaps I can tell you more if we speak again. Good luck.|",
 	1, 5, TSFX_TAVERN0 }
 };
-int gdwAllTextEntries = 259; /* unused */
+const int gdwAllTextEntries = 259; /* unused */

--- a/Source/textdat.h
+++ b/Source/textdat.h
@@ -2,7 +2,7 @@
 #ifndef __TEXTDAT_H__
 #define __TEXTDAT_H__
 
-extern TextDataStruct alltext[259];
-extern int gdwAllTextEntries;
+extern const TextDataStruct alltext[259];
+extern const int gdwAllTextEntries;
 
 #endif /* __TEXTDAT_H__ */

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -12,14 +12,14 @@ void *pCowCels; // idb
 TownerStruct towner[16];
 
 
-int snSFX[3][3] =
+const int snSFX[3][3] =
 {
   { PS_WARR52, PS_ROGUE52, PS_MAGE52 },
   { PS_WARR49, PS_ROGUE49, PS_MAGE49 },
   { PS_WARR50, PS_ROGUE50, PS_MAGE50 }
 };
 
-/* rdata */
+/* data */
 
 char AnimOrder[6][148] =
 {

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -45,11 +45,11 @@ void __fastcall TownerTalk(int t);
 void __fastcall TalkToTowner(int p, int t);
 void __fastcall CowSFX(int pnum);
 
-/* data */
-
-extern int snSFX[3][3];
-
 /* rdata */
+
+extern const int snSFX[3][3];
+
+/* data */
 
 extern char AnimOrder[6][148];
 extern int TownCowX[3];

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -7,7 +7,7 @@ int track_cpp_init_value; // weak
 int sgdwLastWalk; // weak
 bool sgbIsWalking; // weak
 
-int track_inf = 0x7F800000; // weak
+const int track_inf = 0x7F800000; // weak
 
 struct track_cpp_init
 {

--- a/Source/track.h
+++ b/Source/track.h
@@ -12,8 +12,8 @@ void __cdecl track_process();
 void __fastcall track_repeat_walk(bool rep);
 bool __cdecl track_isscrolling();
 
-/* data */
+/* rdata */
 
-extern int track_inf; // weak
+extern const int track_inf; // weak
 
 #endif /* __TRACK_H__ */

--- a/Source/wave.cpp
+++ b/Source/wave.cpp
@@ -4,7 +4,7 @@
 
 int wave_cpp_init_value; // weak
 
-int wave_inf = 0x7F800000; // weak
+const int wave_inf = 0x7F800000; // weak
 
 struct wave_cpp_init
 {

--- a/Source/wave.h
+++ b/Source/wave.h
@@ -23,8 +23,8 @@ int __fastcall ReadWaveSection(MEMFILE *pMemFile, int a2, int *a3);
 void *__fastcall LoadWaveFile(HANDLE hsFile, WAVEFORMATEX *pwfx, int *a3);
 void __fastcall j_engine_mem_free(void *ptr);
 
-/* data */
+/* rdata */
 
-extern int wave_inf; // weak
+extern const int wave_inf; // weak
 
 #endif /* __WAVE_H__ */


### PR DESCRIPTION
Now the virtual `.rdata` section is the exact same size as the original binary (0x9400)! This should also correct code in how it accesses the data.

Also added the unused data back into engine.cpp. Looks like at one time the seed shifter was stored as a global variable. Interesting.