### PR TITLE
Add pre-liminary source code to DiabloUI.dll

### DIFF
--- a/DiabloUI/artfont.cpp
+++ b/DiabloUI/artfont.cpp
@@ -1,0 +1,406 @@
+// ref: 0x10001058
+void UNKCALL artfont_10001058(char *arg) { return; }
+/* {
+	int v1; // ecx
+	int v2; // ecx
+	int v3; // ecx
+	int v4; // ecx
+	int v5; // ecx
+
+	if ( arg )
+	{
+		v1 = (int)(arg - 2);
+		if ( v1 )
+		{
+			v2 = v1 - 1;
+			if ( v2 )
+			{
+				v3 = v2 - 1;
+				if ( v3 )
+				{
+					v4 = v3 - 1;
+					if ( v4 )
+					{
+						v5 = v4 - 1;
+						if ( v5 )
+						{
+							if ( v5 == 1 )
+								dword_100270C0 = (int)&unk_10028EF8;
+							else
+								dword_100270C0 = (int)&unk_100275D0;
+						}
+						else
+						{
+							dword_100270C0 = (int)&unk_10026BB8;
+						}
+					}
+					else
+					{
+						dword_100270C0 = (int)&unk_100289F0;
+					}
+				}
+				else
+				{
+					dword_100270C0 = (int)&unk_100270C8;
+				}
+			}
+			else
+			{
+				dword_100270C0 = (int)&unk_10027AD8;
+			}
+		}
+		else
+		{
+			dword_100270C0 = (int)&unk_100284E8;
+		}
+	}
+	else
+	{
+		dword_100270C0 = (int)&unk_10027FE0;
+	}
+} */
+// 100270C0: using guessed type int dword_100270C0;
+
+// ref: 0x10001098
+int artfont_10001098() { return 0; }
+/* {
+	int result; // eax
+
+	result = 0;
+	dword_100270BC = 0;
+	dword_100293FC = 0;
+	dword_100275CC = 0;
+	dword_10028EF4 = 0;
+	dword_100289EC = 0;
+	dword_10027FDC = 0;
+	dword_100284E4 = 0;
+	dword_10027AD4 = 0;
+	dword_100270C0 = 0;
+	return result;
+} */
+// 100270BC: using guessed type int dword_100270BC;
+// 100270C0: using guessed type int dword_100270C0;
+// 100275CC: using guessed type int dword_100275CC;
+// 10027AD4: using guessed type int dword_10027AD4;
+// 10027FDC: using guessed type int dword_10027FDC;
+// 100284E4: using guessed type int dword_100284E4;
+// 100289EC: using guessed type int dword_100289EC;
+// 10028EF4: using guessed type int dword_10028EF4;
+// 100293FC: using guessed type int dword_100293FC;
+
+// ref: 0x100010C8
+int artfont_100010C8() { return 0; }
+/* {
+	int result; // eax
+
+	artfont_10001120(&unk_10026BB8);
+	artfont_10001120(&unk_10028EF8);
+	artfont_10001120(&unk_100270C8);
+	artfont_10001120(&unk_100289F0);
+	artfont_10001120(&unk_100284E8);
+	artfont_10001120(&unk_10027AD8);
+	artfont_10001120(&unk_10027FE0);
+	result = artfont_10001120(&unk_100275D0);
+	dword_100270C0 = 0;
+	return result;
+} */
+// 100270C0: using guessed type int dword_100270C0;
+
+// ref: 0x10001120
+int UNKCALL artfont_10001120(_DWORD *arg) { return 0; }
+/* {
+	_DWORD *v1; // edi
+	int *v2; // esi
+	signed int v3; // ebx
+	int result; // eax
+
+	v1 = arg;
+	if ( arg[321] )
+	{
+		v2 = arg + 65;
+		v3 = 256;
+		do
+		{
+			result = *v2;
+			if ( *v2 )
+			{
+				result = STransDelete(*v2);
+				*v2 = 0;
+			}
+			++v2;
+			--v3;
+		}
+		while ( v3 );
+		v1[321] = 0;
+	}
+	return result;
+} */
+// 1001033A: using guessed type int __stdcall STransDelete(_DWORD);
+
+// ref: 0x10001159
+signed int artfont_10001159() { return 0; }
+/* {
+	artfont_100011FB((int)&unk_100270C8, (int)"ui_art\\font30.bin", (int)"ui_art\\font30g.pcx");
+	artfont_100011FB((int)&unk_100289F0, (int)"ui_art\\font30.bin", (int)"ui_art\\font30s.pcx");
+	artfont_100011FB((int)&unk_100284E8, (int)"ui_art\\font24.bin", (int)"ui_art\\font24g.pcx");
+	artfont_100011FB((int)&unk_10027AD8, (int)"ui_art\\font24.bin", (int)"ui_art\\font24s.pcx");
+	artfont_100011FB((int)&unk_10027FE0, (int)"ui_art\\font16.bin", (int)"ui_art\\font16g.pcx");
+	artfont_100011FB((int)&unk_100275D0, (int)"ui_art\\font16.bin", (int)"ui_art\\font16s.pcx");
+	artfont_100011FB((int)&unk_10026BB8, (int)"ui_art\\font42.bin", (int)"ui_art\\font42g.pcx");
+	artfont_100011FB((int)&unk_10028EF8, (int)"ui_art\\font42.bin", (int)"ui_art\\font42y.pcx");
+	return 1;
+} */
+
+// ref: 0x100011FB
+void __fastcall artfont_100011FB(int a1, int a2, int a3) { return; }
+/* {
+	int v3; // esi
+	int v4; // eax
+	signed int v5; // edi
+	unsigned char v6; // al
+	int v7; // ecx
+	int v8; // [esp+8h] [ebp-20h]
+	int v9; // [esp+Ch] [ebp-1Ch]
+	int v10; // [esp+10h] [ebp-18h]
+	int v11; // [esp+14h] [ebp-14h]
+	int v12; // [esp+18h] [ebp-10h]
+	int v13; // [esp+1Ch] [ebp-Ch]
+	int v14; // [esp+20h] [ebp-8h]
+	int v15; // [esp+24h] [ebp-4h]
+	int v16; // [esp+30h] [ebp+8h]
+
+	v3 = a1;
+	if ( !*(_DWORD *)(a1 + 1284) && SFileOpenFile(a2, &v15) )
+	{
+		v4 = SFileGetFileSize(v15, 0);
+		if ( SFileReadFile(v15, v3, v4, 0, 0) )
+		{
+			SFileCloseFile(v15);
+			local_100078BE(a3, &v14, &v12);
+			memset((void *)(v3 + 260), 0, 0x400u);
+			if ( v14 )
+			{
+				v5 = 0;
+				v16 = v3 + 260;
+				do
+				{
+					v6 = *(_BYTE *)(v3 + v5 + 2);
+					if ( v6 )
+					{
+						v7 = *(unsigned char *)(v3 + 1);
+						v10 = v6;
+						v9 = v5 * v7;
+						v8 = 0;
+						v11 = v7 + v5 * v7 - 1;
+						STransCreateI(v14, v12, v13, 8, &v8, 16777248, v16);
+					}
+					v16 += 4;
+					++v5;
+				}
+				while ( v5 <= 256 );
+				*(_DWORD *)(v3 + 1284) = 1;
+				SMemFree(v14, "C:\\Src\\Diablo\\DiabloUI\\artfont.cpp", 206, 0);
+			}
+		}
+		else
+		{
+			SFileCloseFile(v15);
+		}
+	}
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010346: using guessed type int __stdcall STransCreateI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1001034C: using guessed type int __stdcall SFileCloseFile(_DWORD);
+// 10010352: using guessed type int __stdcall SFileReadFile(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010358: using guessed type int __stdcall SFileGetFileSize(_DWORD, _DWORD);
+// 1001035E: using guessed type int __stdcall SFileOpenFile(_DWORD, _DWORD);
+
+// ref: 0x100012F6
+int artfont_100012F6() { return 0; }
+/* {
+	int result; // eax
+
+	if ( dword_100270C0 && *(_DWORD *)(dword_100270C0 + 1284) )
+		result = *(unsigned char *)(dword_100270C0 + 1);
+	else
+		result = 0;
+	return result;
+} */
+// 100270C0: using guessed type int dword_100270C0;
+
+// ref: 0x10001310
+int artfont_10001310() { return 0; }
+/* {
+	int result; // eax
+
+	if ( dword_100270C0 && *(_DWORD *)(dword_100270C0 + 1284) )
+		result = *(unsigned char *)dword_100270C0;
+	else
+		result = 0;
+	return result;
+} */
+// 100270C0: using guessed type int dword_100270C0;
+
+// ref: 0x10001329
+int __fastcall artfont_10001329(unsigned char *a1) { return 0; }
+/* {
+	int result; // eax
+	unsigned char i; // bl
+	unsigned char v3; // bl
+	int v4; // esi
+
+	result = 0;
+	if ( !dword_100270C0 || !*(_DWORD *)(dword_100270C0 + 1284) )
+		return 0;
+	for ( i = *a1; *a1; i = *a1 )
+	{
+		v3 = *(_BYTE *)(i + dword_100270C0 + 2);
+		if ( v3 )
+			v4 = v3;
+		else
+			v4 = *(unsigned char *)dword_100270C0;
+		result += v4;
+		++a1;
+	}
+	return result;
+} */
+// 100270C0: using guessed type int dword_100270C0;
+
+// ref: 0x1000136C
+signed int artfont_1000136C() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10026BB0 = 2139095040;
+	return result;
+} */
+// 10026BB0: using guessed type int dword_10026BB0;
+
+// ref: 0x10001377
+int __fastcall artfont_10001377(unsigned char *a1) { return 0; }
+/* {
+	int result; // eax
+	unsigned char v2; // dl
+	unsigned char v3; // dl
+
+	result = 0;
+	if ( !dword_100270C0 || !*(_DWORD *)(dword_100270C0 + 1284) )
+		return 0;
+	while ( 1 )
+	{
+		v3 = *a1;
+		if ( !*a1 )
+			break;
+		if ( v3 == 10 )
+			break;
+		if ( v3 == 32 )
+			break;
+		v2 = *(_BYTE *)(v3 + dword_100270C0 + 2);
+		if ( !v2 )
+			break;
+		result += v2;
+		++a1;
+	}
+	return result;
+} */
+// 100270C0: using guessed type int dword_100270C0;
+
+// ref: 0x100013B3
+int __cdecl artfont_100013B3(int a1) { return 0; }
+/* {
+	int result; // eax
+
+	if ( a1 )
+		result = SMemFree(a1, "delete", -1, 0);
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x100013CD
+void __fastcall artfont_100013CD(unsigned char *a1, _DWORD *a2, int a3, int a4) { return; }
+/* {
+	_DWORD *v4; // ebx
+	unsigned char *v5; // esi
+	unsigned char v6; // cl
+	int v7; // edi
+	unsigned char v8; // dl
+	int v9; // edi
+	int v10; // ecx
+	int v11; // [esp+Ch] [ebp-8h]
+	int v12; // [esp+Ch] [ebp-8h]
+	unsigned char *v13; // [esp+10h] [ebp-4h]
+
+	v4 = a2;
+	v13 = a1;
+	if ( a2 )
+	{
+		if ( *a2 )
+		{
+			v5 = (unsigned char *)dword_100270C0;
+			if ( dword_100270C0 )
+			{
+				if ( *(_DWORD *)(dword_100270C0 + 1284) )
+				{
+					if ( a3 < 0 )
+						a3 = 0;
+					if ( a4 < 0 )
+						a4 = 0;
+					v6 = *a1;
+					if ( *v13 )
+					{
+						while ( 1 )
+						{
+							v11 = a4 + v5[1];
+							if ( a4 + v5[1] > v4[2] )
+								return;
+							if ( v6 == 10 )
+								break;
+							v7 = v6;
+							v8 = v5[v6 + 2];
+							if ( !v8 )
+							{
+								v9 = *v5;
+								if ( a3 + v9 + artfont_10001377(++v13) < v4[1] )
+								{
+									a3 += v9;
+								}
+								else
+								{
+									a3 = 0;
+									a4 = v11;
+								}
+								goto LABEL_23;
+							}
+							v12 = *(_DWORD *)&v5[4 * v6 + 260];
+							if ( *(_DWORD *)&v5[4 * v6 + 260] )
+							{
+								v10 = v4[1];
+								if ( a3 + v8 <= v10 )
+								{
+									STransBlt(*v4, a3, a4, v10, v12);
+									v5 = (unsigned char *)dword_100270C0;
+									a3 += *(unsigned char *)(v7 + dword_100270C0 + 2);
+									goto LABEL_22;
+								}
+								a3 = 0;
+								a4 += v5[1];
+							}
+LABEL_23:
+							v6 = *v13;
+							if ( !*v13 )
+								return;
+						}
+						a3 = 0;
+						a4 += v5[1];
+LABEL_22:
+						++v13;
+						goto LABEL_23;
+					}
+				}
+			}
+		}
+	}
+} */
+// 1001036A: using guessed type int __stdcall STransBlt(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100270C0: using guessed type int dword_100270C0;

--- a/DiabloUI/bn_prof.cpp
+++ b/DiabloUI/bn_prof.cpp
@@ -1,0 +1,1421 @@
+// ref: 0x100014E8
+signed int bn_prof_100014E8() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029404 = 2139095040;
+	return result;
+} */
+// 10029404: using guessed type int dword_10029404;
+
+// ref: 0x100014F3
+int __cdecl UiProfileGetString() { return 0; }
+//const char *UiProfileGetString() { return 0; }
+/* {
+	return "profile\\sex";
+} */
+
+// ref: 0x100014F9
+void __cdecl UiProfileCallback() { return; }
+//BOOL __stdcall UiProfileCallback(int a1, int a2, int a3, int a4, LPARAM a5, int a6, int a7, int a8, int (__stdcall *a9)(_DWORD, _DWORD, _DWORD, _DWORD)) { return 0; }
+/* {
+	const char *v9; // eax
+	int v10; // eax
+
+	lParam = a5;
+	dword_10029408 = a6;
+	dword_1002941C = a7;
+	dword_10029418 = a8;
+	dword_10029430 = a9;
+	v9 = "DIALOG_PROFILE";
+	if ( !a9 )
+		v9 = "DIALOG_STATIC_PROFILE";
+	v10 = SDlgDialogBoxParam(hInstance, v9, *(_DWORD *)(a3 + 8), bn_prof_1000155F, 0);
+	return v10 && v10 != -1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029408: using guessed type int dword_10029408;
+// 10029418: using guessed type int dword_10029418;
+// 1002941C: using guessed type int dword_1002941C;
+// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000155F
+HGDIOBJ __stdcall bn_prof_1000155F(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	HWND v6; // edi
+
+	if ( Msg <= 0x110 )
+	{
+		switch ( Msg )
+		{
+			case 0x110u:
+				bn_prof_10001C0E(hWnd);
+				break;
+			case 2u:
+				bn_prof_10001F29();
+				break;
+			case 0x2Bu:
+				if ( wParam == 1134 )
+				{
+					bn_prof_100018CE((int)hWnd, lParam);
+					return (HGDIOBJ)1;
+				}
+				return (HGDIOBJ)SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+			default:
+				if ( Msg > 0x103 && Msg <= 0x105 )
+				{
+					v4 = (HWND)SDrawGetFrameWindow();
+					SendMessageA(v4, Msg, wParam, lParam);
+				}
+				return (HGDIOBJ)SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		return 0;
+	}
+	if ( Msg == 273 )
+	{
+		if ( (unsigned short)wParam == 1 )
+		{
+			EnableWindow((HWND)lParam, 0);
+			TitleSnd_10010315();
+			if ( dword_10029430 )
+				bn_prof_100016DD(hWnd);
+			SDlgEndDialog(hWnd, 1);
+		}
+		else if ( (unsigned short)wParam == 2 )
+		{
+			EnableWindow((HWND)lParam, 0);
+			TitleSnd_10010315();
+			SDlgEndDialog(hWnd, 0);
+		}
+		else
+		{
+			if ( (unsigned short)wParam != 1134 || HIWORD(wParam) || dword_10029430 )
+				return (HGDIOBJ)SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+			bn_prof_10001A10(hWnd, (HWND)lParam);
+		}
+		return 0;
+	}
+	if ( Msg == 274 )
+	{
+		if ( wParam != 61536 )
+			return (HGDIOBJ)SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		v6 = GetParent(hWnd);
+		SDlgEndDialog(hWnd, 0);
+		PostMessageA(v6, 0x112u, 0xF060u, lParam);
+		return 0;
+	}
+	if ( Msg != 312 || GetWindowLongA((HWND)lParam, -12) != 1124 )
+		return (HGDIOBJ)SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	SetTextColor((HDC)wParam, 0xFFFFu);
+	return GetStockObject(5);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x100016DD
+void UNKCALL bn_prof_100016DD(HWND arg) { return; }
+/* {
+	int v1; // ebx
+	int v2; // eax
+	const char **v3; // edi
+	int v4; // eax
+	int v5; // ebx
+	int *v6; // ebx
+	LRESULT v7; // eax
+	LPARAM v8; // eax
+	size_t v9; // eax
+	char *v10; // eax
+	int v11; // ebx
+	_DWORD *v12; // edi
+	int v13; // eax
+	int v14; // ebx
+	size_t v15; // [esp+4h] [ebp-28h]
+	char *v16; // [esp+8h] [ebp-24h]
+	HWND hDlg; // [esp+Ch] [ebp-20h]
+	int v18; // [esp+10h] [ebp-1Ch]
+	int v19; // [esp+14h] [ebp-18h]
+	int v20; // [esp+18h] [ebp-14h]
+	char *v21; // [esp+1Ch] [ebp-10h]
+	int v22; // [esp+20h] [ebp-Ch]
+	int v23; // [esp+24h] [ebp-8h]
+	char *v24; // [esp+28h] [ebp-4h]
+	size_t v25; // [esp+28h] [ebp-4h]
+
+	v1 = 0;
+	hDlg = arg;
+	if ( dword_10029430 )
+	{
+		v2 = SMemAlloc(4 * dword_10029408, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 193, 0);
+		v3 = (const char **)v2;
+		v22 = v2;
+		v4 = SMemAlloc(4 * dword_10029408, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 195, 0);
+		v18 = v4;
+		v20 = 0;
+		v23 = 0;
+		if ( dword_10029408 > 0 )
+		{
+			v19 = v4 - (_DWORD)v3;
+			do
+			{
+				v5 = 0;
+				v24 = byte_1001F37C;
+				v16 = *(char **)(4 * v23 + dword_10029418);
+				v21 = *(char **)(4 * v23 + dword_1002941C);
+				while ( 1 )
+				{
+					if ( !_strcmpi(v21, *((const char **)v24 - 1)) )
+					{
+						v15 = strlen(v16);
+						if ( *v24 & 1 )
+							break;
+					}
+					v24 += 16;
+					++v5;
+					if ( (signed int)v24 >= (signed int)&unk_1001F3BC )
+						goto LABEL_13;
+				}
+				v6 = &dword_1001F380[4 * v5];
+				v7 = SendDlgItemMessageA(hDlg, *v6, 0xEu, 0, 0);
+				v25 = v7;
+				v8 = SMemAlloc(v7 + 1, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 218, 0);
+				*v3 = (const char *)v8;
+				SendDlgItemMessageA(hDlg, *v6, 0xDu, v25 + 1, v8);
+				(*v3)[v25] = 0;
+				if ( v25 == v15 && !_strnicmp(v16, *v3, v25) )
+				{
+					SMemFree(*v3, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 236, 0);
+				}
+				else
+				{
+					v9 = strlen(v21);
+					v10 = (char *)SMemAlloc(v9 + 1, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 232, 0);
+					*(const char **)((char *)v3 + v19) = v10;
+					strcpy(v10, v21);
+					++v20;
+					++v3;
+				}
+LABEL_13:
+				++v23;
+			}
+			while ( v23 < dword_10029408 );
+			v1 = v20;
+		}
+		dword_10029430(&byte_10029448, v1, v18, v22);
+		v11 = v1 - 1;
+		if ( v11 >= 0 )
+		{
+			v12 = (_DWORD *)(v22 + 4 * v11);
+			v13 = v18 - v22;
+			v14 = v11 + 1;
+			while ( 1 )
+			{
+				SMemFree(*(_DWORD *)((char *)v12 + v13), "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 250, 0);
+				SMemFree(*v12, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 251, 0);
+				--v12;
+				if ( !--v14 )
+					break;
+				v13 = v18 - v22;
+			}
+		}
+		SMemFree(v18, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 253, 0);
+		SMemFree(v22, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 254, 0);
+	}
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1001F380: using guessed type int dword_1001F380[];
+// 10029408: using guessed type int dword_10029408;
+// 10029418: using guessed type int dword_10029418;
+// 1002941C: using guessed type int dword_1002941C;
+// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x100018CE
+void __fastcall bn_prof_100018CE(int a1, int a2) { return; }
+/* {
+	int v2; // esi
+	LRESULT v3; // eax
+	WPARAM v4; // edi
+	char *v5; // ebx
+
+	v2 = a2;
+	if ( *(_DWORD *)(a2 + 24) && *(_DWORD *)a2 == 5 )
+	{
+		v3 = SendMessageA(*(HWND *)(a2 + 20), 0xEu, 0, 0);
+		v4 = v3 + 1;
+		if ( v3 != 0 )
+		{
+			v5 = (char *)SMemAlloc(v3 + 1, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 362, 0);
+			SendMessageA(*(HWND *)(v2 + 20), 0xDu, v4, (LPARAM)v5);
+			bn_prof_10001938(*(HDC *)(v2 + 24), (_DWORD *)(v2 + 28), v5, 0, 0);
+			SMemFree(v5, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 367, 0);
+		}
+	}
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10001938
+int __fastcall bn_prof_10001938(HDC a1, _DWORD *a2, char *a3, int a4, int a5) { return 0; }
+/* {
+	int result; // eax
+	char *v6; // edi
+	char *v7; // eax
+	char *v8; // esi
+	char v9; // bl
+	char *v10; // eax
+	RECT rc; // [esp+Ch] [ebp-14h]
+	_DWORD *v12; // [esp+1Ch] [ebp-4h]
+	char *v13; // [esp+28h] [ebp+8h]
+
+	result = (int)bn_prof_10002410(a1, a2);
+	v12 = (_DWORD *)result;
+	if ( result )
+	{
+		v6 = a3;
+		if ( a3 )
+		{
+			v13 = (char *)(a4 != 0 ? (unsigned int)&rc : 0);
+			while ( 1 )
+			{
+				v7 = strstr(v6, "http://");
+				v8 = v7;
+				v9 = 0;
+				if ( v7 )
+				{
+					v9 = *v7;
+					*v7 = 0;
+				}
+				if ( !bn_prof_10002456((int)v12, v6, 1, v13) || !v8 )
+					break;
+				*v8 = v9;
+				v10 = strpbrk(v8, " \n\r\t");
+				v6 = v10;
+				if ( v10 )
+				{
+					v9 = *v10;
+					*v10 = 0;
+				}
+				if ( !bn_prof_10002456((int)v12, v8, 2, v13) )
+					break;
+				if ( a4 && PtInRect(&rc, *(POINT *)a4) )
+				{
+					if ( a5 )
+						*(_DWORD *)a5 = v8;
+					return 1;
+				}
+				if ( !v6 )
+					break;
+				*v6 = v9;
+			}
+		}
+		bn_prof_100026C4(v12);
+		result = a4 == 0;
+	}
+	return result;
+} */
+
+// ref: 0x10001A10
+int __fastcall bn_prof_10001A10(HWND a1, HWND a2) { return 0; }
+/* {
+	HWND v2; // esi
+	int result; // eax
+	WPARAM v4; // esi
+	HWND v5; // eax
+	HDC v6; // edi
+	HWND v7; // eax
+	struct tagRECT v8; // [esp+Ch] [ebp-3Ch]
+	struct tagRECT Rect; // [esp+1Ch] [ebp-2Ch]
+	struct tagPOINT Point; // [esp+2Ch] [ebp-1Ch]
+	HWND v11; // [esp+34h] [ebp-14h]
+	int v12; // [esp+38h] [ebp-10h]
+	int v13; // [esp+3Ch] [ebp-Ch]
+	HWND hWnd; // [esp+40h] [ebp-8h]
+	char *v15; // [esp+44h] [ebp-4h]
+
+	v2 = a2;
+	hWnd = a2;
+	v11 = a1;
+	result = GetCursorPos(&Point);
+	if ( result )
+	{
+		result = GetWindowRect(v2, &Rect);
+		if ( result )
+		{
+			result = GetClientRect(v2, &v8);
+			if ( result )
+			{
+				Point.x -= Rect.left;
+				Point.y -= Rect.top;
+				result = SendMessageA(v2, 0xEu, 0, 0);
+				v4 = result + 1;
+				if ( result + 1 > 1 )
+				{
+					v15 = (char *)SMemAlloc(result + 1, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 438, 0);
+					SendMessageA(hWnd, 0xDu, v4, (LPARAM)v15);
+					v5 = GetDesktopWindow();
+					v6 = GetDC(v5);
+					hWnd = (HWND)CreateCompatibleDC(v6);
+					v13 = bn_prof_10001938((HDC)hWnd, &v8, v15, (int)&Point, (int)&v12);
+					DeleteDC((HDC)hWnd);
+					v7 = GetDesktopWindow();
+					ReleaseDC(v7, v6);
+					if ( v13 )
+						bn_prof_10001B0A(v11, (const CHAR *)v12);
+					result = SMemFree(v15, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 450, 0);
+				}
+			}
+		}
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10001B0A
+HINSTANCE __fastcall bn_prof_10001B0A(HWND a1, const CHAR *a2) { return 0; }
+/* {
+	const CHAR *v2; // ebp
+	HWND v3; // eax
+	HWND v4; // eax
+	HINSTANCE result; // eax
+	FILE *v6; // eax
+	HWND v7; // eax
+	HWND v8; // eax
+	HWND v9; // eax
+	HWND hWnd; // [esp+10h] [ebp-348h]
+	CHAR Caption; // [esp+14h] [ebp-344h]
+	CHAR Result; // [esp+54h] [ebp-304h]
+	CHAR Buffer; // [esp+158h] [ebp-200h]
+
+	v2 = a2;
+	hWnd = a1;
+	v3 = GetDesktopWindow();
+	SetForegroundWindow(v3);
+	v4 = (HWND)SDrawGetFrameWindow();
+	result = ShellExecuteA(v4, "open", v2, 0, 0, 1);
+	if ( (unsigned int)result <= 0x20 )
+	{
+		v6 = fopen("battle.htm", "wb");
+		if ( v6 )
+			fclose(v6);
+		if ( (unsigned int)FindExecutableA("battle.htm", 0, &Result) <= 0x20 )
+		{
+			v7 = (HWND)SDrawGetFrameWindow();
+			if ( (unsigned int)ShellExecuteA(v7, "open", &Result, v2, 0, 1) <= 0x20 )
+			{
+				v8 = (HWND)SDrawGetFrameWindow();
+				SetActiveWindow(v8);
+				v9 = (HWND)SDrawGetFrameWindow();
+				ShowWindow(v9, 0);
+				LoadStringA(hInstance, 0x50u, &Buffer, 512);
+				LoadStringA(hInstance, 0x51u, &Caption, 64);
+				UiMessageBoxCallback(hWnd, &Buffer, &Caption, 0x30u);
+			}
+		}
+		result = (HINSTANCE)DeleteFileA("battle.htm");
+	}
+	return result;
+} */
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x10001C0E
+HWND UNKCALL bn_prof_10001C0E(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	LPARAM v2; // ST10_4
+	HWND v3; // eax
+	HWND v4; // eax
+	HWND v5; // eax
+	HWND v6; // eax
+
+	v1 = hWnd;
+	bn_prof_10001CF3(hWnd);
+	ho = bn_prof_10001D81(v1, 2, (int)&unk_1001F3B8);
+	dword_10029424 = bn_prof_10001D81(v1, 1, (int)&unk_1001F3D0);
+	v2 = lParam;
+	v3 = GetDlgItem(v1, 1126);
+	SendMessageA(v3, 0xCu, 0, v2);
+	bn_prof_10001CB9(
+		(_DWORD *)dword_1002941C,
+		dword_10029418,
+		(void (__fastcall *)(_BYTE *, _DWORD, int))bn_prof_10001ED0,
+		0);
+	bn_prof_10001E34(v1);
+	if ( dword_10029430 )
+	{
+		v4 = GetDlgItem(v1, 1128);
+	}
+	else
+	{
+		v5 = GetDlgItem(v1, 1134);
+		bn_prof_100022A2(v5);
+		v6 = GetDlgItem(v1, 1);
+		EnableWindow(v6, 0);
+		v4 = GetDlgItem(v1, 2);
+	}
+	return SetFocus(v4);
+} */
+// 10029418: using guessed type int dword_10029418;
+// 1002941C: using guessed type int dword_1002941C;
+// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10001CB9
+void __fastcall bn_prof_10001CB9(_DWORD *a1, int a2, void (__fastcall *a3)(_BYTE *, _DWORD, int), int a4) { return; }
+/* {
+	_BYTE *v4; // eax
+	_DWORD *v5; // esi
+	int v6; // edi
+
+	if ( a1 )
+	{
+		if ( a2 )
+		{
+			if ( a3 )
+			{
+				v4 = (_BYTE *)*a1;
+				if ( *(_BYTE *)*a1 )
+				{
+					v5 = a1;
+					v6 = a2 - (_DWORD)a1;
+					do
+					{
+						a3(v4, *(_DWORD *)((char *)v5 + v6), a4);
+						++v5;
+						v4 = (_BYTE *)*v5;
+					}
+					while ( *(_BYTE *)*v5 );
+				}
+			}
+		}
+	}
+} */
+
+// ref: 0x10001CF3
+int UNKCALL bn_prof_10001CF3(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	const char *v2; // eax
+	int v3; // ST10_4
+	HWND v4; // eax
+	int v6; // [esp+8h] [ebp-14h]
+	int v7; // [esp+Ch] [ebp-10h]
+	int v8; // [esp+10h] [ebp-Ch]
+	char v9; // [esp+14h] [ebp-8h]
+
+	v8 = 0;
+	v1 = hWnd;
+	v6 = 1;
+	v7 = 2;
+	v2 = "ui_art\\bnprofile.pcx";
+	if ( !dword_10029430 )
+		v2 = "ui_art\\bnstaticprofile.pcx";
+	v3 = (int)v2;
+	v4 = GetParent(hWnd);
+	local_10007944((int)v1, (int)v4, "Popup", -1, 1, v3, &dword_10029410, &v9, 1);
+	local_10007944(0, 0, "Button", -1, 1, (int)"ui_art\\but_xsm.pcx", &dword_10029428, &v9, 1);
+	return SDlgSetControlBitmaps(v1, &v6, 0, dword_10029428, &v9, 1, -1);
+} */
+// 10010388: using guessed type int __stdcall SDlgSetControlBitmaps(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029410: using guessed type int dword_10029410;
+// 10029428: using guessed type int dword_10029428;
+// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10001D81
+HFONT __fastcall bn_prof_10001D81(HWND hWnd, int a2, int a3) { return 0; }
+/* {
+	int v3; // esi
+	void *v4; // ebx
+	int v5; // esi
+	int v6; // eax
+	const char *v7; // ST10_4
+	HFONT v8; // ebx
+	int *v10; // esi
+	int pv; // [esp+8h] [ebp-40h]
+	int v12; // [esp+18h] [ebp-30h]
+	char v13; // [esp+24h] [ebp-24h]
+	HWND hDlg; // [esp+44h] [ebp-4h]
+
+	v3 = a2;
+	hDlg = hWnd;
+	v4 = (void *)SendMessageA(hWnd, 0x31u, 0, 0);
+	if ( !v4 )
+		return 0;
+	memset(&pv, 0, 0x3Cu);
+	if ( !GetObjectA(v4, 60, &pv) )
+		return 0;
+	v5 = 3 * v3;
+	v6 = MulDiv(dword_10022260[v5], 96, 72);
+	v7 = (&off_10022264)[v5];
+	pv = -v6;
+	v12 = dword_10022268[v5];
+	strcpy(&v13, v7);
+	v8 = CreateFontIndirectA((const LOGFONTA *)&pv);
+	if ( !v8 )
+		return 0;
+	v10 = (int *)a3;
+	if ( a3 )
+	{
+		while ( *v10 )
+		{
+			SendDlgItemMessageA(hDlg, *v10, 0x30u, (WPARAM)v8, 0);
+			++v10;
+		}
+	}
+	return v8;
+} */
+// 10022260: using guessed type int dword_10022260[];
+// 10022264: using guessed type char *off_10022264;
+// 10022268: using guessed type int dword_10022268[];
+
+// ref: 0x10001E34
+void UNKCALL bn_prof_10001E34(void *arg) { return; }
+/* {
+	bn_prof_10001CB9(
+		(_DWORD *)dword_1002941C,
+		dword_10029418,
+		(void (__fastcall *)(_BYTE *, _DWORD, int))bn_prof_10001E4C,
+		(int)arg);
+} */
+// 10029418: using guessed type int dword_10029418;
+// 1002941C: using guessed type int dword_1002941C;
+
+// ref: 0x10001E4C
+void __fastcall bn_prof_10001E4C(char *a1, LPARAM lParam, HWND hDlg) { return; }
+/* {
+	int v3; // esi
+	bool v4; // zf
+	LPARAM v5; // ebp
+	char *v6; // ebx
+	const char **v7; // edi
+	int v8; // esi
+	HWND v9; // ebx
+
+	v3 = 0;
+	v4 = dword_10022258 == 0;
+	v5 = lParam;
+	v6 = a1;
+	if ( dword_10022258 > 0 )
+	{
+		v7 = (const char **)&off_1001F378;
+		do
+		{
+			if ( !_strcmpi(v6, *v7) )
+				break;
+			++v3;
+			v7 += 4;
+		}
+		while ( v3 < dword_10022258 );
+		v4 = v3 == dword_10022258;
+	}
+	if ( !v4 )
+	{
+		v8 = 4 * v3;
+		if ( !(byte_1001F37C[v8 * 4] & 4) )
+		{
+			v9 = GetDlgItem(hDlg, dword_1001F380[v8]);
+			SendMessageA(v9, 0xCu, 0, v5);
+			if ( dword_10029430 )
+				SendMessageA(v9, 0xC5u, dword_1001F384[v8], 0);
+		}
+	}
+} */
+// 1001F378: using guessed type char *off_1001F378;
+// 1001F380: using guessed type int dword_1001F380[];
+// 1001F384: using guessed type int dword_1001F384[];
+// 10022258: using guessed type int dword_10022258;
+// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10001ED0
+void __fastcall bn_prof_10001ED0(char *a1, _BYTE *a2, int a3) { return; }
+/* {
+	int v3; // esi
+	bool v4; // zf
+	_BYTE *v5; // edi
+	char *v6; // ebp
+	const char **v7; // ebx
+
+	v3 = 0;
+	v4 = dword_10022258 == 0;
+	v5 = a2;
+	v6 = a1;
+	if ( dword_10022258 > 0 )
+	{
+		v7 = (const char **)&off_1001F378;
+		do
+		{
+			if ( !_strcmpi(v6, *v7) )
+				break;
+			++v3;
+			v7 += 4;
+		}
+		while ( v3 < dword_10022258 );
+		v4 = v3 == dword_10022258;
+	}
+	if ( !v4 )
+	{
+		if ( *v5 )
+			dword_10029438[v3] = (int)v5;
+		else
+			dword_10029438[v3] = (int)"0";
+	}
+} */
+// 1001F378: using guessed type char *off_1001F378;
+// 10022258: using guessed type int dword_10022258;
+
+// ref: 0x10001F29
+int bn_prof_10001F29() { return 0; }
+/* {
+	int result; // eax
+
+	bn_prof_100023D8();
+	bn_prof_10001F84();
+	if ( ho )
+		DeleteObject(ho);
+	ho = 0;
+	if ( dword_10029424 )
+		DeleteObject(dword_10029424);
+	result = dword_10029434;
+	dword_10029424 = 0;
+	if ( dword_10029434 )
+		result = SMemFree(dword_10029434, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 509, 0);
+	dword_10029434 = 0;
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029434: using guessed type int dword_10029434;
+
+// ref: 0x10001F84
+int bn_prof_10001F84() { return 0; }
+/* {
+	int result; // eax
+
+	if ( dword_10029410 )
+	{
+		SMemFree(dword_10029410, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 129, 0);
+		dword_10029410 = 0;
+	}
+	result = dword_10029428;
+	if ( dword_10029428 )
+	{
+		result = SMemFree(dword_10029428, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 133, 0);
+		dword_10029428 = 0;
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029410: using guessed type int dword_10029410;
+// 10029428: using guessed type int dword_10029428;
+
+// ref: 0x10001FC8
+void __cdecl UiProfileDraw() { return; }
+//int __stdcall UiProfileDraw(int a1, int a2, int a3, int a4, HGDIOBJ ho, int a6, int a7, int a8, int a9, int a10, int a11) { return 0; }
+/* {
+	int v11; // eax
+	HFONT v12; // eax
+	int v14; // eax
+	CHAR *v15; // edi
+	int v16; // esi
+	CHAR v17; // al
+	int v18; // ecx
+	int v19; // eax
+	int v20; // edx
+	CHAR Buffer[256]; // [esp+Ch] [ebp-150h]
+	int v22; // [esp+10Ch] [ebp-50h]
+	int v23; // [esp+110h] [ebp-4Ch]
+	int v24; // [esp+114h] [ebp-48h]
+	int v25; // [esp+118h] [ebp-44h]
+	int v26; // [esp+11Ch] [ebp-40h]
+	int v27; // [esp+120h] [ebp-3Ch]
+	int v28; // [esp+124h] [ebp-38h]
+	int v29; // [esp+128h] [ebp-34h]
+	int v30; // [esp+12Ch] [ebp-30h]
+	int v31; // [esp+130h] [ebp-2Ch]
+	int v32; // [esp+134h] [ebp-28h]
+	int v33; // [esp+138h] [ebp-24h]
+	int v34; // [esp+13Ch] [ebp-20h]
+	int v35; // [esp+140h] [ebp-1Ch]
+	int v36; // [esp+144h] [ebp-18h]
+	int v37; // [esp+148h] [ebp-14h]
+	int v38; // [esp+14Ch] [ebp-10h]
+	int v39; // [esp+150h] [ebp-Ch]
+	int v40; // [esp+154h] [ebp-8h]
+	int v41; // [esp+158h] [ebp-4h]
+	HFONT hoa; // [esp+174h] [ebp+18h]
+	int hob; // [esp+174h] [ebp+18h]
+
+	if ( ho )
+		return 0;
+	if ( !a9 )
+		return 0;
+	if ( !a10 )
+		return 0;
+	if ( !a11 )
+		return 0;
+	v24 = dword_1002940C;
+	v34 = dword_1002940C;
+	v30 = 0;
+	v31 = 0;
+	v32 = a10;
+	v33 = a11;
+	v36 = a10;
+	v37 = a11;
+	v22 = 0;
+	v23 = 0;
+	v25 = dword_10029414;
+	v35 = dword_10029414;
+	if ( !SBltROP3Clipped(a9, &v30, &v36, a10, dword_1002942C, &v22, &v34, dword_1002940C, 0, 13369376) )
+		return 0;
+	if ( !LoadStringA(hInstance, 0x4Fu, Buffer, 255) )
+		return 0;
+	v11 = MulDiv(12, 96, 72);
+	v12 = CreateFontA(-v11, 0, 0, 0, 400, 0, 0, 0, 0, 0, 0, 0, 0x20u, "Arial");
+	hoa = v12;
+	if ( !v12 )
+		return 0;
+	v41 = 0;
+	if ( !SGdiImportFont(v12, &v41) )
+		return 0;
+	DeleteObject(hoa);
+	if ( !v41 || !SGdiSelectObject(v41) )
+		return 0;
+	v26 = 0;
+	v27 = 0;
+	v28 = a10;
+	v29 = a11;
+	SGdiSetPitch(a10);
+	v14 = SStrLen(Buffer);
+	v15 = Buffer;
+	hob = v14 + 1;
+	v40 = 8;
+	Buffer[v14 + 1] = 0;
+	v16 = v14 + 1;
+	do
+	{
+		if ( v15[v16 - 1] )
+		{
+			v17 = v15[v16 - 1];
+			do
+			{
+				if ( v17 == 32 )
+					break;
+				if ( v17 == 10 )
+					break;
+				if ( v17 == 9 )
+					break;
+				if ( v16 <= 1 )
+					break;
+				v17 = v15[v16-- - 2];
+			}
+			while ( v17 );
+		}
+		SGdiGetTextExtent(v15, v16, &v38);
+		if ( v38 >= a10 - 8 )
+		{
+			v20 = a10 * hob % v38;
+			if ( --v16 >= a10 * hob / v38 )
+				v16 = a10 * hob / v38;
+		}
+		else
+		{
+			v19 = v16 - 1;
+			if ( v15[v16 - 1] )
+				v19 = v16;
+			SGdiExtTextOut(a9, 8, v40, &v26, 16777471, 1, 0, v15, v19);
+			if ( v15[v16] == 32 )
+				++v16;
+			v15 += v16;
+			v40 += v39;
+			hob -= v16;
+			v16 = hob;
+		}
+	}
+	while ( v16 && hob && v40 < a11 - 8 );
+	SGdiDeleteObject(v18, v20, v41);
+	return 1;
+} */
+// 1001038E: using guessed type int __fastcall SGdiDeleteObject(_DWORD, _DWORD, _DWORD);
+// 10010394: using guessed type int __stdcall SGdiExtTextOut(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1001039A: using guessed type int __stdcall SGdiGetTextExtent(_DWORD, _DWORD, _DWORD);
+// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+// 100103A6: using guessed type int __stdcall SGdiSetPitch(_DWORD);
+// 100103AC: using guessed type int __stdcall SGdiSelectObject(_DWORD);
+// 100103B2: using guessed type int __stdcall SGdiImportFont(_DWORD, _DWORD);
+// 100103B8: using guessed type int __stdcall SBltROP3Clipped(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002940C: using guessed type int dword_1002940C;
+// 10029414: using guessed type int dword_10029414;
+// 1002942C: using guessed type int dword_1002942C;
+// 10001FC8: using guessed type CHAR Buffer[256];
+
+// ref: 0x100021C4
+int bn_prof_100021C4() { return 0; }
+/* {
+	int v0; // edi
+	int v2; // [esp+4h] [ebp-8h]
+	int v3; // [esp+8h] [ebp-4h]
+
+	v3 = 0;
+	v2 = 0;
+	if ( !SBmpLoadImage("ui_Art\\profilebkg.pcx", 0, 0, 0, &v3, &v2, 0) || !v3 || !v2 )
+		return 0;
+	v0 = v3 * v2;
+	dword_1002942C = SMemAlloc(v3 * v2, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 760, 0);
+	dword_1002940C = v3;
+	dword_10029414 = v2;
+	return SBmpLoadImage("ui_Art\\profilebkg.pcx", 0, dword_1002942C, v0, &v3, &v2, 0);
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100103BE: using guessed type int __stdcall SBmpLoadImage(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002940C: using guessed type int dword_1002940C;
+// 10029414: using guessed type int dword_10029414;
+// 1002942C: using guessed type int dword_1002942C;
+
+// ref: 0x10002247
+int bn_prof_10002247() { return 0; }
+/* {
+	int result; // eax
+
+	result = dword_1002942C;
+	if ( dword_1002942C )
+	{
+		result = SMemFree(dword_1002942C, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 776, 0);
+		dword_1002942C = 0;
+		dword_1002940C = 0;
+		dword_10029414 = 0;
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002940C: using guessed type int dword_1002940C;
+// 10029414: using guessed type int dword_10029414;
+// 1002942C: using guessed type int dword_1002942C;
+
+// ref: 0x10002278
+int j_bn_prof_10002282() { return 0; }
+/* {
+	bn_prof_10002282();
+	return atexit(bn_prof_10002298);
+} */
+
+// ref: 0x10002282
+_DWORD *bn_prof_10002282() { return 0; }
+/* {
+	_DWORD *result; // eax
+	_DWORD *v1; // edx
+
+	result = dword_10029460;
+	v1 = &dword_10029460[1];
+	*v1 = 0;
+	v1[1] = 0;
+	*v1 = v1;
+	dword_10029460[0] = 0;
+	dword_10029460[2] = ~(unsigned int)&dword_10029460[1];
+	return result;
+} */
+
+// ref: 0x10002298
+void __cdecl bn_prof_10002298() { return; }
+/* {
+	bn_prof_100026F0(dword_10029460);
+} */
+
+// ref: 0x100022A2
+int UNKCALL bn_prof_100022A2(HWND hWnd) { return 0; }
+/* {
+	HFONT v2; // eax
+	HFONT v3; // eax
+	char pv; // [esp+4h] [ebp-40h]
+	char v5; // [esp+19h] [ebp-2Bh]
+	HANDLE h; // [esp+40h] [ebp-4h]
+
+	if ( !hWnd )
+		return 0;
+	h = (HANDLE)SendMessageA(hWnd, 0x31u, 0, 0);
+	if ( !h )
+		return 0;
+	memset(&pv, 0, 0x3Cu);
+	if ( GetObjectA(h, 60, &pv) )
+	{
+		v2 = CreateFontIndirectA((const LOGFONTA *)&pv);
+		if ( v2 )
+		{
+			dword_10029450 = v2;
+			dword_10029458 = bn_prof_10002353(v2);
+		}
+	}
+	memset(&pv, 0, 0x3Cu);
+	if ( GetObjectA(h, 60, &pv) )
+	{
+		v5 = 1;
+		v3 = CreateFontIndirectA((const LOGFONTA *)&pv);
+		if ( v3 )
+		{
+			::h = v3;
+			dword_1002946C = bn_prof_10002353(v3);
+		}
+	}
+	return 1;
+} */
+// 10029458: using guessed type int dword_10029458;
+// 1002946C: using guessed type int dword_1002946C;
+
+// ref: 0x10002353
+int UNKCALL bn_prof_10002353(HGDIOBJ h) { return 0; }
+/* {
+	HGDIOBJ v1; // ebx
+	HWND v2; // eax
+	HDC v3; // ebp
+	HDC v4; // esi
+	HWND v5; // eax
+	int v7; // [esp+10h] [ebp-10h]
+	HGDIOBJ ha; // [esp+14h] [ebp-Ch]
+	struct tagSIZE psizl; // [esp+18h] [ebp-8h]
+
+	v1 = h;
+	v2 = GetDesktopWindow();
+	v3 = GetDC(v2);
+	v4 = CreateCompatibleDC(v3);
+	v7 = 0;
+	ha = SelectObject(v4, v1);
+	if ( GetTextExtentPoint32A(v4, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", 52, &psizl) )
+		v7 = (psizl.cx / 26 + 1) / 2;
+	SelectObject(v4, ha);
+	DeleteDC(v4);
+	v5 = GetDesktopWindow();
+	ReleaseDC(v5, v3);
+	return v7;
+} */
+
+// ref: 0x100023D8
+HGDIOBJ bn_prof_100023D8() { return 0; }
+/* {
+	HGDIOBJ result; // eax
+	int v1; // esi
+
+	if ( dword_10029450 )
+	{
+		DeleteObject(dword_10029450);
+		dword_10029450 = 0;
+	}
+	result = h;
+	if ( h )
+	{
+		result = (HGDIOBJ)DeleteObject(h);
+		h = 0;
+	}
+	while ( 1 )
+	{
+		v1 = dword_10029460[2];
+		if ( v1 <= 0 )
+			break;
+		bn_prof_100027D8((_DWORD *)dword_10029460[2]);
+		result = (HGDIOBJ)SMemFree(v1, ".?AU_DRAWTEXT@@", -2, 0);
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10002410
+_DWORD *__fastcall bn_prof_10002410(HDC hdc, _DWORD *a2) { return 0; }
+/* {
+	HDC v2; // ebp
+	_DWORD *v3; // esi
+	_DWORD *v4; // eax
+	_DWORD *v5; // ebx
+	_DWORD *v6; // esi
+
+	v2 = hdc;
+	v3 = a2;
+	v4 = bn_prof_10002782(dword_10029460, 2, 0, 0);
+	v5 = v4;
+	v4[2] = v2;
+	v4[3] = *v3;
+	++v3;
+	v4[4] = *v3;
+	++v3;
+	v4[5] = *v3;
+	v4[6] = v3[1];
+	v4[7] = 0;
+	v4[8] = 0;
+	v6 = v4 + 9;
+	GetTextMetricsA(v2, (LPTEXTMETRICA)(v4 + 9));
+	v5[23] = *v6 + v5[13];
+	return v5;
+} */
+
+// ref: 0x10002456
+signed int __fastcall bn_prof_10002456(int a1, const CHAR *a2, char a3, _DWORD *a4) { return 0; }
+/* {
+	int v4; // esi
+	HGDIOBJ v6; // edi
+	int v7; // eax
+	int v8; // ecx
+	int v9; // edi
+	int v10; // eax
+	int v11; // eax
+	int v12; // eax
+	LPCSTR v13; // ebx
+	LONG v14; // ecx
+	int v15; // eax
+	int v16; // eax
+	int v17; // eax
+	int v18; // ecx
+	const CHAR *v19; // eax
+	int v20; // eax
+	int v21; // eax
+	COLORREF v22; // [esp-Ch] [ebp-2Ch]
+	struct tagSIZE Size; // [esp+4h] [ebp-1Ch]
+	COLORREF color; // [esp+Ch] [ebp-14h]
+	HGDIOBJ h; // [esp+10h] [ebp-10h]
+	int cchString; // [esp+14h] [ebp-Ch]
+	LPCSTR lpszString; // [esp+18h] [ebp-8h]
+	int nFit; // [esp+1Ch] [ebp-4h]
+	int v29; // [esp+28h] [ebp+8h]
+
+	v4 = a1;
+	lpszString = a2;
+	if ( !a1 )
+		return 0;
+	cchString = strlen(a2);
+	if ( a4 )
+		memset(a4, 0, 0x10u);
+	h = 0;
+	if ( a3 & 2 )
+	{
+		v6 = ::h;
+		v7 = dword_1002946C;
+		v22 = 16711680;
+	}
+	else
+	{
+		v6 = dword_10029450;
+		v7 = dword_10029458;
+		v22 = 0xFFFFFF;
+	}
+	v29 = v7;
+	color = SetTextColor(*(HDC *)(v4 + 8), v22);
+	if ( v6 )
+		h = SelectObject(*(HDC *)(v4 + 8), v6);
+	if ( a4 )
+	{
+		*a4 = *(_DWORD *)(v4 + 28);
+		a4[1] = *(_DWORD *)(v4 + 32);
+	}
+	do
+	{
+		while ( cchString > 0 && *(_WORD *)lpszString == 2573 )
+		{
+			v8 = *(_DWORD *)(v4 + 92);
+			cchString -= 2;
+			*(_DWORD *)(v4 + 32) += v8;
+			lpszString += 2;
+			*(_DWORD *)(v4 + 28) = 0;
+		}
+		if ( !cchString )
+			break;
+		nFit = 0;
+		GetTextExtentExPointA(
+			*(HDC *)(v4 + 8),
+			lpszString,
+			cchString,
+			*(_DWORD *)(v4 + 20) - *(_DWORD *)(v4 + 28) - *(_DWORD *)(v4 + 12) - v29 + 1,
+			&nFit,
+			0,
+			&Size);
+		v9 = nFit;
+		if ( nFit )
+		{
+			if ( nFit < cchString )
+			{
+				if ( nFit > 0 )
+				{
+					do
+					{
+						if ( isspace(lpszString[v9]) )
+							break;
+						--v9;
+					}
+					while ( v9 > 0 );
+					if ( v9 > 0 )
+					{
+LABEL_26:
+						++v9;
+						goto LABEL_27;
+					}
+				}
+				if ( *(_DWORD *)(v4 + 28) > 0 )
+				{
+					if ( isspace(lpszString[v9]) )
+						goto LABEL_26;
+LABEL_27:
+					nFit = v9;
+				}
+			}
+			v11 = 0;
+			if ( nFit > 0 )
+			{
+				while ( *(_WORD *)&lpszString[v11] != 2573 && lpszString[v11] != 9 )
+				{
+					if ( ++v11 >= nFit )
+						goto LABEL_34;
+				}
+				nFit = v11;
+			}
+LABEL_34:
+			if ( a4 )
+			{
+				v12 = *(_DWORD *)(v4 + 28);
+				if ( v12 < *a4 )
+					*a4 = v12;
+			}
+			else
+			{
+				ExtTextOutA(
+					*(HDC *)(v4 + 8),
+					*(_DWORD *)(v4 + 28),
+					*(_DWORD *)(v4 + 32),
+					4u,
+					(const RECT *)(v4 + 12),
+					lpszString,
+					nFit,
+					0);
+			}
+			v13 = lpszString;
+			GetTextExtentPoint32A(*(HDC *)(v4 + 8), lpszString, nFit, &Size);
+			v14 = Size.cx;
+			if ( a4 )
+			{
+				v15 = Size.cx + *(_DWORD *)(v4 + 28);
+				if ( v15 > a4[2] )
+					a4[2] = v15;
+				v16 = Size.cy + *(_DWORD *)(v4 + 32);
+				if ( v16 > a4[3] )
+					a4[3] = v16;
+			}
+			v17 = nFit;
+			*(_DWORD *)(v4 + 28) += v14;
+			v18 = *(_DWORD *)(v4 + 28);
+			if ( v17 < cchString )
+			{
+				v19 = &v13[v17];
+				if ( *v19 == 9 )
+				{
+					++nFit;
+					*(_DWORD *)(v4 + 28) = 8 * v29 + v18 - v18 % (8 * v29);
+				}
+				else
+				{
+					if ( *(_WORD *)v19 == 2573 )
+						nFit += 2;
+					v20 = *(_DWORD *)(v4 + 92);
+					*(_DWORD *)(v4 + 28) = 0;
+					*(_DWORD *)(v4 + 32) += v20;
+				}
+			}
+			cchString -= nFit;
+			lpszString += nFit;
+			continue;
+		}
+		v10 = *(_DWORD *)(v4 + 92);
+		*(_DWORD *)(v4 + 28) &= nFit;
+		*(_DWORD *)(v4 + 32) += v10;
+	}
+	while ( cchString > 0 );
+	if ( *(_DWORD *)(v4 + 28) > *(_DWORD *)(v4 + 20) - *(_DWORD *)(v4 + 12) - v29 + 1 )
+	{
+		v21 = *(_DWORD *)(v4 + 92);
+		*(_DWORD *)(v4 + 28) = 0;
+		*(_DWORD *)(v4 + 32) += v21;
+	}
+	if ( h )
+		SelectObject(*(HDC *)(v4 + 8), h);
+	SetTextColor(*(HDC *)(v4 + 8), color);
+	return 1;
+} */
+// 10029458: using guessed type int dword_10029458;
+// 1002946C: using guessed type int dword_1002946C;
+
+// ref: 0x100026B9
+signed int bn_prof_100026B9() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029454 = 2139095040;
+	return result;
+} */
+// 10029454: using guessed type int dword_10029454;
+
+// ref: 0x100026C4
+signed int UNKCALL bn_prof_100026C4(_DWORD *arg) { return 0; }
+/* {
+	if ( !arg )
+		return 0;
+	bn_prof_10002749((char *)dword_10029460, arg);
+	return 1;
+} */
+
+// ref: 0x100026F0
+void UNKCALL bn_prof_100026F0(_DWORD *arg) { return; }
+/* {
+	_DWORD *v1; // esi
+
+	v1 = arg;
+	bn_prof_1000287D(arg);
+	bn_prof_10002890(v1 + 1);
+} */
+
+// ref: 0x10002749
+int UNKCALL bn_prof_10002749(char *arg, _DWORD *a2) { return 0; }
+/* {
+	int v2; // eax
+	int v3; // eax
+	int v4; // esi
+
+	v2 = (int)a2;
+	if ( !a2 )
+		v2 = (int)(arg + 4);
+	v3 = *(_DWORD *)(v2 + 4);
+	if ( v3 > 0 )
+		v4 = v3;
+	else
+		v4 = 0;
+	bn_prof_100027D8(a2);
+	SMemFree(a2, ".?AU_DRAWTEXT@@", -2, 0);
+	return v4;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10002782
+_DWORD *UNKCALL bn_prof_10002782(int *arg, int a2, int a3, int a4) { return 0; }
+/* {
+	int v4; // eax
+	int *v5; // edi
+	_DWORD *v6; // eax
+	_DWORD *v7; // esi
+
+	v4 = a4;
+	LOBYTE(v4) = a4 | 8;
+	v5 = arg;
+	v6 = (_DWORD *)SMemAlloc(a3 + 96, ".?AU_DRAWTEXT@@", -2, v4);
+	if ( v6 )
+		v7 = bn_prof_100027CE(v6);
+	else
+		v7 = 0;
+	if ( a2 )
+		bn_prof_1000280C(v5, v7, a2, 0);
+	return v7;
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x100027CE
+_DWORD *UNKCALL bn_prof_100027CE(_DWORD *arg) { return 0; }
+/* {
+	_DWORD *result; // eax
+
+	result = arg;
+	*arg = 0;
+	arg[1] = 0;
+	return result;
+} */
+
+// ref: 0x100027D8
+void UNKCALL bn_prof_100027D8(_DWORD *arg) { return; }
+/* {
+	_DWORD *v1; // ST00_4
+
+	v1 = arg;
+	bn_prof_10002890(arg);
+	bn_prof_10002890(v1);
+} */
+
+// ref: 0x1000280C
+_DWORD *UNKCALL bn_prof_1000280C(int *arg, _DWORD *a2, int a3, _DWORD *a4) { return 0; }
+/* {
+	int *v4; // edi
+	_DWORD *v5; // esi
+	_DWORD *result; // eax
+	int v7; // ecx
+	int v8; // edx
+	int v9; // ecx
+	int v10; // edx
+
+	v4 = arg;
+	v5 = a2;
+	if ( !a2 )
+		v5 = arg + 1;
+	if ( *v5 )
+		bn_prof_10002890(v5);
+	result = a4;
+	if ( !a4 )
+		result = v4 + 1;
+	if ( a3 == 1 )
+	{
+		*v5 = result;
+		v5[1] = result[1];
+		v8 = result[1];
+		v9 = *v4;
+		if ( v8 > 0 )
+		{
+			if ( v9 < 0 )
+				v9 = (int)result - *(_DWORD *)(*result + 4);
+			v10 = v9 + v8;
+		}
+		else
+		{
+			v10 = ~v8;
+		}
+		*(_DWORD *)v10 = v5;
+		result[1] = a2;
+	}
+	else if ( a3 == 2 )
+	{
+		v7 = *result;
+		*v5 = *result;
+		v5[1] = *(_DWORD *)(v7 + 4);
+		*(_DWORD *)(v7 + 4) = a2;
+		*result = v5;
+	}
+	return result;
+} */
+
+// ref: 0x1000287D
+void UNKCALL bn_prof_1000287D(_DWORD *arg) { return; }
+/* {
+	_DWORD *v1; // esi
+	_DWORD *v2; // ecx
+
+	v1 = arg;
+	while ( 1 )
+	{
+		v2 = (_DWORD *)v1[2];
+		if ( (signed int)v2 <= 0 )
+			break;
+		bn_prof_10002890(v2);
+	}
+} */
+
+// ref: 0x10002890
+void UNKCALL bn_prof_10002890(_DWORD *arg) { return; }
+/* {
+	int v1; // esi
+	int v2; // edx
+	int v3; // edx
+
+	v1 = *arg;
+	if ( *arg )
+	{
+		v2 = arg[1];
+		if ( v2 > 0 )
+			v3 = (int)arg + v2 - *(_DWORD *)(v1 + 4);
+		else
+			v3 = ~v2;
+		*(_DWORD *)v3 = v1;
+		*(_DWORD *)(*arg + 4) = arg[1];
+		*arg = 0;
+		arg[1] = 0;
+	}
+} */

--- a/DiabloUI/bnetgw.cpp
+++ b/DiabloUI/bnetgw.cpp
@@ -1,0 +1,482 @@
+// ref: 0x100028C2
+void UNKCALL BNetGW_100028C2(_DWORD *arg) { return; }
+/* {
+	_DWORD *v1; // esi
+	bool v2; // zf
+	bool v3; // sf
+	int v4; // edi
+	int v5; // eax
+	int v6; // edi
+	int v7; // ST08_4
+	int v8; // eax
+	signed int v9; // eax
+	struct _TIME_ZONE_INFORMATION TimeZoneInformation; // [esp+Ch] [ebp-B8h]
+	char *v11; // [esp+B8h] [ebp-Ch]
+	int v12; // [esp+BCh] [ebp-8h]
+	int v13; // [esp+C0h] [ebp-4h]
+
+	v1 = arg;
+	arg[2] = 0;
+	arg[3] = 0;
+	arg[4] = 0;
+	arg[5] = 0;
+	arg[6] = 0;
+	*(_BYTE *)arg = 0;
+	BNetGW_10002C23(arg);
+	if ( !v1[4] )
+		goto LABEL_15;
+	if ( v1[6] < 0x3E8u )
+	{
+		v1[1] = 0;
+		BNetGW_10002A07(v1);
+		SRegDeleteValue("Configuration", "Battle.net gateways", 2u);
+	}
+	if ( !v1[4] )
+LABEL_15:
+		BNetGW_10002C51(v1);
+	if ( v1[6] >= 0x3E8u )
+	{
+		v2 = v1[5] == 0;
+		v3 = v1[5] < 0;
+		v4 = v1[4];
+		v13 = -2;
+		v12 = 0;
+		if ( !v3 && !v2 )
+		{
+			do
+			{
+				v5 = SStrLen(v4) + 1;
+				v12 += v5;
+				v4 += v5;
+				++v13;
+			}
+			while ( v12 < v1[5] );
+		}
+		v6 = v1[4];
+		v7 = v1[4];
+		v1[2] = v13 / 3;
+		v8 = SStrLen(v7);
+		v9 = strtoul((const char *)(v6 + v8 + 1), &v11, 10);
+		v1[3] = v9;
+		v1[1] = 0;
+		if ( v9 < 1 || v9 > v1[2] )
+		{
+			SMemZero(&TimeZoneInformation, 172);
+			GetTimeZoneInformation(&TimeZoneInformation);
+			BNetGW_100029BF(v1, TimeZoneInformation.Bias);
+		}
+	}
+	else
+	{
+		v1[2] = 0;
+		v1[3] = 0;
+	}
+} */
+// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+// 100103C4: using guessed type int __stdcall SMemZero(_DWORD, _DWORD);
+// 100103CA: using guessed type int __stdcall SRegDeleteValue(const char *, const char *, unsigned int);
+
+// ref: 0x100029BF
+void UNKCALL BNetGW_100029BF(_DWORD *arg, int a2) { return; }
+/* {
+	_DWORD *v2; // esi
+	char *v3; // edi
+	signed int v4; // ebx
+	signed int v5; // ebp
+	int v6; // eax
+	int v7; // eax
+
+	v2 = arg;
+	v3 = (char *)1;
+	v4 = 1380;
+	v5 = 1;
+	if ( arg[2] >= 1 )
+	{
+		do
+		{
+			v6 = BNetGW_10002AF0(v2, v3);
+			v7 = abs(60 * v6 - a2);
+			if ( v7 < v4 )
+			{
+				v4 = v7;
+				v5 = (signed int)v3;
+			}
+			++v3;
+		}
+		while ( (signed int)v3 <= v2[2] );
+	}
+	BNetGW_10002B51(v2, v5);
+} */
+
+// ref: 0x10002A07
+int UNKCALL BNetGW_10002A07(_DWORD *arg) { return 0; }
+/* {
+	_DWORD *v1; // esi
+	int v2; // edi
+	_BYTE *v3; // ecx
+	const char *v4; // eax
+	int result; // eax
+
+	v1 = arg;
+	if ( arg[1] )
+	{
+		v2 = arg[4];
+		if ( v2 )
+		{
+			v3 = (_BYTE *)(v2 + SStrLen(arg[4]) + 1);
+			*v3 = v1[3] / 10 + 48;
+			v4 = "Override Battle.net gateways";
+			v3[1] = v1[3] % 10 + 48;
+			if ( !v1[7] )
+				v4 = "Battle.net gateways";
+			SRegSaveData("Configuration", v4, 0x82u, (void *)v1[4], v1[5]);
+		}
+	}
+	result = v1[4];
+	if ( result )
+	{
+		result = SMemFree(result, "C:\\Src\\Diablo\\DiabloUI\\BNetGW.cpp", 152, 0);
+		v1[4] = 0;
+		v1[5] = 0;
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+// 100103D0: using guessed type int __stdcall SRegSaveData(const char *, const char *, unsigned int, void *, unsigned int);
+
+// ref: 0x10002A84
+_DWORD *UNKCALL BNetGW_10002A84(_DWORD *arg, signed int a2) { return 0; }
+/* {
+	signed int v2; // eax
+	signed int v3; // ebx
+	int v4; // esi
+	int v5; // edi
+	bool v6; // sf
+	unsigned char v7; // of
+	int v8; // eax
+	_DWORD *result; // eax
+	_DWORD *v10; // [esp+8h] [ebp-4h]
+	_DWORD *v11; // [esp+14h] [ebp+8h]
+
+	v10 = arg;
+	if ( !arg[4] )
+		return arg;
+	v2 = a2;
+	v3 = 1;
+	if ( a2 < 1 || a2 > arg[2] )
+		return arg;
+	v4 = 3 * a2;
+	v5 = 0;
+	v11 = (_DWORD *)arg[4];
+	if ( 3 * v2 <= 1 )
+	{
+LABEL_7:
+		v7 = __OFSUB__(v5, arg[5]);
+		v6 = v5 - arg[5] < 0;
+	}
+	else
+	{
+		while ( 1 )
+		{
+			v7 = __OFSUB__(v5, arg[5]);
+			v6 = v5 - arg[5] < 0;
+			if ( v5 >= arg[5] )
+				break;
+			v8 = SStrLen(v11);
+			arg = v10;
+			v11 = (_DWORD *)((char *)v11 + ++v8);
+			v5 += v8;
+			if ( ++v3 >= v4 )
+				goto LABEL_7;
+		}
+	}
+	if ( !(v6 ^ v7) )
+		return arg;
+	result = v11;
+	if ( v3 > v4 )
+		return arg;
+	return result;
+} */
+// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+
+// ref: 0x10002AE5
+signed int BNetGW_10002AE5() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029478 = 2139095040;
+	return result;
+} */
+// 10029478: using guessed type int dword_10029478;
+
+// ref: 0x10002AF0
+int UNKCALL BNetGW_10002AF0(_DWORD *arg, char *a2) { return 0; }
+/* {
+	const char *v2; // eax
+	const char *v3; // esi
+
+	v2 = (const char *)BNetGW_10002A84(arg, (signed int)a2);
+	v3 = v2;
+	if ( *v2 )
+		v3 = &v2[SStrLen(v2) + 1];
+	return strtol(v3, &a2, 10);
+} */
+// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+
+// ref: 0x10002B21
+_BYTE *UNKCALL BNetGW_10002B21(_DWORD *arg, signed int a2) { return 0; }
+/* {
+	_DWORD *v2; // eax
+	_BYTE *v3; // esi
+
+	v2 = BNetGW_10002A84(arg, a2);
+	v3 = v2;
+	if ( *(_BYTE *)v2 )
+	{
+		v3 = (char *)v2 + SStrLen(v2) + 1;
+		if ( *v3 )
+			v3 += SStrLen(v3) + 1;
+	}
+	return v3;
+} */
+// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+
+// ref: 0x10002B51
+void UNKCALL BNetGW_10002B51(_DWORD *arg, signed int a2) { return; }
+/* {
+	signed int v2; // eax
+
+	if ( arg[4] )
+	{
+		v2 = a2;
+		if ( a2 >= 1 && a2 <= arg[2] )
+		{
+			if ( a2 > 99 )
+				v2 = 99;
+			arg[3] = v2;
+			arg[1] = 1;
+		}
+	}
+} */
+
+// ref: 0x10002B78
+char *UNKCALL BNetGW_10002B78(_DWORD *arg, char *a2) { return 0; }
+/* {
+	_DWORD *v2; // esi
+	char *result; // eax
+	char *v4; // ST08_4
+	void *v5; // eax
+	char *v6; // [esp+Ch] [ebp-4h]
+
+	v2 = arg;
+	v6 = 0;
+	result = (char *)SRegLoadData("Configuration", a2, 0x82u, 0, 0, (unsigned int *)&v6);
+	if ( result )
+	{
+		result = v6;
+		if ( v6 )
+		{
+			v4 = v6;
+			v2[5] = v6;
+			v5 = (void *)SMemAlloc(v4, "C:\\Src\\Diablo\\DiabloUI\\BNetGW.cpp", 263, 0);
+			v2[4] = v5;
+			if ( !SRegLoadData("Configuration", a2, 0x82u, v5, v2[5], 0) )
+			{
+				SMemFree(v2[4], "C:\\Src\\Diablo\\DiabloUI\\BNetGW.cpp", 271, 0);
+				v2[4] = 0;
+				v2[5] = 0;
+			}
+			result = (char *)v2[4];
+			v2[6] = 0;
+			if ( result )
+			{
+				a2 = result;
+				v2[6] = strtoul(result, &a2, 10);
+				result = (char *)v2[4];
+				if ( result == a2 )
+					v2[6] = 0;
+			}
+		}
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100103D6: using guessed type int __stdcall SRegLoadData(const char *, const char *, unsigned int, void *, unsigned int, unsigned int *);
+
+// ref: 0x10002C23
+char *UNKCALL BNetGW_10002C23(_DWORD *arg) { return 0; }
+/* {
+	_DWORD *v1; // esi
+	char *result; // eax
+
+	v1 = arg;
+	arg[7] = 0;
+	result = BNetGW_10002B78(arg, "Override Battle.net gateways");
+	if ( !v1[4] )
+		return BNetGW_10002B78(v1, "Battle.net gateways");
+	v1[7] = 1;
+	return result;
+} */
+
+// ref: 0x10002C51
+int UNKCALL BNetGW_10002C51(_DWORD *arg) { return 0; }
+/* {
+	int result; // eax
+	char *v2; // edi
+	char *v3; // esi
+	unsigned int v4; // ebx
+	char *v5; // esi
+	_BYTE *v6; // esi
+	char *v7; // eax
+	char *v8; // eax
+	_BYTE *v9; // esi
+	char *v10; // esi
+	char v11; // al
+	unsigned int v12; // esi
+	char *v13; // [esp+4h] [ebp-10h]
+	int v14; // [esp+8h] [ebp-Ch]
+	int v15; // [esp+Ch] [ebp-8h]
+	_DWORD *v16; // [esp+10h] [ebp-4h]
+
+	v15 = 0;
+	v16 = arg;
+	result = BNetGW_10002DBF(&v15);
+	v2 = (char *)result;
+	v14 = result;
+	if ( result )
+	{
+		v3 = (char *)SMemAlloc(2 * v15, "C:\\Src\\Diablo\\DiabloUI\\BNetGW.cpp", 358, 0);
+		v13 = v3;
+		v4 = (unsigned int)&v2[v15];
+		sprintf(v3, "%d", 1000);
+		v5 = &v3[SStrLen(v3) + 1];
+		*v5++ = 48;
+		*v5++ = 48;
+		*v5 = 0;
+		v6 = v5 + 1;
+		if ( (unsigned int)v2 < v4 )
+		{
+			if ( (unsigned int)v2 >= v4 )
+				goto LABEL_8;
+			do
+			{
+				if ( *v2 == 35 )
+				{
+					v7 = BNetGW_10002DEB(v2, v4);
+					v8 = BNetGW_10002E0B(v7, v4);
+				}
+				else
+				{
+					do
+					{
+						if ( isspace(*v2) )
+							break;
+						*v6++ = *v2++;
+					}
+					while ( (unsigned int)v2 < v4 );
+LABEL_8:
+					*v6 = 0;
+					v9 = v6 + 1;
+					if ( (unsigned int)v2 < v4 )
+					{
+						do
+						{
+							if ( !isspace(*v2) )
+								break;
+							++v2;
+						}
+						while ( (unsigned int)v2 < v4 );
+						while ( (unsigned int)v2 < v4 && !isspace(*v2) )
+							*v9++ = *v2++;
+					}
+					*v9 = 0;
+					v10 = v9 + 1;
+					if ( (unsigned int)v2 < v4 )
+					{
+						do
+						{
+							if ( !isspace(*v2) )
+								break;
+							++v2;
+						}
+						while ( (unsigned int)v2 < v4 );
+						while ( (unsigned int)v2 < v4 )
+						{
+							v11 = *v2;
+							if ( *v2 == 13 || v11 == 10 )
+								break;
+							*v10++ = v11;
+							++v2;
+						}
+					}
+					*v10 = 0;
+					v6 = v10 + 1;
+					v8 = BNetGW_10002E0B(v2, v4);
+				}
+				v2 = v8;
+			}
+			while ( (unsigned int)v8 < v4 );
+		}
+		*v6 = 0;
+		v12 = v6 - v13 + 1;
+		SRegSaveData("Configuration", "Battle.net gateways", 0x82u, v13, v12);
+		SMemFree(v14, "C:\\Src\\Diablo\\DiabloUI\\BNetGW.cpp", 429, 0);
+		result = (int)v16;
+		v16[5] = v12;
+		*(_DWORD *)(result + 16) = v13;
+		*(_DWORD *)(result + 24) = 1000;
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+// 100103D0: using guessed type int __stdcall SRegSaveData(const char *, const char *, unsigned int, void *, unsigned int);
+
+// ref: 0x10002DBF
+int UNKCALL BNetGW_10002DBF(_DWORD *arg) { return 0; }
+/* {
+	_DWORD *v1; // esi
+	int v3; // [esp+4h] [ebp-8h]
+	int v4; // [esp+8h] [ebp-4h]
+
+	v4 = 0;
+	v1 = arg;
+	SFileLoadFile("rez\\gateways.txt", &v3, &v4, 0, 0);
+	*v1 = v4;
+	return v3;
+} */
+// 100103DC: using guessed type int __stdcall SFileLoadFile(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10002DEB
+char *__stdcall BNetGW_10002DEB(char *a1, unsigned int a2) { return 0; }
+/* {
+	char *result; // eax
+	char v3; // cl
+
+	for ( result = a1; (unsigned int)result < a2; ++result )
+	{
+		v3 = *result;
+		if ( !*result || v3 == 13 || v3 == 10 )
+			break;
+	}
+	return result;
+} */
+
+// ref: 0x10002E0B
+char *__stdcall BNetGW_10002E0B(char *a1, unsigned int a2) { return 0; }
+/* {
+	char *result; // eax
+	char v3; // cl
+
+	for ( result = a1; (unsigned int)result < a2; ++result )
+	{
+		v3 = *result;
+		if ( !*result || v3 != 13 && v3 != 10 )
+			break;
+	}
+	return result;
+} */

--- a/DiabloUI/connect.cpp
+++ b/DiabloUI/connect.cpp
@@ -1,0 +1,1063 @@
+// ref: 0x10002E2B
+int Connect_10002E2B() { return 0; }
+/* {
+	int *v0; // edi
+	int result; // eax
+
+	if ( dword_100295D8 )
+	{
+		SMemFree(dword_100295D8, "C:\\Src\\Diablo\\DiabloUI\\Connect.cpp", 124, 0);
+		dword_100295D8 = 0;
+	}
+	if ( dword_100295DC )
+	{
+		SMemFree(dword_100295DC, "C:\\Src\\Diablo\\DiabloUI\\Connect.cpp", 129, 0);
+		dword_100295DC = 0;
+	}
+	v0 = dword_100295E8;
+	do
+	{
+		if ( *v0 )
+		{
+			STransDelete(*v0);
+			*v0 = 0;
+		}
+		++v0;
+	}
+	while ( (signed int)v0 < (signed int)&dword_10029610 );
+	if ( dword_100295E0 )
+	{
+		SMemFree(dword_100295E0, "C:\\Src\\Diablo\\DiabloUI\\Connect.cpp", 141, 0);
+		dword_100295E0 = 0;
+	}
+	result = dword_100295E4;
+	if ( dword_100295E4 )
+	{
+		result = SMemFree(dword_100295E4, "C:\\Src\\Diablo\\DiabloUI\\Connect.cpp", 146, 0);
+		dword_100295E4 = 0;
+	}
+	return result;
+} */
+// 1001033A: using guessed type int __stdcall STransDelete(_DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100295D8: using guessed type int dword_100295D8;
+// 100295DC: using guessed type int dword_100295DC;
+// 100295E0: using guessed type int dword_100295E0;
+// 100295E4: using guessed type int dword_100295E4;
+// 10029610: using guessed type int dword_10029610;
+
+// ref: 0x10002EC4
+signed int Connect_10002EC4() { return 0; }
+/* {
+	int *v0; // esi
+	int v1; // ebx
+	int v3; // [esp+4h] [ebp-14h]
+	int v4; // [esp+8h] [ebp-10h]
+	int v5; // [esp+Ch] [ebp-Ch]
+	int v6; // [esp+10h] [ebp-8h]
+	int v7; // [esp+14h] [ebp-4h]
+
+	v7 = 0;
+	if ( !dword_100295D8 && !dword_100295E8[0] )
+	{
+		local_100078BE((int)"ui_art\\heroport.pcx", &dword_100295D8, &dword_100294A8);
+		local_100078BE((int)"ui_art\\spwnport.pcx", &dword_100295DC, 0);
+		local_100078BE((int)"ui_art\\heronum.pcx", &v7, &dword_100295C8);
+		local_100078BE((int)"ui_art\\special.pcx", &dword_100295E0, &dword_100295B8);
+		dword_100295D4 = 14;
+		dword_100295D0 = dword_100295CC / 10;
+		dword_100294A4 = dword_100295BC / 8;
+		dword_100295B0 = dword_100295CC / 10 * dword_100295C8;
+		dword_100295C0 = 14 * dword_100294A8;
+		v0 = dword_100295E8;
+		dword_100295E4 = SMemAlloc(14 * dword_100294A8, "C:\\Src\\Diablo\\DiabloUI\\Connect.cpp", 194, 0);
+		memset(dword_100295E8, 0, 0x28u);
+		if ( v7 )
+		{
+			v1 = 0;
+			do
+			{
+				v3 = 0;
+				v5 = dword_100295C8 - 1;
+				v4 = v1 * dword_100295D0;
+				v6 = dword_100295D0 + v1 * dword_100295D0 - 1;
+				STransCreateI(v7, dword_100295C8, dword_100295D0, 8, &v3, 16777455, v0);
+				++v0;
+				++v1;
+			}
+			while ( (signed int)v0 < (signed int)&dword_10029610 );
+			SMemFree(v7, "C:\\Src\\Diablo\\DiabloUI\\Connect.cpp", 218, 0);
+		}
+	}
+	return 1;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010346: using guessed type int __stdcall STransCreateI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100294A4: using guessed type int dword_100294A4;
+// 100294A8: using guessed type int dword_100294A8;
+// 100295B0: using guessed type int dword_100295B0;
+// 100295B8: using guessed type int dword_100295B8;
+// 100295BC: using guessed type int dword_100295BC;
+// 100295C0: using guessed type int dword_100295C0;
+// 100295C8: using guessed type int dword_100295C8;
+// 100295CC: using guessed type int dword_100295CC;
+// 100295D0: using guessed type int dword_100295D0;
+// 100295D4: using guessed type int dword_100295D4;
+// 100295D8: using guessed type int dword_100295D8;
+// 100295DC: using guessed type int dword_100295DC;
+// 100295E0: using guessed type int dword_100295E0;
+// 100295E4: using guessed type int dword_100295E4;
+// 10029610: using guessed type int dword_10029610;
+
+// ref: 0x10003009
+void __cdecl UiArtCallback() { return; }
+//int __stdcall UiArtCallback(int a1, unsigned int a2, int a3, int a4, int a5, int a6, int a7, int a8) { return 0; }
+/* {
+	int result; // eax
+	CHAR v9; // [esp+8h] [ebp-104h]
+	char v10; // [esp+9h] [ebp-103h]
+	short v11; // [esp+109h] [ebp-3h]
+	char v12; // [esp+10Bh] [ebp-1h]
+
+	v9 = byte_10029448;
+	memset(&v10, 0, 0x100u);
+	v11 = 0;
+	v12 = 0;
+	SStrCopy(&v9, "ui_art\\", 260);
+	if ( a1 == 1112425812 )
+	{
+		if ( a2 > 0x80000004 )
+		{
+			switch ( a2 )
+			{
+				case 0x80000005:
+					SStrPack(&v9, "bnconnbg.pcx", 0x104u);
+					return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				case 0x80000006:
+					SStrPack(&v9, "bnselchn.pcx", 0x104u);
+					return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				case 0x80000007:
+					SStrPack(&v9, "bnlogin.pcx", 0x104u);
+					return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				case 0x80000008:
+					SStrPack(&v9, "newaccount.pcx", 0x104u);
+					return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				case 0x80000009:
+					SStrPack(&v9, "changepassword.pcx", 0x104u);
+					return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				case 0x8000000A:
+					SStrPack(&v9, "bnladder.pcx", 0x104u);
+					return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				case 0x8000000B:
+					SStrPack(&v9, "badconn.pcx", 0x104u);
+					return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				case 0x8000000C:
+					SStrPack(&v9, "welcome.pcx", 0x104u);
+					return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				case 0x8000000D:
+					SStrPack(&v9, "lepopup.pcx", 0x104u);
+					return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				case 0x8000000E:
+					SStrPack(&v9, "tos.pcx", 0x104u);
+					return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				default:
+					break;
+			}
+		}
+		else
+		{
+			if ( a2 == -2147483644 )
+			{
+				SStrPack(&v9, "redlag.pcx", 0x104u);
+				return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+			}
+			if ( a2 > 7 )
+			{
+				switch ( a2 )
+				{
+					case 8u:
+LABEL_48:
+						SStrPack(&v9, "but_lrg.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+					case 0x80000000:
+						SStrPack(&v9, "bnbuttns.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+					case 0x80000001:
+						SStrPack(&v9, "chat_bkg.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+					case 0x80000002:
+						SStrPack(&v9, "greenlag.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+					case 0x80000003:
+						SStrPack(&v9, "yellolag.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				}
+			}
+			else
+			{
+				switch ( a2 )
+				{
+					case 7u:
+LABEL_47:
+						SStrPack(&v9, "but_med.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+					case 0u:
+						SStrPack(&v9, "bn_bkg.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+					case 2u:
+						SStrPack(&v9, "bnjoinbg.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+					case 3u:
+						SStrPack(&v9, "hpopup.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+					case 5u:
+LABEL_46:
+						SStrPack(&v9, "but_xsm.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+					case 6u:
+LABEL_11:
+						SStrPack(&v9, "but_sml.pcx", 0x104u);
+						return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+				}
+			}
+		}
+	}
+	else if ( a1 == 1230002254 )
+	{
+		if ( !a2 )
+		{
+			SStrPack(&v9, "ipx_bkg.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		}
+	}
+	else if ( !a1 && !a2 )
+	{
+		SStrPack(&v9, "connect.pcx", 0x104u);
+		return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+	}
+	switch ( a2 )
+	{
+		case 0u:
+		case 2u:
+			SStrPack(&v9, "menu.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 1u:
+		case 8u:
+			goto LABEL_48;
+		case 3u:
+		case 4u:
+			SStrPack(&v9, "lpopup.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 5u:
+			goto LABEL_46;
+		case 6u:
+			goto LABEL_11;
+		case 7u:
+			goto LABEL_47;
+		case 9u:
+			SStrPack(&v9, "xsmlogo.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0xAu:
+			SStrPack(&v9, "prog_bg.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0xBu:
+			SStrPack(&v9, "prog_fil.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0xCu:
+			SStrPack(&v9, "spopup.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0xDu:
+			SStrPack(&v9, "scrlarrw.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0xEu:
+			SStrPack(&v9, "scrlthmb.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0xFu:
+			SStrPack(&v9, "scrlbar.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x10u:
+			SStrPack(&v9, "cmel.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x11u:
+			SStrPack(&v9, "cmml.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x12u:
+			SStrPack(&v9, "cmbl.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x13u:
+			SStrPack(&v9, "cmec.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x14u:
+			SStrPack(&v9, "cmmc.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x15u:
+			SStrPack(&v9, "cmbc.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x16u:
+			SStrPack(&v9, "cmer.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x17u:
+			SStrPack(&v9, "cmmr.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x18u:
+			SStrPack(&v9, "cmbr.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x19u:
+			SStrPack(&v9, "slgray.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x1Au:
+			SStrPack(&v9, "slthumb.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x1Bu:
+			SStrPack(&v9, "slfocus.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x1Cu:
+			SStrPack(&v9, "slleft.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x1Du:
+			SStrPack(&v9, "slmiddle.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x1Eu:
+			SStrPack(&v9, "slright.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x20u:
+			SStrPack(&v9, "but_checkoff.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		case 0x21u:
+			SStrPack(&v9, "but_checkon.pcx", 0x104u);
+			return SBmpLoadImage(&v9, a3, a4, a5, a6, a7, a8);
+		default:
+			result = 0;
+			break;
+	}
+	return result;
+} */
+// 100103BE: using guessed type int __stdcall SBmpLoadImage(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100103E2: using guessed type unsigned int __stdcall SStrPack(char *, const char *, unsigned int);
+// 100103E8: using guessed type int __stdcall SStrCopy(_DWORD, _DWORD, _DWORD);
+
+// ref: 0x100033D1
+signed int Connect_100033D1() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_100294A0 = 2139095040;
+	return result;
+} */
+// 100294A0: using guessed type int dword_100294A0;
+
+// ref: 0x100033DC
+void __cdecl UiGetDataCallback() { return; }
+//BOOL __stdcall UiGetDataCallback(int a1, int a2, void *a3, int a4, int a5) { return 0; }
+/* {
+	signed int v5; // edi
+	_DWORD *v6; // esi
+	HCURSOR v7; // eax
+
+	v5 = 0;
+	if ( a1 != 1112425812 || a2 != 0x80000000 )
+	{
+		switch ( a2 )
+		{
+			case 1:
+				v5 = 16;
+				if ( !a3 )
+					goto LABEL_24;
+				if ( (unsigned int)a4 >= 0x10 )
+				{
+					memcpy(a3, "\r", 0x10u);
+					goto LABEL_24;
+				}
+				return 0;
+			case 2:
+				v6 = a3;
+				v5 = 4;
+				if ( !a3 )
+					goto LABEL_24;
+				if ( (unsigned int)a4 < 4 )
+					return 0;
+				v7 = LoadCursorA(hInstance, "DIABLO_LINKCURSOR");
+				break;
+			case 3:
+				v6 = a3;
+				v5 = 4;
+				if ( !a3 )
+					goto LABEL_24;
+				if ( (unsigned int)a4 < 4 )
+					return 0;
+				v7 = LoadCursorA(hInstance, "DIABLO_ARROWCURSOR");
+				break;
+			case 4:
+				v6 = a3;
+				v5 = 4;
+				if ( !a3 )
+					goto LABEL_24;
+				if ( (unsigned int)a4 < 4 )
+					return 0;
+				v7 = LoadCursorA(hInstance, "DIABLOIBEAM");
+				break;
+			default:
+				goto LABEL_24;
+		}
+		*v6 = v7;
+		if ( v7 )
+			goto LABEL_24;
+		return 0;
+	}
+	v5 = 4;
+	if ( a3 )
+	{
+		if ( (unsigned int)a4 >= 4 )
+		{
+			*(_DWORD *)a3 = 54;
+			goto LABEL_24;
+		}
+		return 0;
+	}
+LABEL_24:
+	if ( a5 )
+		*(_DWORD *)a5 = v5;
+	return v5 != 0;
+} */
+
+// ref: 0x100034AB
+void __cdecl UiSoundCallback() { return; }
+//int __stdcall UiSoundCallback(int a1, int a2, int a3) { return 0; }
+/* {
+	if ( a2 )
+	{
+		if ( a2 == 1 )
+			TitleSnd_1001031F();
+	}
+	else
+	{
+		TitleSnd_10010315();
+	}
+	return 0;
+} */
+
+// ref: 0x100034C8
+void __cdecl UiAuthCallback() { return; }
+//int __stdcall UiAuthCallback(int a1, int a2, char *a3, char a4, char *a5, LPSTR lpBuffer, int cchBufferMax) { return 0; }
+/* {
+	size_t v7; // edi
+	size_t v8; // ebx
+	int v9; // ebx
+	char *v10; // ebx
+	size_t v11; // eax
+	int v12; // eax
+	int v14; // eax
+	CHAR v15; // [esp+0h] [ebp-434h]
+	char v16; // [esp+100h] [ebp-334h]
+	char v17; // [esp+200h] [ebp-234h]
+	CHAR Buffer; // [esp+300h] [ebp-134h]
+	char v19; // [esp+400h] [ebp-34h]
+	unsigned short v20; // [esp+414h] [ebp-20h]
+	unsigned char v21; // [esp+416h] [ebp-1Eh]
+	char v22; // [esp+42Ch] [ebp-8h]
+	int v23; // [esp+430h] [ebp-4h]
+
+	v23 = 0;
+	if ( cchBufferMax )
+		*lpBuffer = 0;
+	v7 = strlen(a3) + 1;
+	v8 = strlen(a5) + 1;
+	if ( v7 > 0x100 || v8 > 0x100 )
+	{
+		if ( lpBuffer )
+			LoadStringA(hInstance, 0x413u, lpBuffer, cchBufferMax);
+		return 0;
+	}
+	memcpy(&v16, a3, v7);
+	memcpy(&v17, a5, v8);
+	if ( Connect_10003E61(&v16, &v19) )
+	{
+		if ( a1 == 1 )
+		{
+			if ( !(a4 & 9) )
+			{
+				v9 = 0;
+				while ( 1 )
+				{
+					LoadStringA(hInstance, v9 + 4, &Buffer, 256);
+					if ( strstr(&v17, &Buffer) )
+						break;
+					if ( ++v9 >= 3 )
+						goto LABEL_16;
+				}
+				if ( v21 != v9 )
+					goto LABEL_20;
+				v23 = 1;
+LABEL_16:
+				LoadStringA(hInstance, 0x408u, &Buffer, 256);
+				v10 = strstr(&v17, &Buffer);
+				if ( v10 )
+				{
+					v11 = strlen(&Buffer);
+					v12 = atoi(&v10[v11]);
+					if ( v20 >= v12 )
+						return 1;
+				}
+				if ( v23 )
+					return 1;
+LABEL_20:
+				if ( lpBuffer )
+				{
+					LoadStringA(hInstance, 0x415u, &v15, 256);
+					v14 = sprintf(&Buffer, &v15, &v17) + 1;
+					if ( cchBufferMax >= v14 )
+					{
+						memcpy(lpBuffer, &Buffer, v14);
+					}
+					else
+					{
+						memcpy(lpBuffer, &Buffer, cchBufferMax);
+						lpBuffer[cchBufferMax - 1] = 0;
+					}
+				}
+				return 0;
+			}
+		}
+		else if ( !(a4 & 8) )
+		{
+			Connect_10003DAF(&v17, (int)&v22, 0, 0);
+			if ( (_BYTE)v23 == 1 )
+			{
+				if ( v20 < 0x14u )
+				{
+					if ( lpBuffer )
+						LoadStringA(hInstance, 0x411u, lpBuffer, cchBufferMax);
+					return 0;
+				}
+			}
+			else if ( (_BYTE)v23 == 2 && v20 < 0x1Eu )
+			{
+				if ( lpBuffer )
+					LoadStringA(hInstance, 0x412u, lpBuffer, cchBufferMax);
+				return 0;
+			}
+		}
+		return 1;
+	}
+	if ( lpBuffer )
+		LoadStringA(hInstance, 0x414u, lpBuffer, cchBufferMax);
+	return 0;
+} */
+
+// ref: 0x10003710
+void __cdecl UiDrawDescCallback() { return; }
+//int __stdcall UiDrawDescCallback(int a1, COLORREF color, LPCSTR lpString, char *a4, int a5, UINT align, time_t a7, int a8) { return 0; }
+/* {
+	int v8; // ebx
+	int v9; // esi
+	int v10; // esi
+	size_t v11; // eax
+	UINT v13; // eax
+	BOOL v14; // esi
+	int v15; // eax
+	int v16; // eax
+	HDC v17; // ST20_4
+	struct tm *v18; // eax
+	struct tm *v19; // edi
+	signed int v20; // eax
+	int v21; // eax
+	int v22; // eax
+	UINT v23; // eax
+	int v24; // esi
+	int v25; // eax
+	int v26; // eax
+	signed int v27; // [esp-4h] [ebp-2E8h]
+	char v28[4]; // [esp+Ch] [ebp-2D8h]
+	CHAR String; // [esp+10Ch] [ebp-1D8h]
+	CHAR Buffer; // [esp+18Ch] [ebp-158h]
+	char v31; // [esp+18Dh] [ebp-157h]
+	short v32; // [esp+209h] [ebp-DBh]
+	char v33; // [esp+20Bh] [ebp-D9h]
+	CHAR v34; // [esp+20Ch] [ebp-D8h]
+	int v35; // [esp+22Ch] [ebp-B8h]
+	struct tagPOINT v36; // [esp+248h] [ebp-9Ch]
+	struct tagTEXTMETRICA tm; // [esp+25Ch] [ebp-88h]
+	char v38; // [esp+294h] [ebp-50h]
+	CHAR v39; // [esp+2A0h] [ebp-44h]
+	unsigned short v40; // [esp+2A8h] [ebp-3Ch]
+	unsigned char v41; // [esp+2AAh] [ebp-3Ah]
+	unsigned char v42; // [esp+2ABh] [ebp-39h]
+	int v43; // [esp+2BCh] [ebp-28h]
+	struct tagPOINT pt; // [esp+2C0h] [ebp-24h]
+	char v45; // [esp+2C8h] [ebp-1Ch]
+	unsigned char v46; // [esp+2CCh] [ebp-18h]
+	struct tagRECT rc; // [esp+2D0h] [ebp-14h]
+	COLORREF v48; // [esp+2E0h] [ebp-4h]
+	LPCSTR lpStringa; // [esp+2F4h] [ebp+10h]
+
+	Buffer = byte_10029448;
+	v8 = a8;
+	memset(&v31, 0, 0x7Cu);
+	v9 = *(_DWORD *)(a8 + 16);
+	v32 = 0;
+	v33 = 0;
+	v10 = v9 & 1;
+	v11 = strlen(a4) + 1;
+	if ( v11 > 0x100 )
+		return 0;
+	memcpy(v28, a4, v11);
+	if ( color == 1 )
+	{
+		a8 = 0;
+		a4 = 0;
+		if ( !Connect_10003DAF(v28, (int)&v45, (int)&a8, (int)&a4) )
+			return 0;
+		color = SetTextColor(*(HDC *)(v8 + 24), 0xFFFFFFu);
+		v48 = SetBkColor(*(HDC *)(v8 + 24), v10 != 0 ? 0x808080 : 0);
+		if ( align & 1 )
+		{
+			v13 = strlen(lpString);
+			ExtTextOutA(
+				*(HDC *)(v8 + 24),
+				*(_DWORD *)(v8 + 28),
+				*(_DWORD *)(v8 + 32),
+				6u,
+				(const RECT *)(v8 + 28),
+				lpString,
+				v13,
+				0);
+		}
+		else
+		{
+			v14 = a8 && a4;
+			if ( v46 < 3u )
+				LoadStringA(hInstance, v46 + 1003, &Buffer, 128);
+			if ( align & 2 && v14 )
+			{
+				GetTextMetricsA(*(HDC *)(v8 + 24), &tm);
+				lpStringa = (LPCSTR)(tm.tmHeight + tm.tmExternalLeading);
+				MoveToEx(*(HDC *)(v8 + 24), *(_DWORD *)(v8 + 28), *(_DWORD *)(v8 + 32), &pt);
+				align = SetTextAlign(*(HDC *)(v8 + 24), 1u);
+				v15 = strlen(&Buffer);
+				TextOutA(*(HDC *)(v8 + 24), 0, 0, &Buffer, v15);
+				LoadStringA(hInstance, 0x409u, &String, 128);
+				MoveToEx(*(HDC *)(v8 + 24), *(_DWORD *)(v8 + 28), (int)&lpStringa[*(_DWORD *)(v8 + 32)], 0);
+				v16 = strlen(&String);
+				TextOutA(*(HDC *)(v8 + 24), 0, 0, &String, v16);
+				v17 = *(HDC *)(v8 + 24);
+				qmemcpy(&v35, (const void *)v8, 0x30u);
+				GetCurrentPositionEx(v17, &v36);
+				SetTextAlign(*(HDC *)(v8 + 24), 0);
+				dword_10029614 = 1;
+				UiDrawDescCallback(a1, 2u, (LPCSTR)a8, a4, 0, 1u, 0, (int)&v35);
+				dword_10029614 = 0;
+				if ( a7 )
+				{
+					SetTextAlign(*(HDC *)(v8 + 24), 1u);
+					LoadStringA(hInstance, 0x40Cu, &v39, 32);
+					LoadStringA(hInstance, 0x40Du, &v34, 32);
+					v18 = localtime(&a7);
+					v19 = v18;
+					if ( v18 )
+					{
+						LoadStringA(hInstance, (v18->tm_hour > 12) + 1034, (LPSTR)&rc.top, 10);
+						v20 = v19->tm_hour;
+						if ( v20 > 12 )
+							v19->tm_hour = v20 - 12;
+						if ( !v19->tm_hour )
+							v19->tm_hour = 12;
+						sprintf(&String, &v39, &v34, v19->tm_hour, v19->tm_min, &rc.top);
+						MoveToEx(
+							*(HDC *)(v8 + 24),
+							*(_DWORD *)(v8 + 28),
+							*(_DWORD *)(v8 + 32) + 2 * (_DWORD)lpStringa,
+							0);
+						v21 = strlen(&String);
+						TextOutA(*(HDC *)(v8 + 24), 0, 0, &String, v21);
+					}
+				}
+				MoveToEx(*(HDC *)(v8 + 24), pt.x, pt.y, 0);
+				SetTextAlign(*(HDC *)(v8 + 24), align);
+			}
+			else
+			{
+				v22 = strlen(&Buffer);
+				TextOutA(*(HDC *)(v8 + 24), *(_DWORD *)(v8 + 28), *(_DWORD *)(v8 + 32), &Buffer, v22);
+			}
+		}
+		goto LABEL_56;
+	}
+	GetTextMetricsA(*(HDC *)(v8 + 24), &tm);
+	a4 = (char *)((tm.tmHeight - dword_100295D4) / 2 + 1);
+	if ( !dword_10029614 )
+	{
+		color = SetTextColor(*(HDC *)(v8 + 24), 0xFFFFu);
+		v48 = SetBkColor(*(HDC *)(v8 + 24), v10 != 0 ? 0x808080 : 0);
+	}
+	if ( align & 1 )
+	{
+		v23 = strlen(lpString);
+		ExtTextOutA(
+			*(HDC *)(v8 + 24),
+			*(_DWORD *)(v8 + 28) + dword_100294A8 + 2,
+			*(_DWORD *)(v8 + 32),
+			6u,
+			(const RECT *)(v8 + 28),
+			lpString,
+			v23,
+			0);
+	}
+	if ( a5 )
+	{
+		if ( a5 & 0x20 )
+		{
+			v27 = 5;
+LABEL_45:
+			v24 = v27;
+			goto LABEL_46;
+		}
+		if ( a5 & 1 )
+		{
+			v24 = 0;
+LABEL_46:
+			SetRect(&rc, 0, 0, dword_100295B8 - 1, dword_100294A4 - 1);
+			OffsetRect(&rc, 0, dword_100294A4 * v24);
+			SDlgBltToWindowI(
+				*(_DWORD *)(v8 + 20),
+				0,
+				*(_DWORD *)(v8 + 28),
+				&a4[*(_DWORD *)(v8 + 32)],
+				dword_100295E0,
+				&rc,
+				&dword_100295B8,
+				-1,
+				0,
+				13369376);
+			goto LABEL_55;
+		}
+		if ( a5 & 2 )
+		{
+			v27 = 2;
+			goto LABEL_45;
+		}
+		if ( a5 & 4 )
+		{
+			v27 = 3;
+			goto LABEL_45;
+		}
+		if ( a5 & 8 )
+		{
+			v25 = (a1 != 1112425812) - 1;
+			LOBYTE(v25) = v25 & 0xFD;
+			v24 = v25 + 4;
+			goto LABEL_46;
+		}
+	}
+	if ( *(_DWORD *)v28 == 1128808788 )
+	{
+		v27 = 6;
+		goto LABEL_45;
+	}
+	if ( *(_DWORD *)v28 == 1397053520 || *(_DWORD *)v28 == 1397966930 || *(_DWORD *)v28 == 1398030674 )
+	{
+		v27 = 7;
+		goto LABEL_45;
+	}
+	if ( Connect_10003E61(v28, &v38) )
+	{
+		if ( v43 )
+		{
+			if ( dword_100295DC )
+				SBltROP3(
+					dword_100295E4,
+					dword_100295DC,
+					dword_100294A8,
+					dword_100295D4,
+					dword_100294A8,
+					dword_100294A8,
+					0,
+					13369376);
+		}
+		else
+		{
+			SBltROP3(
+				dword_100295E4,
+				dword_100295D8 + dword_100295C0 * (v41 + 3 * v42),
+				dword_100294A8,
+				dword_100295D4,
+				dword_100294A8,
+				dword_100294A8,
+				0,
+				13369376);
+		}
+		v26 = v40 / 10;
+		if ( v26 )
+			STransBlt(
+				dword_100294A8 + dword_100295E4 + 4 * dword_100294A8 + 14,
+				0,
+				0,
+				dword_100294A8,
+				dword_100295E8[v26]);
+		STransBlt(
+			dword_100295E4 + 4 * (dword_100294A8 + 4) + dword_100294A8 + 4,
+			0,
+			0,
+			dword_100294A8,
+			dword_100295E8[v40 % 10]);
+		SetRect(&rc, 0, 0, dword_100294A8 - 1, dword_100295D4 - 1);
+		SDlgBltToWindowI(
+			*(_DWORD *)(v8 + 20),
+			0,
+			*(_DWORD *)(v8 + 28),
+			&a4[*(_DWORD *)(v8 + 32)],
+			dword_100295E4,
+			&rc,
+			&dword_100294A8,
+			-1,
+			0,
+			13369376);
+	}
+LABEL_55:
+	if ( !dword_10029614 )
+	{
+LABEL_56:
+		SetTextColor(*(HDC *)(v8 + 24), color);
+		SetBkColor(*(HDC *)(v8 + 24), v48);
+	}
+	return 1;
+} */
+// 1001036A: using guessed type int __stdcall STransBlt(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100103EE: using guessed type int __stdcall SDlgBltToWindowI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100103F4: using guessed type int __stdcall SBltROP3(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100294A4: using guessed type int dword_100294A4;
+// 100294A8: using guessed type int dword_100294A8;
+// 100295B8: using guessed type int dword_100295B8;
+// 100295C0: using guessed type int dword_100295C0;
+// 100295D4: using guessed type int dword_100295D4;
+// 100295D8: using guessed type int dword_100295D8;
+// 100295DC: using guessed type int dword_100295DC;
+// 100295E0: using guessed type int dword_100295E0;
+// 100295E4: using guessed type int dword_100295E4;
+// 10029614: using guessed type int dword_10029614;
+
+// ref: 0x10003CE4
+void __cdecl UiCategoryCallback() { return; }
+//signed int __stdcall UiCategoryCallback(int a1, int a2, int a3, int a4, int a5, _DWORD *a6, _DWORD *a7) { return 0; }
+/* {
+	*a7 = 0xFFFF;
+	*a6 = Connect_10003D04(byte_100294B0);
+	return 1;
+} */
+
+// ref: 0x10003D04
+int UNKCALL Connect_10003D04(char *arg) { return 0; }
+/* {
+	char v3; // [esp+0h] [ebp-22Ch]
+	char v4; // [esp+200h] [ebp-2Ch]
+	unsigned short v5; // [esp+214h] [ebp-18h]
+
+	strcpy(&v3, arg);
+	if ( !Connect_10003E61(&v3, &v4) || v5 == 1 )
+		return 0;
+	if ( (signed int)v5 < 4 )
+		return 1;
+	if ( (signed int)v5 < 6 )
+		return 2;
+	if ( (signed int)v5 < 8 )
+		return 3;
+	if ( (signed int)v5 < 10 )
+		return 4;
+	if ( (signed int)v5 < 13 )
+		return 5;
+	if ( (signed int)v5 < 17 )
+		return 6;
+	if ( (signed int)v5 < 20 )
+		return 7;
+	if ( (signed int)v5 < 25 )
+		return 8;
+	if ( (signed int)v5 < 30 )
+		return 9;
+	if ( (signed int)v5 < 35 )
+		return 10;
+	if ( (signed int)v5 < 40 )
+		return 11;
+	return ((signed int)v5 >= 48) + 12;
+} */
+
+// ref: 0x10003DAF
+int __fastcall Connect_10003DAF(char *a1, int a2, int a3, int a4) { return 0; }
+/* {
+	char *v4; // esi
+	int v5; // edi
+	unsigned char v6; // al
+	char *v8; // eax
+	const char *v9; // eax
+	char *v10; // eax
+
+	v4 = a1;
+	v5 = a2;
+	if ( !*a1 )
+		return 0;
+	v6 = atoi(a1);
+	*(_BYTE *)(v5 + 4) = v6;
+	if ( v6 >= 3u )
+		return 0;
+	v8 = strchr(v4, 13);
+	if ( v8 )
+	{
+		*v8 = 0;
+		v9 = v8 + 1;
+		if ( a3 )
+			*(_DWORD *)a3 = v9;
+		v10 = strchr(v9, 13);
+		if ( v10 )
+		{
+			*v10 = 0;
+			if ( a4 )
+				*(_DWORD *)a4 = v10 + 1;
+		}
+	}
+	return 1;
+} */
+
+// ref: 0x10003E0C
+char *__fastcall Connect_10003E0C(int a1, const char *a2, char *a3, char *a4, int a5) { return 0; }
+/* {
+	const char *v5; // edi
+	int v6; // esi
+	size_t v7; // ebx
+	size_t v8; // eax
+	bool v9; // zf
+	bool v10; // sf
+	unsigned char v11; // of
+	int v12; // eax
+	char *result; // eax
+
+	v5 = a2;
+	v6 = a1;
+	v7 = strlen(a2);
+	v8 = v7 + strlen(a3) + 5;
+	v11 = __OFSUB__(a5, v8);
+	v9 = a5 == v8;
+	v10 = (signed int)(a5 - v8) < 0;
+	v12 = *(unsigned char *)(v6 + 4);
+	if ( (unsigned char)(v10 ^ v11) | v9 )
+		result = _itoa(v12, a4, 10);
+	else
+		result = (char *)sprintf(a4, "%d\r%s\r%s", v12, v5, a3);
+	return result;
+} */
+
+// ref: 0x10003E61
+signed int __fastcall Connect_10003E61(const char *a1, _BYTE *a2) { return 0; }
+/* {
+	_BYTE *v2; // esi
+	const char *v3; // edi
+	int v4; // eax
+	int v5; // edi
+	int v6; // edx
+	short v7; // di
+	char v8; // cl
+	int v10; // [esp+Ch] [ebp-24h]
+	unsigned int v11; // [esp+10h] [ebp-20h]
+	unsigned int v12; // [esp+14h] [ebp-1Ch]
+	unsigned int v13; // [esp+18h] [ebp-18h]
+	int v14; // [esp+1Ch] [ebp-14h]
+	int v15; // [esp+20h] [ebp-10h]
+	int v16; // [esp+24h] [ebp-Ch]
+	int v17; // [esp+28h] [ebp-8h]
+	int v18; // [esp+2Ch] [ebp-4h]
+
+	v2 = a2;
+	v3 = a1;
+	memset(a2, 0, 0x2Cu);
+	if ( !*v3 )
+		return 0;
+	v4 = *(_DWORD *)v3;
+	if ( *(_DWORD *)v3 != 1146246220 && v4 != 1146308690 && v4 != 1146377044 )
+		return 0;
+	if ( sscanf(v3 + 4, "%d %d %d %d %d %d %d %d %d", &v13, &v12, &v11, &v18, &v17, &v16, &v15, &v10, &v14) != 9 )
+		return 0;
+	v5 = *(_DWORD *)v3;
+	v6 = v14;
+	if ( v5 == 1146246220 )
+	{
+		if ( v14 )
+			return 0;
+	}
+	if ( v5 == 1146308690 && !v14 )
+		return 0;
+	v7 = v13;
+	if ( !v13 )
+		return 0;
+	if ( v13 > 0x63 )
+		return 0;
+	v8 = v12;
+	if ( v12 >= 3 || v11 > 3 || v18 < 0 || v17 < 0 || v16 < 0 || v15 < 0 )
+		return 0;
+	v2[23] = v11;
+	*((_WORD *)v2 + 10) = v7;
+	*((_WORD *)v2 + 12) = (unsigned char)v18;
+	v2[22] = v8;
+	*((_WORD *)v2 + 13) = (unsigned char)v17;
+	*((_DWORD *)v2 + 10) = v6;
+	*((_WORD *)v2 + 14) = (unsigned char)v16;
+	*((_WORD *)v2 + 15) = (unsigned char)v15;
+	*((_DWORD *)v2 + 8) = v10;
+	return 1;
+} */
+
+// ref: 0x10003F6F
+int __fastcall Connect_10003F6F(int a1, int a2, size_t a3) { return 0; }
+/* {
+	*(_DWORD *)a2 = dword_10029610;
+	return _snprintf(
+			   (char *)(a2 + 4),
+			   a3,
+			   " %d %d %d %d %d %d %d %d %d",
+			   *(unsigned short *)(a1 + 20),
+			   *(unsigned char *)(a1 + 22),
+			   *(unsigned char *)(a1 + 23),
+			   *(unsigned short *)(a1 + 24),
+			   *(unsigned short *)(a1 + 26),
+			   *(unsigned short *)(a1 + 28),
+			   *(unsigned short *)(a1 + 30),
+			   *(_DWORD *)(a1 + 32),
+			   *(_DWORD *)(a1 + 40));
+} */
+// 10029610: using guessed type int dword_10029610;
+
+// ref: 0x10003FB7
+int __stdcall UiCreateGameCriteria(int a1, char *a2) { return 0; }
+/* {
+	return sprintf(a2, "#%d?%d", 3, *(unsigned short *)(a1 + 20));
+} */
+
+// ref: 0x10003FD6
+int __stdcall UiCreatePlayerDescription(_uiheroinfo *info, int mode, char *desc) { return 0; }
+/* {
+	dword_10029610 = a2;
+	Connect_10003F6F(a1, a3, 0x80u);
+	return 1;
+} */
+// 10029610: using guessed type int dword_10029610;
+
+// ref: 0x10003FF7
+int __stdcall UiSetupPlayerInfo(char *str, _uiheroinfo *info, int mode) { return 0; }
+/* {
+	dword_10029610 = a3;
+	SStrCopy(&unk_10029530, a1, 128);
+	return Connect_10003F6F(a2, (int)byte_100294B0, 0x80u);
+} */
+// 100103E8: using guessed type int __stdcall SStrCopy(_DWORD, _DWORD, _DWORD);
+// 10029610: using guessed type int dword_10029610;
+
+// ref: 0x10004028
+int __fastcall Connect_10004028(int a1, int a2, int a3, int a4) { return 0; }
+/* {
+	int result; // eax
+
+	if ( a1 )
+		result = SStrCopy(a1, &unk_10029530, a2);
+	if ( a3 )
+		result = SStrCopy(a3, byte_100294B0, a4);
+	return result;
+} */
+// 100103E8: using guessed type int __stdcall SStrCopy(_DWORD, _DWORD, _DWORD);

--- a/DiabloUI/copyprot.cpp
+++ b/DiabloUI/copyprot.cpp
@@ -1,0 +1,180 @@
+// ref: 0x10004054
+void __stdcall UiCopyProtError(int a1) { return; }
+//signed int __stdcall UiCopyProtError(int *a1) { return 0; }
+/* {
+	int v1; // eax
+	int v2; // eax
+	CHAR Buffer; // [esp+0h] [ebp-80h]
+
+	if ( DiabloUI_10005C2A() )
+		LoadStringA(hInstance, 0x3Fu, &Buffer, 127);
+	else
+		LoadStringA(hInstance, 0x1Bu, &Buffer, 127);
+	v1 = SDrawGetFrameWindow();
+	v2 = SDlgDialogBoxParam(hInstance, "OKCANCEL_DIALOG", v1, CopyProt_100040AF, &Buffer);
+	if ( a1 )
+		*a1 = v2;
+	return 1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x100040AF
+int __stdcall CopyProt_100040AF(int a1, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	int v4; // ecx
+	int v5; // edx
+	HWND v6; // eax
+	LONG v7; // eax
+	HWND v9; // eax
+
+	if ( Msg == 2 )
+	{
+		CopyProt_10004173();
+		Fade_100072BE(10);
+		return SDlgDefDialogProc(a1, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(a1, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v9 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v9, Msg, wParam, lParam);
+		return SDlgDefDialogProc(a1, Msg, wParam, lParam);
+	}
+	if ( Msg == 272 )
+	{
+		CopyProt_100041B5((HWND)a1, (const CHAR *)lParam);
+		return 1;
+	}
+	if ( Msg != 273 )
+		return SDlgDefDialogProc(a1, Msg, wParam, lParam);
+	switch ( (unsigned short)wParam )
+	{
+		case 1u:
+			v6 = GetFocus();
+			v7 = GetWindowLongA(v6, -12);
+			v4 = a1;
+			if ( v7 == 1109 )
+			{
+				v5 = 1;
+				goto LABEL_13;
+			}
+			goto LABEL_12;
+		case 2u:
+			v4 = a1;
+LABEL_12:
+			v5 = 2;
+			goto LABEL_13;
+		case 0x455u:
+			v4 = a1;
+			v5 = 1;
+LABEL_13:
+			CopyProt_1000430C(v4, v5);
+			break;
+	}
+	return SDlgDefDialogProc(a1, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x10004173
+HGLOBAL CopyProt_10004173() { return 0; }
+/* {
+	HGLOBAL result; // eax
+
+	if ( hResData )
+	{
+		FreeResource(hResData);
+		hResData = 0;
+	}
+	if ( dword_10029624 )
+	{
+		FreeResource(dword_10029624);
+		dword_10029624 = 0;
+	}
+	result = dword_10029618;
+	if ( dword_10029618 )
+	{
+		result = (HGLOBAL)FreeResource(dword_10029618);
+		dword_10029618 = 0;
+	}
+	return result;
+} */
+
+// ref: 0x100041B5
+signed int __fastcall CopyProt_100041B5(HWND a1, const CHAR *a2) { return 0; }
+/* {
+	HRSRC v2; // eax
+	HRSRC v3; // eax
+	HRSRC v4; // eax
+	LPVOID v5; // edi
+	LPVOID v6; // ebx
+	HWND v7; // eax
+	char v9; // [esp+Ch] [ebp-420h]
+	int v10; // [esp+40Ch] [ebp-20h]
+	int v11; // [esp+410h] [ebp-1Ch]
+	int v12; // [esp+414h] [ebp-18h]
+	int v13; // [esp+418h] [ebp-14h]
+	int v14; // [esp+41Ch] [ebp-10h]
+	LPCSTR lpString; // [esp+420h] [ebp-Ch]
+	void *v16; // [esp+424h] [ebp-8h]
+	HWND hDlg; // [esp+428h] [ebp-4h]
+
+	v12 = 0;
+	lpString = a2;
+	hDlg = a1;
+	v13 = 112;
+	v14 = 140;
+	v10 = 1109;
+	v11 = 2;
+	v2 = FindResourceA(hInstance, "IDR_POPUPART", "ART_FILES");
+	dword_10029618 = LoadResource(hInstance, v2);
+	v3 = FindResourceA(hInstance, "IDR_BTNART", "ART_FILES");
+	dword_10029624 = LoadResource(hInstance, v3);
+	v4 = FindResourceA(hInstance, "IDR_ARTPAL", "ART_FILES");
+	hResData = LoadResource(hInstance, v4);
+	v5 = LockResource(dword_10029618);
+	v6 = LockResource(dword_10029624);
+	v16 = LockResource(hResData);
+	if ( v5 )
+		SDlgSetBitmapI(hDlg, 0, &byte_10029448, -1, 1, v5, 0, 284, 148, -1);
+	ShowCursor(1);
+	Fade_100073EF(hDlg);
+	if ( v6 )
+		local_10007B1B(hDlg, &v10, (int)v6, &v13);
+	if ( v16 )
+	{
+		memcpy(&v9, v16, 0x400u);
+		SDrawUpdatePalette(0, 256, &v9, 1);
+	}
+	v7 = GetDlgItem(hDlg, 1026);
+	SetWindowTextA(v7, lpString);
+	return 1;
+} */
+// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000430C
+int __fastcall CopyProt_1000430C(int a1, int a2) { return 0; }
+/* {
+	int v2; // esi
+	int v3; // edi
+
+	v2 = a2;
+	v3 = a1;
+	ShowCursor(0);
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+
+// ref: 0x10004329
+signed int CopyProt_10004329() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029620 = 2139095040;
+	return result;
+} */
+// 10029620: using guessed type int dword_10029620;

--- a/DiabloUI/cr8game.cpp
+++ b/DiabloUI/cr8game.cpp
@@ -1,0 +1,487 @@
+// ref: 0x10004339
+signed int cr8game_10004339() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002962C = 2139095040;
+	return result;
+} */
+// 1002962C: using guessed type int dword_1002962C;
+
+// ref: 0x10004344
+int UNKCALL cr8game_10004344(HWND arg) { return 0; }
+/* {
+	int result; // eax
+	int v2; // eax
+	int v3; // ST24_4
+	int v4; // ST18_4
+	int v5; // ST14_4
+	int v6; // ST10_4
+	int v7; // eax
+	CHAR Buffer; // [esp+Ch] [ebp-308h]
+	CHAR Text; // [esp+8Ch] [ebp-288h]
+	char v10; // [esp+18Ch] [ebp-188h]
+	int v11; // [esp+20Ch] [ebp-108h]
+	char v12; // [esp+28Ch] [ebp-88h]
+	int v13; // [esp+30Ch] [ebp-8h]
+	HWND hWnd; // [esp+310h] [ebp-4h]
+
+	hWnd = arg;
+	Connect_10004028((int)&v11, 128, (int)&v12, 128);
+	Connect_10003E0C((int)&unk_10029648, (const char *)&v11, &v12, &v10, 128);
+	if ( UiAuthCallback(2, (int)&v11, &v12, 0, &v10, &Text, 256) )
+	{
+		v2 = dword_10029634;
+		if ( *(_DWORD *)(dword_10029634 + 32) >= 8u )
+		{
+			*(_BYTE *)(*(_DWORD *)(dword_10029634 + 28) + 4) = byte_1002964C;
+			v2 = dword_10029634;
+		}
+		v3 = dword_10029644;
+		v4 = *(_DWORD *)(dword_10029630 + 8);
+		v5 = *(_DWORD *)(v2 + 32);
+		v6 = *(_DWORD *)(v2 + 28);
+		v7 = Connect_10003D04(&v12);
+		v13 = SNetCreateGame(&byte_10029670, &byte_10029690, &v10, v7, v6, v5, v4, &v11, 0, v3);
+		if ( !v13 )
+		{
+			if ( SErrGetLastError() == 183 )
+			{
+				LoadStringA(hInstance, 0x40Fu, &Buffer, 128);
+				sprintf(&Text, &Buffer, &byte_10029670);
+			}
+			else
+			{
+				LoadStringA(hInstance, 0x410u, &Text, 256);
+			}
+			UiMessageBoxCallback(hWnd, &Text, 0, 0x30u);
+		}
+		result = v13;
+	}
+	else
+	{
+		UiMessageBoxCallback(hWnd, &Text, 0, 0x30u);
+		result = 0;
+	}
+	return result;
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 1001040C: using guessed type int __stdcall SNetCreateGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029630: using guessed type int dword_10029630;
+// 10029634: using guessed type int dword_10029634;
+// 10029644: using guessed type int dword_10029644;
+// 1002964C: using guessed type char byte_1002964C;
+// 10029690: using guessed type char byte_10029690;
+
+// ref: 0x100044AA
+void __cdecl UiCreateGameCallback() { return; }
+//int __stdcall UiCreateGameCallback(int a1, int a2, int a3, int a4, int a5, int a6) { return 0; }
+/* {
+	int v6; // eax
+
+	dword_10029630 = a1;
+	dword_10029634 = a2;
+	dword_10029638 = a3;
+	dword_10029640 = a5;
+	dword_1002963C = a4;
+	dword_10029644 = a6;
+	v6 = SDlgDialogBoxParam(hInstance, "DIALOG_CREATE_GAME", *(_DWORD *)(a4 + 8), cr8game_10004506, 0);
+	return v6 != -1 ? v6 : 0;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029630: using guessed type int dword_10029630;
+// 10029634: using guessed type int dword_10029634;
+// 10029638: using guessed type int dword_10029638;
+// 1002963C: using guessed type int dword_1002963C;
+// 10029640: using guessed type int dword_10029640;
+// 10029644: using guessed type int dword_10029644;
+
+// ref: 0x10004506
+HGDIOBJ __stdcall cr8game_10004506(HWND hDlg, UINT Msg, WPARAM wParam, HWND hWnd) { return 0; }
+/* {
+	UINT v4; // ebx
+	HWND v6; // eax
+	HWND v7; // eax
+	HWND v8; // eax
+	CHAR Buffer; // [esp+Ch] [ebp-104h]
+	int v10; // [esp+10Ch] [ebp-4h]
+
+	v4 = Msg;
+	if ( Msg == 2 )
+	{
+		cr8game_10004828();
+		cr8game_10004914(hDlg);
+		if ( dword_10029628 )
+			DeleteObject(dword_10029628);
+		dword_10029650 = 0;
+		::hWnd = 0;
+		return (HGDIOBJ)SDlgDefDialogProc(hDlg, v4, wParam, hWnd);
+	}
+	if ( Msg > 0x103 )
+	{
+		if ( Msg > 0x105 )
+		{
+			if ( Msg == 272 )
+			{
+				::hWnd = GetDlgItem(hDlg, 1010);
+				dword_10029650 = GetDlgItem(hDlg, 1011);
+				cr8game_1000487F(hDlg);
+				cr8game_1000497F(hDlg);
+				cr8game_10004A93(hDlg);
+				dword_10029628 = cr8game_10004BA8(hDlg);
+				SendMessageA(::hWnd, 0xC5u, 0x1Fu, 0);
+				SendMessageA(dword_10029650, 0xC5u, 0x1Fu, 0);
+				return (HGDIOBJ)1;
+			}
+			if ( Msg != 273 )
+			{
+				if ( Msg == 312 && GetWindowLongA(hWnd, -12) == 1030 )
+				{
+					local_10007C2E((HDC)wParam);
+					return GetStockObject(5);
+				}
+				return (HGDIOBJ)SDlgDefDialogProc(hDlg, v4, wParam, hWnd);
+			}
+			if ( (unsigned short)wParam == 1 )
+			{
+				if ( SendMessageA(::hWnd, 0xEu, 0, 0) )
+				{
+					SendMessageA(::hWnd, 0xDu, 0x20u, (LPARAM)&byte_10029670);
+					if ( SelHero_1000BAB4(&byte_10029670)
+					  || SelHero_1000BB34(&byte_10029670, (char *)&byte_10029448)
+					  || !cr8game_10004B3F(&byte_10029670) )
+					{
+						LoadStringA(hInstance, 0x404u, &Buffer, 256);
+						OkCancel_1000930A((int)hDlg, (int)&Buffer, 1);
+						byte_10029670 = 0;
+					}
+					else
+					{
+						byte_10029690 = 0;
+						if ( SendMessageA(dword_10029650, 0xEu, 0, 0) )
+							SendMessageA(dword_10029650, 0xDu, 0x20u, (LPARAM)&byte_10029690);
+						byte_1002964C = dword_1002966C;
+						TitleSnd_1001031F();
+						if ( cr8game_10004344(hDlg) )
+							SDlgEndDialog(hDlg, 1);
+					}
+				}
+				else
+				{
+					LoadStringA(hInstance, 0x3F0u, &Buffer, 256);
+					OkCancel_1000930A((int)hDlg, (int)&Buffer, 1);
+				}
+			}
+			else
+			{
+				if ( (unsigned short)wParam != 2 )
+				{
+					if ( (signed int)(unsigned short)wParam > 1031 && (signed int)(unsigned short)wParam <= 1034 )
+					{
+						v10 = (unsigned short)wParam - 1032;
+						if ( HIWORD(wParam) == 6 )
+							SetFocus(::hWnd);
+						if ( dword_1002966C != (unsigned short)wParam - 1032 )
+						{
+							if ( dword_1002966C != -1 )
+							{
+								v6 = GetDlgItem(hDlg, dword_1002966C + 1032);
+								SendMessageA(v6, 0xF3u, 0, 0);
+								TitleSnd_10010315();
+							}
+							cr8game_10004ABA(hDlg, v10);
+							v7 = GetDlgItem(hDlg, 1040);
+							cr8game_10004B02(v7, 1029, v10);
+							v4 = 273;
+							dword_1002966C = v10;
+						}
+						SendMessageA(hWnd, 0xF3u, 1u, 0);
+					}
+					return (HGDIOBJ)SDlgDefDialogProc(hDlg, v4, wParam, hWnd);
+				}
+				TitleSnd_1001031F();
+				SDlgEndDialog(hDlg, 0);
+			}
+			return 0;
+		}
+		v8 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v8, Msg, wParam, (LPARAM)hWnd);
+	}
+	return (HGDIOBJ)SDlgDefDialogProc(hDlg, v4, wParam, hWnd);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1002964C: using guessed type char byte_1002964C;
+// 1002966C: using guessed type int dword_1002966C;
+// 10029690: using guessed type char byte_10029690;
+
+// ref: 0x10004828
+int cr8game_10004828() { return 0; }
+/* {
+	int result; // eax
+
+	if ( dword_100296B0 )
+	{
+		SMemFree(dword_100296B0, "C:\\Src\\Diablo\\DiabloUI\\cr8game.cpp", 55, 0);
+		dword_100296B0 = 0;
+	}
+	if ( dword_100296B4 )
+	{
+		SMemFree(dword_100296B4, "C:\\Src\\Diablo\\DiabloUI\\cr8game.cpp", 60, 0);
+		dword_100296B4 = 0;
+	}
+	result = dword_100296B8;
+	if ( dword_100296B8 )
+	{
+		result = SMemFree(dword_100296B8, "C:\\Src\\Diablo\\DiabloUI\\cr8game.cpp", 65, 0);
+		dword_100296B8 = 0;
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100296B4: using guessed type int dword_100296B4;
+// 100296B8: using guessed type int dword_100296B8;
+
+// ref: 0x1000487F
+int UNKCALL cr8game_1000487F(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	int v3; // [esp+8h] [ebp-1Ch]
+	int v4; // [esp+Ch] [ebp-18h]
+	int v5; // [esp+10h] [ebp-14h]
+	int v6; // [esp+14h] [ebp-10h]
+	char v7; // [esp+1Ch] [ebp-8h]
+
+	v5 = 0;
+	v1 = hWnd;
+	v3 = 1;
+	v4 = 2;
+	local_10007944((int)hWnd, 0, "Dialog", -1, 1, (int)"ui_art\\creat_bg.pcx", &dword_100296B0, &v6, 1);
+	local_100078BE((int)"ui_art\\but_xsm.pcx", &dword_100296B4, &v7);
+	SDlgSetControlBitmaps(v1, &v3, 0, dword_100296B4, &v7, 1, -1);
+	local_100078BE((int)"ui_art\\diffbtns.pcx", &dword_100296B8, &dword_10029660);
+	local_10007A85(v1, 1040, dword_100296B0, (int)&v6);
+	return 1;
+} */
+// 10010388: using guessed type int __stdcall SDlgSetControlBitmaps(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029660: using guessed type int dword_10029660;
+// 100296B4: using guessed type int dword_100296B4;
+// 100296B8: using guessed type int dword_100296B8;
+
+// ref: 0x10004914
+_DWORD *UNKCALL cr8game_10004914(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // ebp
+	signed int v2; // edi
+	HWND v3; // esi
+	_DWORD *result; // eax
+	_DWORD *v5; // esi
+	int v6; // eax
+	struct tagRECT Rect; // [esp+10h] [ebp-10h]
+
+	v1 = hDlg;
+	v2 = 0;
+	do
+	{
+		v3 = GetDlgItem(v1, v2 + 1032);
+		GetClientRect(v3, &Rect);
+		result = (_DWORD *)GetWindowLongA(v3, -21);
+		v5 = result;
+		if ( result )
+		{
+			v6 = *result;
+			if ( *v5 )
+				SMemFree(v6, "C:\\Src\\Diablo\\DiabloUI\\cr8game.cpp", 160, 0);
+			result = (_DWORD *)SMemFree(v5, "C:\\Src\\Diablo\\DiabloUI\\cr8game.cpp", 162, 0);
+		}
+		++v2;
+	}
+	while ( v2 < 3 );
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000497F
+_DWORD *UNKCALL cr8game_1000497F(HWND arg) { return 0; }
+/* {
+	int v1; // ebx
+	_DWORD *v2; // esi
+	HWND v3; // ST1C_4
+	LONG v4; // eax
+	_DWORD *result; // eax
+	struct tagRECT Rect; // [esp+Ch] [ebp-18h]
+	HWND hDlg; // [esp+1Ch] [ebp-8h]
+	HWND hWnd; // [esp+20h] [ebp-4h]
+
+	hDlg = arg;
+	v1 = 0;
+	do
+	{
+		hWnd = GetDlgItem(hDlg, v1 + 1032);
+		GetClientRect(hWnd, &Rect);
+		v2 = (_DWORD *)SMemAlloc(272, "C:\\Src\\Diablo\\DiabloUI\\cr8game.cpp", 177, 0);
+		*v2 = SMemAlloc(Rect.right * Rect.bottom, "C:\\Src\\Diablo\\DiabloUI\\cr8game.cpp", 178, 0);
+		v3 = hWnd;
+		v2[1] = Rect.right;
+		v4 = Rect.bottom;
+		v2[3] = 0;
+		v2[2] = v4;
+		SetWindowLongA(v3, -21, (LONG)v2);
+		SDlgSetBitmapI(hWnd, 0, &byte_10029448, -1, 241, *v2, 0, v2[1], v2[2], -1);
+		result = cr8game_10004A34(hWnd, v1++, 0);
+	}
+	while ( v1 < 3 );
+	return result;
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10004A34
+_DWORD *__fastcall cr8game_10004A34(HWND hWnd, int a2, int a3) { return 0; }
+/* {
+	HWND v3; // ebp
+	int v4; // ebx
+	_DWORD *result; // eax
+
+	v3 = hWnd;
+	v4 = a2;
+	result = (_DWORD *)GetWindowLongA(hWnd, -21);
+	if ( result )
+	{
+		if ( dword_100296B8 )
+		{
+			SBltROP3(
+				*result,
+				dword_100296B8 + dword_10029660 * result[2] * (a3 + 2 * v4),
+				result[1],
+				result[2],
+				result[1],
+				dword_10029660,
+				0,
+				13369376);
+			result = (_DWORD *)InvalidateRect(v3, 0, 0);
+		}
+	}
+	return result;
+} */
+// 100103F4: using guessed type int __stdcall SBltROP3(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029660: using guessed type int dword_10029660;
+// 100296B8: using guessed type int dword_100296B8;
+
+// ref: 0x10004A93
+LRESULT UNKCALL cr8game_10004A93(HWND hDlg) { return 0; }
+/* {
+	dword_1002966C = -1;
+	dword_10029658 = 0;
+	dword_10029668 = 0;
+	return SendDlgItemMessageA(hDlg, 1032, 0xF5u, 0, 0);
+} */
+// 10029658: using guessed type int dword_10029658;
+// 10029668: using guessed type int dword_10029668;
+// 1002966C: using guessed type int dword_1002966C;
+
+// ref: 0x10004ABA
+_DWORD *__fastcall cr8game_10004ABA(HWND hDlg, int a2) { return 0; }
+/* {
+	int v2; // edi
+	HWND v3; // ebx
+	HWND v4; // eax
+	HWND v5; // eax
+
+	v2 = a2;
+	v3 = hDlg;
+	if ( dword_1002966C != -1 )
+	{
+		v4 = GetDlgItem(hDlg, dword_1002966C + 1032);
+		cr8game_10004A34(v4, dword_1002966C, 0);
+	}
+	v5 = GetDlgItem(v3, v2 + 1032);
+	return cr8game_10004A34(v5, v2, 1);
+} */
+// 1002966C: using guessed type int dword_1002966C;
+
+// ref: 0x10004B02
+BOOL __fastcall cr8game_10004B02(HWND hWnd, int a2, int a3) { return 0; }
+/* {
+	HWND v3; // esi
+	CHAR Buffer; // [esp+4h] [ebp-100h]
+
+	v3 = hWnd;
+	LoadStringA(hInstance, a3 + a2, &Buffer, 256);
+	return SetWindowTextA(v3, &Buffer);
+} */
+
+// ref: 0x10004B3F
+int UNKCALL cr8game_10004B3F(char *arg) { return 0; }
+/* {
+	signed int v1; // edi
+	char v2; // al
+	signed int v3; // esi
+	int result; // eax
+	char v5; // [esp+8h] [ebp-24h]
+	char v6[31]; // [esp+9h] [ebp-23h]
+	char *v7; // [esp+28h] [ebp-4h]
+
+	v7 = arg;
+	strcpy(&v5, arg);
+	v1 = 0;
+	if ( v5 == 32 )
+	{
+		v2 = 32;
+		while ( v2 )
+		{
+			v2 = v6[v1++];
+			if ( v2 != 32 )
+				goto LABEL_5;
+		}
+LABEL_9:
+		result = 0;
+	}
+	else
+	{
+LABEL_5:
+		v3 = strlen(&v5);
+		while ( *(&v5 + --v3) == 32 )
+		{
+			if ( v3 <= v1 )
+				goto LABEL_9;
+		}
+		v6[v3] = 0;
+		strcpy(v7, &v5 + v1);
+		result = v3 + 1 - v1;
+	}
+	return result;
+} */
+// 10004B3F: using guessed type char var_23[31];
+
+// ref: 0x10004BA8
+HFONT UNKCALL cr8game_10004BA8(HWND hWnd) { return 0; }
+/* {
+	HFONT v1; // edi
+	HFONT v2; // eax
+	int pv; // [esp+8h] [ebp-40h]
+	int v5; // [esp+Ch] [ebp-3Ch]
+	HWND hDlg; // [esp+44h] [ebp-4h]
+
+	hDlg = hWnd;
+	v1 = (HFONT)SendMessageA(hWnd, 0x31u, 0, 0);
+	if ( v1 )
+	{
+		if ( GetObjectA(v1, 60, &pv) )
+		{
+			pv = -MulDiv(12, 96, 72);
+			v5 = 0;
+			v2 = CreateFontIndirectA((const LOGFONTA *)&pv);
+			v1 = v2;
+			if ( v2 )
+			{
+				SendDlgItemMessageA(hDlg, 1032, 0x30u, (WPARAM)v2, 0);
+				SendDlgItemMessageA(hDlg, 1033, 0x30u, (WPARAM)v1, 0);
+				SendDlgItemMessageA(hDlg, 1034, 0x30u, (WPARAM)v1, 0);
+			}
+		}
+	}
+	return v1;
+} */

--- a/DiabloUI/creadung.cpp
+++ b/DiabloUI/creadung.cpp
@@ -1,0 +1,348 @@
+// ref: 0x10004C33
+void UNKCALL CreaDung_10004C33(void *arg) { return; }
+/* {
+	dword_100296CC = (int)arg;
+} */
+// 100296CC: using guessed type int dword_100296CC;
+
+// ref: 0x10004C3F
+signed int CreaDung_10004C3F() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_100296C4 = 2139095040;
+	return result;
+} */
+// 100296C4: using guessed type int dword_100296C4;
+
+// ref: 0x10004C4A
+int __stdcall CreaDung_10004C4A(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	HWND v6; // eax
+	int savedregs; // [esp+Ch] [ebp+0h]
+
+	if ( Msg == 2 )
+	{
+		CreaDung_10004E2E(hWnd);
+	}
+	else if ( Msg > 0x103 )
+	{
+		if ( Msg > 0x105 )
+		{
+			if ( Msg == 272 )
+			{
+				dword_100296D8 = lParam;
+				CreaDung_10004E8B(hWnd);
+			}
+			else
+			{
+				if ( Msg == 273 )
+				{
+					if ( HIWORD(wParam) == 7 )
+					{
+						Focus_100075B7(hWnd, (HWND)lParam);
+					}
+					else if ( HIWORD(wParam) == 6 )
+					{
+						Focus_10007458((void *)lParam);
+						Focus_100075DC(hWnd, (HWND)lParam);
+						CreaDung_10004D75(hWnd, (unsigned short)wParam);
+					}
+					else if ( wParam == 327681 )
+					{
+						CreaDung_10004F5D(hWnd, (int)&savedregs);
+					}
+					else if ( (_WORD)wParam == 2 )
+					{
+						CreaDung_10004F40((int)hWnd, 2);
+					}
+					return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+				}
+				if ( Msg != 275 )
+				{
+					if ( Msg == 513 )
+						CreaDung_1000517E(hWnd, (unsigned short)lParam, (int)&savedregs, (unsigned int)lParam >> 16);
+					return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+				}
+				if ( wParam == 1 )
+				{
+					v4 = GetFocus();
+					Focus_100075DC(hWnd, v4);
+				}
+			}
+			return 0;
+		}
+		v6 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v6, Msg, wParam, lParam);
+	}
+	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 100296D8: using guessed type int dword_100296D8;
+
+// ref: 0x10004D75
+int __fastcall CreaDung_10004D75(HWND a1, int a2) { return 0; }
+/* {
+	int v2; // esi
+	HWND v3; // eax
+	int v4; // eax
+	HWND v5; // eax
+	int v6; // eax
+	HWND hDlg; // [esp+0h] [ebp-104h]
+	CHAR Buffer; // [esp+4h] [ebp-100h]
+
+	v2 = a2;
+	hDlg = a1;
+	LoadStringA(hInstance, a2 - 1055, &Buffer, 255);
+	v3 = GetDlgItem(hDlg, 1097);
+	if ( v3 )
+	{
+		v4 = GetWindowLongA(v3, -21);
+		local_10007FA4(v4, &Buffer);
+	}
+	Doom_10006A13(hDlg, (int *)&unk_100228E8, 5);
+	LoadStringA(hInstance, v2 - 65, &Buffer, 255);
+	v5 = GetDlgItem(hDlg, 1099);
+	if ( v5 )
+	{
+		v6 = GetWindowLongA(v5, -21);
+		local_10007FA4(v6, &Buffer);
+	}
+	return Doom_10006A13(hDlg, (int *)&unk_100228F0, 1);
+} */
+
+// ref: 0x10004E2E
+void UNKCALL CreaDung_10004E2E(HWND hDlg) { return; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	Doom_10006C53(hDlg, (int *)&unk_10022904);
+	Doom_10006C53(v1, (int *)&unk_100228F8);
+	Doom_10006C53(v1, (int *)&unk_100228F0);
+	Doom_10006C53(v1, (int *)&unk_100228E8);
+	Doom_10006C53(v1, (int *)&unk_100228DC);
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+	if ( dword_100296CC )
+		Focus_100076C3();
+} */
+// 100296CC: using guessed type int dword_100296CC;
+
+// ref: 0x10004E8B
+int UNKCALL CreaDung_10004E8B(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	int *v3; // edi
+
+	v1 = hWnd;
+	if ( dword_100296CC )
+		Focus_10007719("ui_art\\focus16.pcx");
+	else
+		Focus_100076FA();
+	SDlgSetTimer(v1, 1, 55, 0);
+	v2 = local_10007F46();
+	v3 = (int *)v2;
+	if ( v2 )
+	{
+		SetWindowLongA(v1, -21, v2);
+		local_10007944((int)v1, 0, "popup", -1, 1, (int)"ui_art\\seldiff.pcx", v3, v3 + 1, 0);
+	}
+	local_10007CB5(v1, (int *)&unk_10022904);
+	Doom_100068AB(v1, (int *)&unk_100228DC, 5);
+	Doom_100068AB(v1, (int *)&unk_100228E8, 5);
+	Doom_100068AB(v1, (int *)&unk_100228F0, 1);
+	Doom_1000658C(v1, (int *)&unk_100228F8, 4, 0);
+	return Doom_1000658C(v1, (int *)&unk_10022904, 2, 1);
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100296CC: using guessed type int dword_100296CC;
+
+// ref: 0x10004F40
+int __fastcall CreaDung_10004F40(int a1, int a2) { return 0; }
+/* {
+	int v2; // edi
+	int v3; // esi
+
+	v2 = a2;
+	v3 = a1;
+	TitleSnd_1001031F();
+	SDlgKillTimer(v3, 1);
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x10004F5D
+HWND USERCALL CreaDung_10004F5D(HWND a1, int a2) { return 0; }
+/* {
+	int v2; // esi
+	HWND v3; // eax
+	LONG v4; // eax
+	HWND result; // eax
+	HWND v6; // edi
+	HWND v7; // eax
+	int v8; // [esp-288h] [ebp-28Ch]
+	int v9; // [esp-188h] [ebp-18Ch]
+	int v10; // [esp-108h] [ebp-10Ch]
+	int v11; // [esp-88h] [ebp-8Ch]
+	int v12; // [esp-8h] [ebp-Ch]
+	char v13; // [esp-4h] [ebp-8h]
+	int v14; // [esp+0h] [ebp-4h]
+
+	v2 = (int)a1;
+	if ( dword_100296D8 == 1 )
+	{
+		v14 = a2;
+		v6 = a1;
+		Connect_10004028((int)&v11, 128, (int)&v10, 128);
+		v7 = GetFocus();
+		v13 = GetWindowLongA(v7, -12) - 70;
+		Connect_10003E0C((int)&v12, (const char *)&v11, (char *)&v10, (char *)&v9, 128);
+		if ( UiAuthCallback(2, (int)&v11, (char *)&v10, 0, (char *)&v9, (LPSTR)&v8, 256) )
+			result = CreaDung_10005037(v6);
+		else
+			result = (HWND)SelYesNo_1000FD39((int)v6, (const CHAR *)&v8, 0, 0);
+	}
+	else
+	{
+		v3 = GetFocus();
+		v4 = GetWindowLongA(v3, -12);
+		SelHero_1000B7AC((void *)(v4 - 1094));
+		result = (HWND)CreaDung_10004F40(v2, 1);
+	}
+	return result;
+} */
+// 10004F5D: could not find valid save-restore pair for ebp
+// 100296D8: using guessed type int dword_100296D8;
+
+// ref: 0x10005037
+HWND UNKCALL CreaDung_10005037(HWND arg) { return 0; }
+/* {
+	HWND v1; // eax
+	HWND v2; // ebx
+	HWND result; // eax
+	int v4; // eax
+	int v5; // edi
+	char v6; // [esp+8h] [ebp-34Ch]
+	CHAR v7; // [esp+108h] [ebp-24Ch]
+	CHAR Buffer; // [esp+188h] [ebp-1CCh]
+	char v9; // [esp+248h] [ebp-10Ch]
+	char v10; // [esp+2C8h] [ebp-8Ch]
+	char v11; // [esp+348h] [ebp-Ch]
+	char v12; // [esp+34Ch] [ebp-8h]
+	HWND v13; // [esp+350h] [ebp-4h]
+
+	v13 = arg;
+	v1 = GetFocus();
+	v2 = v1;
+	result = GetParent(v1);
+	if ( v13 == result )
+	{
+		Connect_10004028((int)&v10, 128, (int)&v9, 128);
+		v12 = GetWindowLongA(v2, -12) - 70;
+		Connect_10003E0C((int)&v11, &v10, &v9, &v6, 256);
+		v4 = dword_100296D0;
+		if ( *(_DWORD *)(dword_100296D0 + 32) >= 8u )
+		{
+			v5 = *(_DWORD *)(dword_100296D0 + 28);
+			*(_BYTE *)(v5 + 4) = GetWindowLongA(v2, -12) - 70;
+			v4 = dword_100296D0;
+		}
+		if ( SNetCreateGame(
+				 dword_100296DC,
+				 0,
+				 &v6,
+				 0,
+				 *(_DWORD *)(v4 + 28),
+				 *(_DWORD *)(v4 + 32),
+				 *(_DWORD *)(dword_100296BC + 8),
+				 &v10,
+				 0,
+				 dword_100296C0) )
+		{
+			result = (HWND)CreaDung_10004F40((int)v13, 1);
+		}
+		else
+		{
+			dword_100296D4 = SErrGetLastError();
+			if ( dword_100296D4 == 183 )
+			{
+				LoadStringA(hInstance, 0x49u, &v7, 127);
+				wsprintfA(&Buffer, &v7, dword_100296DC);
+			}
+			else
+			{
+				LoadStringA(hInstance, 0x26u, &Buffer, 191);
+			}
+			result = (HWND)SelYesNo_1000FD39((int)v13, &Buffer, 0, 0);
+		}
+	}
+	return result;
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 1001040C: using guessed type int __stdcall SNetCreateGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100296BC: using guessed type int dword_100296BC;
+// 100296C0: using guessed type int dword_100296C0;
+// 100296D0: using guessed type int dword_100296D0;
+// 100296D4: using guessed type int dword_100296D4;
+// 100296DC: using guessed type int dword_100296DC;
+
+// ref: 0x1000517E
+HWND USERPURGE CreaDung_1000517E(HWND hWnd, int a2, int a3, int a4) { return 0; }
+/* {
+	int v4; // ebx
+	HWND v5; // esi
+	int v6; // ST08_4
+	HWND v7; // eax
+	HWND result; // eax
+	HWND v9; // eax
+
+	v4 = a2;
+	v5 = hWnd;
+	v6 = a2;
+	v7 = GetDlgItem(hWnd, 1056);
+	if ( local_10007C3B(v5, v7, v6, a4) )
+		return CreaDung_10004F5D(v5, a3);
+	v9 = GetDlgItem(v5, 1054);
+	result = (HWND)local_10007C3B(v5, v9, v4, a4);
+	if ( result )
+		result = (HWND)CreaDung_10004F40((int)v5, 2);
+	return result;
+} */
+
+// ref: 0x100051D8
+int __fastcall CreaDung_100051D8(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8) { return 0; }
+/* {
+	int v8; // eax
+	int result; // eax
+
+	dword_100296BC = a1;
+	dword_100296C8 = a3;
+	dword_100296C0 = a6;
+	dword_100296CC = a7;
+	dword_100296D0 = a2;
+	dword_100296DC = a8;
+	v8 = SelHero_1000B7CA();
+	result = SDlgDialogBoxParam(hInstance, "SELDIFF_DIALOG", *(_DWORD *)(a4 + 8), CreaDung_10004C4A, v8);
+	if ( result != 1 )
+	{
+		SErrSetLastError(dword_100296D4);
+		result = 0;
+	}
+	return result;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 100296BC: using guessed type int dword_100296BC;
+// 100296C0: using guessed type int dword_100296C0;
+// 100296C8: using guessed type int dword_100296C8;
+// 100296CC: using guessed type int dword_100296CC;
+// 100296D0: using guessed type int dword_100296D0;
+// 100296D4: using guessed type int dword_100296D4;
+// 100296DC: using guessed type int dword_100296DC;

--- a/DiabloUI/creastat.cpp
+++ b/DiabloUI/creastat.cpp
@@ -1,0 +1,25 @@
+// ref: 0x1000523E
+signed int __stdcall UiGetDefaultStats(int a1, _WORD *a2) { return 0; }
+/* {
+	if ( !a2 )
+		return 0;
+	*a2 = word_10022958[4 * a1];
+	a2[1] = word_1002295A[4 * a1];
+	a2[2] = word_1002295C[4 * a1];
+	a2[3] = word_1002295E[4 * a1];
+	return 1;
+} */
+// 10022958: using guessed type short word_10022958[];
+// 1002295A: using guessed type short word_1002295A[];
+// 1002295C: using guessed type short word_1002295C[];
+
+// ref: 0x10005287
+signed int CreaStat_10005287() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_100296E0 = 2139095040;
+	return result;
+} */
+// 100296E0: using guessed type int dword_100296E0;

--- a/DiabloUI/credits.cpp
+++ b/DiabloUI/credits.cpp
@@ -1,0 +1,301 @@
+// ref: 0x10005297
+signed int credits_10005297() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_100296EC = 2139095040;
+	return result;
+} */
+// 100296EC: using guessed type int dword_100296EC;
+
+// ref: 0x100052A2
+void __stdcall UiCreditsDialog(int a1) { return; }
+/* {
+	int v1; // eax
+
+	v1 = SDrawGetFrameWindow();
+	SDlgDialogBoxParam(hInstance, "CREDITS_DIALOG", v1, credits_100052C7, 25);
+	return 1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x100052C7
+int __fastcall credits_100052C7(int a1, int a2, HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v7; // eax
+	int v8; // [esp+0h] [ebp-Ch]
+
+	if ( Msg > 0x111 )
+	{
+		if ( Msg == 275 )
+		{
+			credits_100055C0(hWnd);
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		if ( Msg == 513 || Msg == 516 )
+			goto LABEL_12;
+		if ( Msg != 528 )
+		{
+			if ( Msg == 2024 )
+			{
+				if ( !Fade_1000739F() )
+					Fade_100073FD(hWnd, v8);
+				return 0;
+			}
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		if ( (_WORD)wParam != 513 && (_WORD)wParam != 516 )
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+LABEL_25:
+		Title_100102D7(hWnd);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg == 273 )
+		goto LABEL_25;
+	if ( Msg != 2 )
+	{
+		if ( Msg == 135 )
+			return 4;
+		if ( Msg != 256 )
+		{
+			if ( Msg > 0x103 )
+			{
+				if ( Msg <= 0x105 )
+				{
+					v7 = (HWND)SDrawGetFrameWindow();
+					SendMessageA(v7, Msg, wParam, lParam);
+				}
+				else if ( Msg == 272 )
+				{
+					credits_1000543A(hWnd, lParam);
+					PostMessageA(hWnd, 0x7E8u, 0, 0);
+					return 1;
+				}
+			}
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		if ( wParam != 32 )
+			return 0;
+LABEL_12:
+		Title_100102D7(hWnd);
+		return 0;
+	}
+	credits_100053D9(hWnd, a2);
+	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x100053D9
+HGLOBAL __fastcall credits_100053D9(HWND hWnd, int a2) { return 0; }
+/* {
+	HWND v2; // edi
+	_DWORD *v3; // eax
+	HGLOBAL result; // eax
+
+	v2 = hWnd;
+	if ( dword_10029708 )
+	{
+		SGdiDeleteObject(hWnd, a2, dword_10029708);
+		dword_10029708 = 0;
+	}
+	if ( dword_10029704 )
+	{
+		SMemFree(dword_10029704, "C:\\Src\\Diablo\\DiabloUI\\credits.cpp", 46, 0);
+		dword_10029704 = 0;
+	}
+	v3 = (_DWORD *)GetWindowLongA(v2, -21);
+	local_10007F72(v3);
+	result = dword_100296F0;
+	if ( dword_100296F0 )
+	{
+		result = (HGLOBAL)FreeResource(dword_100296F0);
+		dword_100296F0 = 0;
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1001038E: using guessed type int __fastcall SGdiDeleteObject(_DWORD, _DWORD, _DWORD);
+// 10029704: using guessed type int dword_10029704;
+// 10029708: using guessed type int dword_10029708;
+
+// ref: 0x1000543A
+int __fastcall credits_1000543A(HWND a1, int a2) { return 0; }
+/* {
+	int v2; // eax
+	HRSRC v3; // eax
+	HRSRC v4; // eax
+	int v5; // eax
+	int *v6; // esi
+	int v7; // ebx
+	int v8; // esi
+	HFONT v9; // eax
+	HFONT v10; // esi
+	int v11; // ebx
+	int result; // eax
+	struct tagRECT Rect; // [esp+Ch] [ebp-18h]
+	HWND v14; // [esp+1Ch] [ebp-8h]
+	HWND hWnd; // [esp+20h] [ebp-4h]
+
+	hWnd = a1;
+	if ( a2 )
+		v2 = 1000 / a2;
+	else
+		v2 = 50;
+	SDlgSetTimer(a1, 1, v2, 0);
+	v3 = FindResourceA(hInstance, "IDR_CREDITS", "TEXT_FILES");
+	dword_100296F0 = LoadResource(hInstance, v3);
+	v4 = FindResourceA(hInstance, "IDR_CREDITS", "TEXT_FILES");
+	dword_100296E8 = SizeofResource(hInstance, v4);
+	v5 = local_10007F46();
+	v6 = (int *)v5;
+	if ( v5 )
+	{
+		SetWindowLongA(hWnd, -21, v5);
+		local_10007944((int)hWnd, 0, &byte_10029448, -1, 1, (int)"ui_art\\credits.pcx", v6, v6 + 1, 0);
+		Fade_100073C5(hWnd, 0);
+	}
+	v14 = GetDlgItem(hWnd, 1000);
+	GetWindowRect(v14, &Rect);
+	v7 = Rect.right - Rect.left;
+	v8 = Rect.bottom - Rect.top + 60;
+	dword_10029704 = SMemAlloc((Rect.right - Rect.left) * v8, "C:\\Src\\Diablo\\DiabloUI\\credits.cpp", 122, 0);
+	dword_100296F8 = v7;
+	dword_100296FC = v8;
+	local_10007A68(&Rect, 0, 30);
+	SDlgSetBitmapI(v14, 0, 0, -1, 1, dword_10029704, &Rect, v7, v8, -1);
+	dword_100296F4 = v8 - 30;
+	credits_100055C0(hWnd);
+	v9 = CreateFontA(-17, 0, 0, 0, 700, 0, 0, 0, 0, 0, 0, 0, 0x12u, "Times New Roman");
+	v10 = v9;
+	if ( !v9 || (v11 = SGdiImportFont(v9, &dword_10029708), result = DeleteObject(v10), !v11) )
+		result = Title_100102D7(hWnd);
+	return result;
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100103B2: using guessed type int __stdcall SGdiImportFont(_DWORD, _DWORD);
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100296E8: using guessed type int dword_100296E8;
+// 100296F4: using guessed type int dword_100296F4;
+// 100296F8: using guessed type int dword_100296F8;
+// 100296FC: using guessed type int dword_100296FC;
+// 10029704: using guessed type int dword_10029704;
+// 10029708: using guessed type int dword_10029708;
+
+// ref: 0x100055C0
+BOOL UNKCALL credits_100055C0(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // ebx
+	_DWORD *v2; // edi
+	struct tagRECT Rect; // [esp+Ch] [ebp-14h]
+	HWND hWnda; // [esp+1Ch] [ebp-4h]
+
+	v1 = hWnd;
+	hWnda = GetDlgItem(hWnd, 1000);
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	GetWindowRect(hWnda, &Rect);
+	ScreenToClient(v1, (LPPOINT)&Rect);
+	ScreenToClient(v1, (LPPOINT)&Rect.right);
+	SBltROP3(
+		dword_10029704 + 30 * dword_100296F8,
+		Rect.left + *v2 + Rect.top * v2[1],
+		dword_100296F8,
+		Rect.bottom - Rect.top,
+		dword_100296F8,
+		v2[1],
+		0,
+		13369376);
+	--dword_100296F4;
+	credits_10005660(v1);
+	InvalidateRect(hWnda, 0, 0);
+	return UpdateWindow(hWnda);
+} */
+// 100103F4: using guessed type int __stdcall SBltROP3(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100296F4: using guessed type int dword_100296F4;
+// 100296F8: using guessed type int dword_100296F8;
+// 10029704: using guessed type int dword_10029704;
+
+// ref: 0x10005660
+signed int UNKCALL credits_10005660(void *arg) { return 0; }
+/* {
+	_BYTE *v1; // esi
+	signed int result; // eax
+	int i; // edi
+	int v4; // ebp
+	int v5; // ebx
+	void *v6; // [esp+38h] [ebp-4h]
+
+	v6 = arg;
+	v1 = LockResource(dword_100296F0);
+	dword_10029700 = dword_100296E8;
+	SGdiSelectObject(dword_10029708);
+	result = SGdiSetPitch(dword_100296F8);
+	for ( i = dword_100296F4; dword_10029700 > 0; v1 = (_BYTE *)result )
+	{
+		v4 = 0;
+		while ( *v1 == 9 )
+		{
+			v4 += 40;
+			++v1;
+			--dword_10029700;
+		}
+		result = credits_10005736(v1);
+		v5 = result;
+		if ( result == -1 )
+			break;
+		if ( i >= 0 )
+		{
+			result = dword_100296FC - 30;
+			if ( i > dword_100296FC - 30 )
+				break;
+			if ( v5 )
+			{
+				SGdiTextOut(dword_10029704, v4 + 2, i + 2, 0x1000000, v1, v5);
+				SGdiTextOut(dword_10029704, v4, i, 16777440, v1, v5);
+			}
+		}
+		i += 22;
+		result = credits_10005755((int)v1, v5);
+	}
+	if ( i < 0 )
+		result = Title_100102D7(v6);
+	return result;
+} */
+// 100103A6: using guessed type int __stdcall SGdiSetPitch(_DWORD);
+// 100103AC: using guessed type int __stdcall SGdiSelectObject(_DWORD);
+// 10010424: using guessed type int __stdcall SGdiTextOut(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100296E8: using guessed type int dword_100296E8;
+// 100296F4: using guessed type int dword_100296F4;
+// 100296F8: using guessed type int dword_100296F8;
+// 100296FC: using guessed type int dword_100296FC;
+// 10029700: using guessed type int dword_10029700;
+// 10029704: using guessed type int dword_10029704;
+// 10029708: using guessed type int dword_10029708;
+
+// ref: 0x10005736
+signed int __fastcall credits_10005736(_BYTE *a1) { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 0;
+	while ( *a1 != 13 && *a1 != 10 )
+	{
+		++result;
+		++a1;
+		if ( result > dword_10029700 )
+			return -1;
+	}
+	return result;
+} */
+// 10029700: using guessed type int dword_10029700;
+
+// ref: 0x10005755
+int __fastcall credits_10005755(int a1, int a2) { return 0; }
+/* {
+	dword_10029700 += -2 - a2;
+	return a1 + a2 + 2;
+} */
+// 10029700: using guessed type int dword_10029700;

--- a/DiabloUI/diabedit.cpp
+++ b/DiabloUI/diabedit.cpp
@@ -1,0 +1,309 @@
+// ref: 0x10005765
+BOOL UNKCALL DiabEdit_10005765(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	struct tagPAINTSTRUCT Paint; // [esp+4h] [ebp-40h]
+
+	v1 = hWnd;
+	BeginPaint(hWnd, &Paint);
+	SDlgDrawBitmap(v1, 1, 0, 0, 0, 0, 0);
+	return EndPaint(v1, &Paint);
+} */
+// 1001042A: using guessed type int __stdcall SDlgDrawBitmap(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000579B
+signed int DiabEdit_1000579B() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002970C = 2139095040;
+	return result;
+} */
+// 1002970C: using guessed type int dword_1002970C;
+
+// ref: 0x100057A6
+ATOM DiabEdit_100057A6() { return 0; }
+/* {
+	WNDCLASSA WndClass; // [esp+0h] [ebp-28h]
+
+	memset(&WndClass, 0, 0x28u);
+	WndClass.style = 64;
+	WndClass.lpfnWndProc = (WNDPROC)DiabEdit_100057E8;
+	WndClass.hInstance = GetModuleHandleA(0);
+	WndClass.lpszClassName = "DIABLOEDIT";
+	return RegisterClassA(&WndClass);
+} */
+
+// ref: 0x100057E8
+HANDLE __stdcall DiabEdit_100057E8(HWND hWnd, UINT Msg, HANDLE hData, LPARAM lParam) { return 0; }
+/* {
+	if ( Msg <= 0x113 )
+	{
+		if ( Msg == 275 )
+		{
+			DiabEdit_1000594E((LPARAM)hWnd);
+			return 0;
+		}
+		if ( Msg == 1 )
+		{
+			DiabEdit_10005B9F(hWnd);
+		}
+		else if ( Msg == 2 )
+		{
+			DiabEdit_10005BE7(hWnd);
+		}
+		else
+		{
+			if ( Msg != 7 )
+			{
+				if ( Msg == 15 )
+				{
+					DiabEdit_10005765(hWnd);
+				}
+				else
+				{
+					if ( Msg == 135 )
+						return (HANDLE)129;
+					if ( Msg != 256 )
+					{
+						if ( Msg == 258 )
+							DiabEdit_10005A0A(hWnd, (unsigned char)hData, lParam);
+						return (HANDLE)DefWindowProcA(hWnd, Msg, (WPARAM)hData, lParam);
+					}
+					DiabEdit_10005AF4((LPARAM)hWnd, (int)hData, lParam);
+				}
+				return 0;
+			}
+			DiabEdit_1000591C((LPARAM)hWnd, 1u);
+		}
+		return (HANDLE)DefWindowProcA(hWnd, Msg, (WPARAM)hData, lParam);
+	}
+	switch ( Msg )
+	{
+		case 0x201u:
+			SetFocus(hWnd);
+			return (HANDLE)DefWindowProcA(hWnd, Msg, (WPARAM)hData, lParam);
+		case 0x400u:
+			SetWindowTextA(hWnd, &byte_10029448);
+			DiabEdit_1000591C((LPARAM)hWnd, 3u);
+			return 0;
+		case 0x401u:
+			SetPropA(hWnd, "LIMIT", hData);
+			return 0;
+		case 0x402u:
+			return GetPropA(hWnd, "LIMIT");
+	}
+	if ( Msg != 1027 )
+	{
+		if ( Msg == 1028 )
+		{
+			DiabEdit_10005B70(hWnd, (char *)lParam);
+			return 0;
+		}
+		return (HANDLE)DefWindowProcA(hWnd, Msg, (WPARAM)hData, lParam);
+	}
+	return GetPropA(hWnd, "CURSOR");
+} */
+
+// ref: 0x1000591C
+LRESULT __fastcall DiabEdit_1000591C(LPARAM lParam, unsigned short a2) { return 0; }
+/* {
+	HWND v2; // esi
+	LPARAM v3; // ST0C_4
+	int v4; // ST08_4
+	HWND v5; // eax
+
+	v2 = (HWND)lParam;
+	v3 = lParam;
+	v4 = (a2 << 16) | (unsigned short)GetWindowLongA((HWND)lParam, -12);
+	v5 = GetParent(v2);
+	return SendMessageA(v5, 0x111u, v4, v3);
+} */
+
+// ref: 0x1000594E
+LRESULT UNKCALL DiabEdit_1000594E(LPARAM lParam) { return 0; }
+/* {
+	HWND v1; // ebx
+	LRESULT result; // eax
+	size_t v3; // eax
+	CHAR *v4; // esi
+	CHAR String; // [esp+Ch] [ebp-100h]
+	char v6[252]; // [esp+Dh] [ebp-FFh]
+	short v7; // [esp+109h] [ebp-3h]
+	char v8; // [esp+10Bh] [ebp-1h]
+
+	v1 = (HWND)lParam;
+	String = byte_10029448;
+	memset(v6, 0, sizeof(v6));
+	v7 = 0;
+	v8 = 0;
+	if ( GetPropA((HWND)lParam, "CURSOR") )
+	{
+		SetPropA(v1, "CURSOR", 0);
+		result = DiabEdit_1000591C((LPARAM)v1, 3u);
+	}
+	else
+	{
+		SetPropA(v1, "CURSOR", HANDLE_FLAG_INHERIT);
+		GetWindowTextA(v1, &String, 255);
+		HIBYTE(v7) = 0;
+		v3 = strlen(&String);
+		v6[v3] = 0;
+		v4 = &String + v3;
+		*(&String + v3) = 124;
+		SetWindowTextA(v1, &String);
+		DiabEdit_1000591C((LPARAM)v1, 3u);
+		*v4 = 0;
+		result = SetWindowTextA(v1, &String);
+	}
+	return result;
+} */
+// 1000594E: using guessed type char var_FF[252];
+
+// ref: 0x10005A0A
+char *__fastcall DiabEdit_10005A0A(HWND a1, unsigned char a2, int a3) { return 0; }
+/* {
+	char *result; // eax
+	unsigned char v4; // bl
+	char v5; // cl
+	signed int v6; // eax
+	signed int v7; // esi
+	char v8; // [esp+7h] [ebp-105h]
+	CHAR String; // [esp+8h] [ebp-104h]
+	char v10[252]; // [esp+9h] [ebp-103h]
+	short v11; // [esp+105h] [ebp-7h]
+	char v12; // [esp+107h] [ebp-5h]
+	HWND hWnd; // [esp+108h] [ebp-4h]
+
+	hWnd = a1;
+	String = byte_10029448;
+	result = 0;
+	v4 = a2;
+	memset(v10, 0, sizeof(v10));
+	v11 = 0;
+	v12 = 0;
+	if ( a2 == 8 )
+		goto LABEL_9;
+	if ( a2 < 0x20u || a2 > 0x7Eu && a2 < 0xC0u )
+		return result;
+	result = (char *)GetPropA(hWnd, "RESTRICTED");
+	if ( !result || (v5 = *result) == 0 )
+	{
+LABEL_9:
+		GetWindowTextA(hWnd, &String, 255);
+		HIBYTE(v11) = 0;
+		v6 = strlen(&String);
+		v7 = v6;
+		if ( v4 == 8 )
+		{
+			if ( v6 )
+			{
+				*(&v8 + v6) = 0;
+				goto LABEL_14;
+			}
+		}
+		else if ( v6 < (signed int)GetPropA(hWnd, "LIMIT") )
+		{
+			*(&String + v7) = v4;
+			v10[v7] = 0;
+LABEL_14:
+			SetWindowTextA(hWnd, &String);
+			return (char *)DiabEdit_1000594E((LPARAM)hWnd);
+		}
+		return (char *)DiabEdit_1000594E((LPARAM)hWnd);
+	}
+	while ( v4 != v5 )
+	{
+		v5 = *++result;
+		if ( !*result )
+			goto LABEL_9;
+	}
+	return result;
+} */
+// 10005A0A: using guessed type char var_103[252];
+
+// ref: 0x10005AF4
+int __fastcall DiabEdit_10005AF4(LPARAM lParam, int a2, int a3) { return 0; }
+/* {
+	HWND v3; // esi
+	int v4; // ebx
+	int result; // eax
+	char v6; // [esp+Bh] [ebp-101h]
+	CHAR String; // [esp+Ch] [ebp-100h]
+	char v8; // [esp+Dh] [ebp-FFh]
+	short v9; // [esp+109h] [ebp-3h]
+	char v10; // [esp+10Bh] [ebp-1h]
+
+	v3 = (HWND)lParam;
+	String = byte_10029448;
+	memset(&v8, 0, 0xFCu);
+	v9 = 0;
+	v10 = 0;
+	v4 = a2;
+	GetWindowTextA((HWND)lParam, &String, 255);
+	HIBYTE(v9) = 0;
+	result = strlen(&String);
+	if ( v4 == 37 )
+	{
+		if ( result )
+		{
+			*(&v6 + result) = 0;
+			SetWindowTextA(v3, &String);
+		}
+		result = DiabEdit_1000594E((LPARAM)v3);
+	}
+	return result;
+} */
+
+// ref: 0x10005B70
+char *__fastcall DiabEdit_10005B70(HWND hWnd, char *a2) { return 0; }
+/* {
+	char *v2; // edi
+	char *result; // eax
+	char *v4; // esi
+
+	v2 = a2;
+	result = (char *)GetPropA(hWnd, "RESTRICTED");
+	v4 = result;
+	if ( result )
+	{
+		result = strncpy(result, v2, 0xFFu);
+		v4[255] = 0;
+	}
+	return result;
+} */
+
+// ref: 0x10005B9F
+BOOL UNKCALL DiabEdit_10005B9F(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	_BYTE *v2; // eax
+
+	v1 = hWnd;
+	SDlgSetTimer(hWnd, 1, 500, 0);
+	SetPropA(v1, "CURSOR", 0);
+	v2 = (_BYTE *)SMemAlloc(256, "C:\\Src\\Diablo\\DiabloUI\\DiabEdit.cpp", 185, 0);
+	*v2 = 0;
+	return SetPropA(v1, "RESTRICTED", v2);
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10005BE7
+HANDLE UNKCALL DiabEdit_10005BE7(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HANDLE result; // eax
+
+	v1 = hWnd;
+	SDlgKillTimer(hWnd, 1);
+	RemovePropA(v1, "LIMIT");
+	RemovePropA(v1, "CURSOR");
+	result = RemovePropA(v1, "RESTRICTED");
+	if ( result )
+		result = (HANDLE)SMemFree(result, "C:\\Src\\Diablo\\DiabloUI\\DiabEdit.cpp", 200, 0);
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);

--- a/DiabloUI/diabloui.cpp
+++ b/DiabloUI/diabloui.cpp
@@ -16,45 +16,152 @@
 #include "..\structs.h"
 #include "diabloui.h"
 
-BOOL APIENTRY DllMain( HANDLE hModule, 
-                       DWORD  ul_reason_for_call, 
-                       LPVOID lpReserved
-					 )
+#define UNKCALL     __fastcall
+#define USERCALL    __fastcall
+#define USERPURGE   __fastcall
+
+//temporarily include everything directly
+#include "artfont.cpp"
+#include "bnetgw.cpp"
+#include "bn_prof.cpp"
+#include "connect.cpp"
+#include "copyprot.cpp"
+#include "cr8game.cpp"
+#include "creadung.cpp"
+#include "creastat.cpp"
+#include "credits.cpp"
+#include "diabedit.cpp"
+#include "dirlink.cpp"
+#include "disclaim.cpp"
+#include "doom.cpp"
+#include "entdial.cpp"
+#include "entname.cpp"
+#include "fade.cpp"
+#include "focus.cpp"
+#include "local.cpp"
+#include "mainmenu.cpp"
+#include "modem.cpp"
+#include "modmstat.cpp"
+#include "okcancel.cpp"
+#include "progress.cpp"
+#include "sbar.cpp"
+#include "selclass.cpp"
+#include "selconn.cpp"
+#include "seldial.cpp"
+#include "selgame.cpp"
+#include "selhero.cpp"
+#include "selipx.cpp"
+#include "sellist.cpp"
+#include "selload.cpp"
+#include "selmodem.cpp"
+#include "selregn.cpp"
+#include "selyesno.cpp"
+#include "title.cpp"
+#include "titlesnd.cpp"
+
+
+// ref: 0x10005C2A
+int DiabloUI_10005C2A() { return 0; }
+/* {
+	return dword_1002972C;
+} */
+// 1002972C: using guessed type int dword_1002972C;
+
+// ref: 0x10005C30
+void __stdcall UiOnPaint(int a1)
 {
-    switch (ul_reason_for_call)
-	{
-		case DLL_PROCESS_ATTACH:
-		case DLL_THREAD_ATTACH:
-		case DLL_THREAD_DETACH:
-		case DLL_PROCESS_DETACH:
-			break;
-    }
-    return TRUE;
+	return;
 }
 
-void __cdecl UiDestroy() { return; }
-void __stdcall UiTitleDialog(int a1) { return; }
+// ref: 0x10005C33
+int __stdcall UiSetBackgroundBitmap(int a1, int a2, int a3, int a4, int a5) { return 0; }
+/* {
+	dword_1002971C = a3;
+	dword_10029720 = a4;
+	dword_10029724 = a5;
+	return SDrawUpdatePalette(10, 236, a2 + 40, 0);
+} */
+// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002971C: using guessed type int dword_1002971C;
+// 10029720: using guessed type int dword_10029720;
+// 10029724: using guessed type int dword_10029724;
+
+// ref: 0x10005C67
+int __stdcall UiSetSpawned(int a1) { return 0; }
+/* {
+	int result; // eax
+
+	result = a1;
+	dword_1002972C = a1;
+	return result;
+} */
+// 1002972C: using guessed type int dword_1002972C;
+
+// ref: 0x10005C73
 void __cdecl UiInitialize() { return; }
-void __stdcall UiCopyProtError(int a1) { return; }
+//int UiInitialize() { return 0; }
+/* {
+	dword_10029714 = 1;
+	TitleSnd_1001030D();
+	artfont_10001098();
+	Connect_10002EC4();
+	local_10007FD0();
+	return bn_prof_100021C4();
+} */
+// 10029714: using guessed type int dword_10029714;
+
+// ref: 0x10005C96
+void __cdecl UiDestroy() { return; }
+//int UiDestroy() { return 0; }
+/* {
+	int result; // eax
+
+	bn_prof_10002247();
+	local_100080AD();
+	result = Connect_10002E2B();
+	dword_10029714 = 0;
+	return result;
+} */
+// 10029714: using guessed type int dword_10029714;
+
+// ref: 0x10005CAD
 void __stdcall UiAppActivate(int a1) { return; }
-int __stdcall UiValidPlayerName(char *a1) { return 0; }
-int __stdcall UiSelHeroMultDialog(void *fninfo, void *fncreate, void *fnremove, void *fnstats, int *a5, int *a6, char *name) { return 0; }
-int __stdcall UiSelHeroSingDialog(void *fninfo, void *fncreate, void *fnremove, void *fnstats, int *a5, char *name, int *difficulty) { return 0; }
-void __stdcall UiCreditsDialog(int a1) { return; }
-int __stdcall UiMainMenuDialog(char *name, int *a2, void *fnSound, int a4) { return 0; }
-int __stdcall UiProgressDialog(HWND window, char *msg, int a3, void *fnfunc, int a5) { return 0; }
-int __cdecl UiProfileGetString() { return 0; }
-void __cdecl UiProfileCallback() { return; }
-void __cdecl UiProfileDraw() { return; }
-void __cdecl UiCategoryCallback() { return; }
-void __cdecl UiGetDataCallback() { return; }
-void __cdecl UiAuthCallback() { return; }
-void __cdecl UiSoundCallback() { return; }
-void __cdecl UiMessageBoxCallback() { return; }
-void __cdecl UiDrawDescCallback() { return; }
-void __cdecl UiCreateGameCallback() { return; }
-void __cdecl UiArtCallback() { return; }
-int __stdcall UiSelectGame(int a1, _SNETPROGRAMDATA *client_info, _SNETPLAYERDATA *user_info, _SNETUIDATA *ui_info, _SNETVERSIONDATA *file_info, int *a6) { return 0; }
-int __stdcall UiSelectProvider(int a1, _SNETPROGRAMDATA *client_info, _SNETPLAYERDATA *user_info, _SNETUIDATA *ui_info, _SNETVERSIONDATA *file_info, int *type) { return 0; }
-int __stdcall UiCreatePlayerDescription(_uiheroinfo *info, int mode, char *desc) { return 0; }
-int __stdcall UiSetupPlayerInfo(char *str, _uiheroinfo *info, int mode) { return 0; }
+//int __stdcall UiAppActivate(int a1) { return 0; }
+/* {
+	int result; // eax
+
+	result = a1;
+	dword_10029728 = a1;
+	return result;
+} */
+// 10029728: using guessed type int dword_10029728;
+
+// ref: 0x10005CB9
+BOOL __stdcall DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+	if ( fdwReason )
+	{
+		if ( fdwReason == 1 )
+		{
+			// hInstance = hinstDLL;
+			DiabEdit_100057A6();
+			local_10007825();
+		}
+	}
+	else
+	{
+		local_1000787D();
+	}
+	return 1;
+}
+
+// ref: 0x10005CEA
+signed int DiabloUI_10005CEA() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029710 = 2139095040;
+	return result;
+} */
+// 10029710: using guessed type int dword_10029710;

--- a/DiabloUI/diabloui.def
+++ b/DiabloUI/diabloui.def
@@ -1,29 +1,36 @@
 LIBRARY "DiabloUI"
 
 EXPORTS
-	UiDestroy
-	UiTitleDialog
-	UiInitialize
-	UiCopyProtError
-	UiAppActivate
 	UiValidPlayerName
-	UiSelHeroMultDialog
-	UiSelHeroSingDialog
+	UiAppActivate
+	UiArtCallback
+	UiAuthCallback
+	UiBetaDisclaimer
+	UiCategoryCallback
+	UiCopyProtError
+	UiCreateGameCallback
+	UiCreateGameCriteria
+	UiCreatePlayerDescription
 	UiCreditsDialog
+	UiDestroy
+	UiDrawDescCallback
+	UiGetDataCallback
+	UiGetDefaultStats
+	UiInitialize
 	UiMainMenuDialog
-	UiProgressDialog
-	UiProfileGetString
+	UiMessageBoxCallback
+	UiOnPaint
 	UiProfileCallback
 	UiProfileDraw
-	UiCategoryCallback
-	UiGetDataCallback
-	UiAuthCallback
-	UiSoundCallback
-	UiMessageBoxCallback
-	UiDrawDescCallback
-	UiCreateGameCallback
-	UiArtCallback
+	UiProfileGetString
+	UiProgressDialog
+	UiSelHeroMultDialog
+	UiSelHeroSingDialog
 	UiSelectGame
 	UiSelectProvider
-	UiCreatePlayerDescription
+	UiSelectRegion
+	UiSetBackgroundBitmap
+	UiSetSpawned
 	UiSetupPlayerInfo
+	UiSoundCallback
+	UiTitleDialog

--- a/DiabloUI/diabloui_gcc.def
+++ b/DiabloUI/diabloui_gcc.def
@@ -1,48 +1,48 @@
 LIBRARY "DiabloUI"
 
 EXPORTS
-  UiValidPlayerName              @1 NONAME
-  UiValidPlayerName@4            @1 NONAME
-  UiAppActivate                  @2 NONAME
-  UiAppActivate@4                @2 NONAME
-  UiArtCallback                  @3 NONAME
-  UiAuthCallback                 @4 NONAME
-  UiBetaDisclaimer               @5 NONAME
-  UiCategoryCallback             @6 NONAME
-  UiCopyProtError                @7 NONAME
-  UiCreateGameCallback           @8 NONAME
-  UiCreateGameCriteria           @9 NONAME
-  UiCreatePlayerDescription      @10 NONAME
-  UiCreatePlayerDescription@12   @10 NONAME
-  UiCreditsDialog                @11 NONAME
-  UiCreditsDialog@4              @11 NONAME
-  UiDestroy                      @12 NONAME
-  UiDrawDescCallback             @13 NONAME
-  UiGetDataCallback              @14 NONAME
-  UiGetDefaultStats              @15 NONAME
-  UiInitialize                   @16 NONAME
-  UiMainMenuDialog               @17 NONAME
-  UiMainMenuDialog@16            @17 NONAME
-  UiMessageBoxCallback           @18 NONAME
-  UiOnPaint                      @19 NONAME
-  UiProfileCallback              @20 NONAME
-  UiProfileDraw                  @21 NONAME
-  UiProfileGetString             @22 NONAME
-  UiProgressDialog               @23 NONAME
-  UiProgressDialog@20            @23 NONAME
-  UiSelHeroMultDialog            @24 NONAME
-  UiSelHeroMultDialog@28         @24 NONAME
-  UiSelHeroSingDialog            @25 NONAME
-  UiSelHeroSingDialog@28         @25 NONAME
-  UiSelectGame                   @26 NONAME
-  UiSelectGame@24                @26 NONAME
-  UiSelectProvider               @27 NONAME
-  UiSelectProvider@24            @27 NONAME
-  UiSelectRegion                 @28 NONAME
-  UiSetBackgroundBitmap          @29 NONAME
-  UiSetSpawned                   @30 NONAME
-  UiSetupPlayerInfo              @31 NONAME
-  UiSetupPlayerInfo@12           @31 NONAME
-  UiSoundCallback                @32 NONAME
-  UiTitleDialog                  @33 NONAME
-  UiTitleDialog@4                @33 NONAME
+	UiValidPlayerName              @1
+	UiValidPlayerName@4            @1
+	UiAppActivate                  @2
+	UiAppActivate@4                @2
+	UiArtCallback                  @3
+	UiAuthCallback                 @4
+	UiBetaDisclaimer               @5
+	UiCategoryCallback             @6
+	UiCopyProtError                @7
+	UiCreateGameCallback           @8
+	UiCreateGameCriteria           @9
+	UiCreatePlayerDescription      @10
+	UiCreatePlayerDescription@12   @10
+	UiCreditsDialog                @11
+	UiCreditsDialog@4              @11
+	UiDestroy                      @12
+	UiDrawDescCallback             @13
+	UiGetDataCallback              @14
+	UiGetDefaultStats              @15
+	UiInitialize                   @16
+	UiMainMenuDialog               @17
+	UiMainMenuDialog@16            @17
+	UiMessageBoxCallback           @18
+	UiOnPaint                      @19
+	UiProfileCallback              @20
+	UiProfileDraw                  @21
+	UiProfileGetString             @22
+	UiProgressDialog               @23
+	UiProgressDialog@20            @23
+	UiSelHeroMultDialog            @24
+	UiSelHeroMultDialog@28         @24
+	UiSelHeroSingDialog            @25
+	UiSelHeroSingDialog@28         @25
+	UiSelectGame                   @26
+	UiSelectGame@24                @26
+	UiSelectProvider               @27
+	UiSelectProvider@24            @27
+	UiSelectRegion                 @28
+	UiSetBackgroundBitmap          @29
+	UiSetSpawned                   @30
+	UiSetupPlayerInfo              @31
+	UiSetupPlayerInfo@12           @31
+	UiSoundCallback                @32
+	UiTitleDialog                  @33
+	UiTitleDialog@4                @33

--- a/DiabloUI/dirlink.cpp
+++ b/DiabloUI/dirlink.cpp
@@ -1,0 +1,384 @@
+// ref: 0x10005CFA
+signed int DirLink_10005CFA() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029730 = 2139095040;
+	return result;
+} */
+// 10029730: using guessed type int dword_10029730;
+
+// ref: 0x10005D05
+BOOL __fastcall DirLink_10005D05(int a1, int a2, int a3, _DWORD *a4, int a5, int a6) { return 0; }
+/* {
+	int v6; // esi
+
+	dword_1002983C = a3;
+	dword_1002984C = a2;
+	dword_10029840 = a5;
+	dword_10029848 = a4;
+	dword_10029844 = a6;
+	artfont_10001159();
+	v6 = SDlgDialogBoxParam(hInstance, "DIRLINK_DIALOG", a4[2], DirLink_10005D63, 0);
+	artfont_100010C8();
+	return v6 == 1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002983C: using guessed type int dword_1002983C;
+// 10029840: using guessed type int dword_10029840;
+// 10029844: using guessed type int dword_10029844;
+// 1002984C: using guessed type int dword_1002984C;
+
+// ref: 0x10005D63
+int __stdcall DirLink_10005D63(HWND hWnd, UINT Msg, WPARAM wParam, unsigned int lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	int v6; // [esp+0h] [ebp-Ch]
+	char *v7; // [esp+4h] [ebp-8h]
+	char *v8; // [esp+8h] [ebp-4h]
+
+	if ( Msg > 0x111 )
+	{
+		switch ( Msg )
+		{
+			case 0x113u:
+				if ( wParam == 3 )
+				{
+					DirLink_100062BF(hWnd, v6, v7, v8);
+					DirLink_10006073(hWnd);
+				}
+				return 0;
+			case 0x201u:
+				DirLink_10006359(hWnd, (unsigned short)lParam, lParam >> 16);
+				break;
+			case 0x7E8u:
+				if ( !Fade_1000739F() )
+					Fade_100073FD(hWnd, v6);
+				return 0;
+		}
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg == 273 )
+	{
+		if ( HIWORD(wParam) == 7 )
+		{
+			Focus_100075B7(hWnd, (HWND)lParam);
+		}
+		else if ( HIWORD(wParam) == 6 )
+		{
+			Focus_10007458((void *)lParam);
+			Focus_100075DC(hWnd, (HWND)lParam);
+			DirLink_10005EB2(hWnd, (unsigned short)wParam);
+		}
+		else if ( wParam == 327681 )
+		{
+			DirLink_100060D1(hWnd);
+		}
+		else if ( (_WORD)wParam == 2 )
+		{
+			DirLink_10006047((int)hWnd, 2);
+		}
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg == 2 )
+	{
+		DirLink_10005F1F(hWnd);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v4 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v4, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg != 272 )
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	PostMessageA(hWnd, 0x7E8u, 0, 0);
+	DirLink_10005F7B(hWnd);
+	return 0;
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x10005EB2
+int __fastcall DirLink_10005EB2(HWND hDlg, int a2) { return 0; }
+/* {
+	HWND v2; // esi
+	int v3; // edi
+	HWND v4; // ebx
+	int v5; // eax
+	CHAR Buffer; // [esp+Ch] [ebp-100h]
+
+	v2 = hDlg;
+	v3 = a2;
+	v4 = GetDlgItem(hDlg, 1102);
+	if ( v3 == 1100 )
+		LoadStringA(hInstance, 0x2Au, &Buffer, 255);
+	else
+		LoadStringA(hInstance, 0x2Fu, &Buffer, 255);
+	v5 = GetWindowLongA(v4, -21);
+	local_10007FA4(v5, &Buffer);
+	return Doom_10006A13(v2, (int *)&unk_10022A40, 1);
+} */
+
+// ref: 0x10005F1F
+int UNKCALL DirLink_10005F1F(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	Doom_10006C53(hDlg, (int *)&unk_10022A54);
+	Doom_10006C53(v1, (int *)&unk_10022A48);
+	Doom_10006C53(v1, (int *)&unk_10022A40);
+	Doom_10006C53(v1, (int *)&unk_10022A38);
+	Doom_10006C53(v1, (int *)&unk_10022A2C);
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+	Title_100100E7(v1);
+	return Focus_10007818(v1);
+} */
+
+// ref: 0x10005F7B
+int UNKCALL DirLink_10005F7B(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // ST1C_4
+	int v3; // eax
+	int *v4; // edi
+	HWND v6; // [esp-4h] [ebp-Ch]
+	int v7; // [esp-4h] [ebp-Ch]
+	char *v8; // [esp+0h] [ebp-8h]
+	char *v9; // [esp+4h] [ebp-4h]
+
+	v1 = hWnd;
+	Focus_100077E9((int)hWnd, "ui_art\\focus16.pcx", v6);
+	Title_1001009E(v1, (int)"ui_art\\smlogo.pcx", v2);
+	v3 = local_10007F46();
+	v4 = (int *)v3;
+	if ( v3 )
+	{
+		SetWindowLongA(v1, -21, v3);
+		local_10007944((int)v1, 0, &byte_10029448, -1, 1, (int)"ui_art\\selgame.pcx", v4, v4 + 1, 0);
+		Fade_100073C5(v1, 1);
+	}
+	local_10007CB5(v1, (int *)&unk_10022A54);
+	Doom_100068AB(v1, (int *)&unk_10022A2C, 5);
+	Doom_100068AB(v1, (int *)&unk_10022A38, 3);
+	Doom_100068AB(v1, (int *)&unk_10022A40, 1);
+	Doom_1000658C(v1, (int *)&unk_10022A48, 4, 0);
+	Doom_1000658C(v1, (int *)&unk_10022A54, 2, 1);
+	DirLink_100062BF(v1, v7, v8, v9);
+	DirLink_10006073(v1);
+	return SDlgSetTimer(v1, 3, 2000, 0);
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10006047
+int __fastcall DirLink_10006047(int a1, int a2) { return 0; }
+/* {
+	int v2; // edi
+	int v3; // esi
+
+	v2 = a2;
+	v3 = a1;
+	TitleSnd_1001031F();
+	Fade_100073B4();
+	SDlgKillTimer(v3, 3);
+	Fade_100072BE(10);
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x10006073
+void UNKCALL DirLink_10006073(void *arg) { return; }
+/* {
+	int v1; // esi
+	char v2; // [esp+4h] [ebp-100h]
+	char v3; // [esp+84h] [ebp-80h]
+
+	v1 = (int)arg;
+	if ( dword_10029738 )
+	{
+		Connect_10004028((int)&v2, 128, (int)&v3, 128);
+		if ( SNetJoinGame(dword_10029738, &byte_1002973C, 0, &v2, &v3, dword_10029844) )
+			DirLink_10006047(v1, 1);
+	}
+} */
+// 10010430: using guessed type int __stdcall SNetJoinGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029738: using guessed type int dword_10029738;
+// 10029844: using guessed type int dword_10029844;
+
+// ref: 0x100060D1
+HWND UNKCALL DirLink_100060D1(HWND arg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // eax
+	HWND v3; // edi
+	HWND result; // eax
+	CHAR Buffer; // [esp+8h] [ebp-80h]
+
+	v1 = arg;
+	v2 = GetFocus();
+	v3 = v2;
+	result = GetParent(v2);
+	if ( v1 == result )
+	{
+		if ( GetWindowLongA(v3, -12) == 1100 )
+		{
+			result = (HWND)DirLink_10006141(v1);
+		}
+		else if ( dword_10029738 )
+		{
+			result = (HWND)DirLink_100061E1(v1);
+		}
+		else
+		{
+			LoadStringA(hInstance, 0x2Bu, &Buffer, 127);
+			result = (HWND)SelYesNo_1000FD39((int)v1, &Buffer, 0, 0);
+		}
+	}
+	return result;
+} */
+// 10029738: using guessed type int dword_10029738;
+
+// ref: 0x10006141
+int UNKCALL DirLink_10006141(void *arg) { return 0; }
+/* {
+	int v1; // edi
+	int result; // eax
+	char v3; // [esp+8h] [ebp-E0h]
+	int v4; // [esp+88h] [ebp-60h]
+	int v5; // [esp+90h] [ebp-58h]
+	int v6; // [esp+D8h] [ebp-10h]
+	int v7; // [esp+DCh] [ebp-Ch]
+	int v8; // [esp+E0h] [ebp-8h]
+	int v9; // [esp+E4h] [ebp-4h]
+
+	v1 = (int)arg;
+	Connect_10004028((int)&v3, 128, 0, 0);
+	memcpy(&v4, dword_10029848, 0x50u);
+	v4 = 80;
+	v5 = v1;
+	memset(&v6, 0, 0x10u);
+	v6 = 16;
+	v7 = 1396916812;
+	v8 = *(_DWORD *)(dword_1002984C + 24);
+	v9 = 0;
+	result = CreaDung_100051D8(
+				 (int)&v6,
+				 dword_1002984C,
+				 dword_1002983C,
+				 (int)&v4,
+				 dword_10029840,
+				 dword_10029844,
+				 0,
+				 (int)&v3);
+	if ( result )
+		result = DirLink_10006047(v1, 1);
+	return result;
+} */
+// 1002983C: using guessed type int dword_1002983C;
+// 10029840: using guessed type int dword_10029840;
+// 10029844: using guessed type int dword_10029844;
+// 1002984C: using guessed type int dword_1002984C;
+
+// ref: 0x100061E1
+int UNKCALL DirLink_100061E1(void *arg) { return 0; }
+/* {
+	int v1; // ebx
+	CHAR *v2; // edx
+	CHAR v4; // [esp+Ch] [ebp-380h]
+	CHAR v5; // [esp+10Ch] [ebp-280h]
+	int v6; // [esp+20Ch] [ebp-180h]
+	char v7; // [esp+28Ch] [ebp-100h]
+	CHAR Buffer; // [esp+30Ch] [ebp-80h]
+
+	v1 = (int)arg;
+	Connect_10004028((int)&v6, 128, (int)&v7, 128);
+	if ( UiAuthCallback(2, (int)&v6, &v7, 0, &byte_100297BC, &v5, 256) )
+	{
+		if ( SNetJoinGame(dword_10029738, &byte_1002973C, 0, &v6, &v7, dword_10029844) )
+			return DirLink_10006047(v1, 1);
+		if ( SErrGetLastError() == -2062548871 )
+			LoadStringA(hInstance, 0x32u, &Buffer, 127);
+		else
+			LoadStringA(hInstance, 0x25u, &Buffer, 127);
+		wsprintfA(&v4, &Buffer, &byte_1002973C);
+		v2 = &v4;
+	}
+	else
+	{
+		v2 = &v5;
+	}
+	return SelYesNo_1000FD39(v1, v2, 0, 0);
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010430: using guessed type int __stdcall SNetJoinGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029738: using guessed type int dword_10029738;
+// 10029844: using guessed type int dword_10029844;
+
+// ref: 0x100062BF
+int UNKCALL DirLink_100062BF(void *arg, int a2, char *a3, char *a4) { return 0; }
+/* {
+	int v4; // esi
+	int result; // eax
+	CHAR Buffer; // [esp+8h] [ebp-80h]
+
+	v4 = (int)arg;
+	dword_10029738 = 0;
+	byte_1002973C = 0;
+	byte_100297BC = 0;
+	result = SNetEnumGames(0, 0, DirLink_1000632B, 0);
+	if ( !result )
+	{
+		result = SErrGetLastError();
+		if ( result == -2062548871 )
+		{
+			LoadStringA(hInstance, 0x32u, &Buffer, 127);
+			SelYesNo_1000FD39(v4, &Buffer, 0, 0);
+			result = DirLink_10006047(v4, 2);
+		}
+	}
+	return result;
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010436: using guessed type int __stdcall SNetEnumGames(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029738: using guessed type int dword_10029738;
+
+// ref: 0x1000632B
+signed int __stdcall DirLink_1000632B(int a1, char *a2, char *a3) { return 0; }
+/* {
+	dword_10029738 = a1;
+	strcpy(&byte_1002973C, a2);
+	strcpy(&byte_100297BC, a3);
+	return 1;
+} */
+// 10029738: using guessed type int dword_10029738;
+
+// ref: 0x10006359
+HWND __fastcall DirLink_10006359(HWND hWnd, int a2, int a3) { return 0; }
+/* {
+	int v3; // ebx
+	HWND v4; // esi
+	int v5; // ST08_4
+	HWND v6; // eax
+	HWND result; // eax
+	HWND v8; // eax
+
+	v3 = a2;
+	v4 = hWnd;
+	v5 = a2;
+	v6 = GetDlgItem(hWnd, 1056);
+	if ( local_10007C3B(v4, v6, v5, a3) )
+		return DirLink_100060D1(v4);
+	v8 = GetDlgItem(v4, 1054);
+	result = (HWND)local_10007C3B(v4, v8, v3, a3);
+	if ( result )
+		result = (HWND)DirLink_10006047((int)v4, 2);
+	return result;
+} */

--- a/DiabloUI/disclaim.cpp
+++ b/DiabloUI/disclaim.cpp
@@ -1,0 +1,125 @@
+// ref: 0x100063B3
+signed int __stdcall UiBetaDisclaimer(int a1) { return 0; }
+/* {
+	int v1; // eax
+
+	v1 = SDrawGetFrameWindow();
+	SDlgDialogBoxParam(hInstance, "DISCLAIMER_DIALOG", v1, disclaim_100063DA, a1);
+	return 1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x100063DA
+int __stdcall disclaim_100063DA(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v5; // eax
+	int v6; // [esp+0h] [ebp-8h]
+
+	if ( Msg > 0x111 )
+	{
+		if ( Msg != 513 && Msg != 516 )
+		{
+			if ( Msg == 528 )
+			{
+				if ( (_WORD)wParam == 513 || (_WORD)wParam == 516 )
+					disclaim_10006552(hWnd);
+			}
+			else if ( Msg == 2024 )
+			{
+				if ( !Fade_1000739F() )
+					Fade_100073FD(hWnd, v6);
+				return 0;
+			}
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+	}
+	else if ( Msg != 273 )
+	{
+		if ( Msg != 2 )
+		{
+			if ( Msg != 256 )
+			{
+				if ( Msg > 0x103 )
+				{
+					if ( Msg <= 0x105 )
+					{
+						v5 = (HWND)SDrawGetFrameWindow();
+						SendMessageA(v5, Msg, wParam, lParam);
+					}
+					else if ( Msg == 272 )
+					{
+						disclaim_100064F3(hWnd);
+						PostMessageA(hWnd, 0x7E8u, 0, 0);
+						return 1;
+					}
+				}
+				return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+			}
+			goto LABEL_21;
+		}
+		disclaim_100064C9(hWnd);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+LABEL_21:
+	disclaim_10006552(hWnd);
+	return 0;
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x100064C9
+void UNKCALL disclaim_100064C9(HWND hDlg) { return; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	Doom_10006C53(hDlg, (int *)&unk_10022AA4);
+	Doom_10006C53(v1, (int *)&unk_10022A98);
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+} */
+
+// ref: 0x100064F3
+int UNKCALL disclaim_100064F3(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	int v2; // eax
+	int *v3; // esi
+
+	v1 = hWnd;
+	v2 = local_10007F46();
+	v3 = (int *)v2;
+	if ( v2 )
+	{
+		SetWindowLongA(v1, -21, v2);
+		local_10007944((int)v1, 0, &byte_10029448, -1, 1, (int)"ui_art\\disclaim.pcx", v3, v3 + 1, 0);
+		Fade_100073C5(v1, 0);
+	}
+	Doom_100068AB(v1, (int *)&unk_10022A98, 5);
+	return Doom_100068AB(v1, (int *)&unk_10022AA4, 2);
+} */
+
+// ref: 0x10006552
+int UNKCALL disclaim_10006552(void *arg) { return 0; }
+/* {
+	void *v1; // esi
+
+	v1 = arg;
+	Fade_100073B4();
+	Fade_100072BE(10);
+	return SDlgEndDialog(v1, 1);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+
+// ref: 0x10006571
+signed int disclaim_10006571() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029850 = 2139095040;
+	return result;
+} */
+// 10029850: using guessed type int dword_10029850;

--- a/DiabloUI/doom.cpp
+++ b/DiabloUI/doom.cpp
@@ -1,0 +1,502 @@
+// ref: 0x10006581
+signed int Doom_10006581() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029854 = 2139095040;
+	return result;
+} */
+// 10029854: using guessed type int dword_10029854;
+
+// ref: 0x1000658C
+int __fastcall Doom_1000658C(HWND hWnd, int *a2, int a3, int a4) { return 0; }
+/* {
+	int *v4; // esi
+	HWND v5; // edi
+	HWND v6; // eax
+	int result; // eax
+
+	v4 = a2;
+	v5 = hWnd;
+	while ( 1 )
+	{
+		result = *v4;
+		if ( !*v4 )
+			break;
+		v6 = GetDlgItem(v5, result);
+		Doom_100065BB(v5, v6, a3, a4);
+		++v4;
+	}
+	return result;
+} */
+
+// ref: 0x100065BB
+void __fastcall Doom_100065BB(HWND hWnd, HWND a2, int a3, int a4) { return; }
+/* {
+	HWND v4; // esi
+	HWND v5; // edi
+	int v6; // eax
+	CHAR String; // [esp+8h] [ebp-100h]
+
+	v4 = a2;
+	v5 = hWnd;
+	if ( a2 )
+	{
+		Doom_10006719((int)hWnd, a2, 1521);
+		Doom_1000678A(v5, v4);
+		artfont_10001058((char *)a3);
+		Doom_1000663F(v4, a4);
+		GetWindowTextA(v4, &String, 255);
+		if ( strlen(&String) )
+		{
+			v6 = GetWindowLongA(v4, -21);
+			local_10007FA4(v6, &String);
+			SetWindowTextA(v4, &byte_10029448);
+		}
+	}
+} */
+
+// ref: 0x1000663F
+_DWORD *__fastcall Doom_1000663F(HWND hWnd, int a2) { return 0; }
+/* {
+	int v2; // edi
+	_DWORD *result; // eax
+	_DWORD *v4; // esi
+	unsigned char *v5; // ebx
+	int v6; // edi
+	size_t v7; // eax
+	unsigned char *i; // eax
+	int v9; // kr04_4
+	int v10; // eax
+	CHAR String; // [esp+8h] [ebp-10Ch]
+	unsigned char *v12; // [esp+108h] [ebp-Ch]
+	HWND hWnda; // [esp+10Ch] [ebp-8h]
+	int v14; // [esp+110h] [ebp-4h]
+
+	v2 = a2;
+	hWnda = hWnd;
+	result = (_DWORD *)GetWindowLongA(hWnd, -21);
+	v4 = result;
+	if ( result && *result )
+	{
+		GetWindowTextA(hWnda, &String, 255);
+		v5 = (unsigned char *)&String;
+		if ( !strlen(&String) )
+			v5 = (unsigned char *)(v4 + 4);
+		v14 = artfont_10001329(v5);
+		if ( v2 )
+		{
+			v6 = v4[1] - 2 * Focus_10007482();
+			v7 = strlen((const char *)v5);
+			if ( v14 > v6 )
+			{
+				for ( i = &v5[v7]; ; i = v12 )
+				{
+					v12 = i - 1;
+					*v12 = 0;
+					v14 = artfont_10001329(v5);
+					if ( v14 <= v6 )
+						break;
+				}
+			}
+		}
+		v9 = v4[1] - v14 - 1;
+		v10 = artfont_100012F6();
+		artfont_100013CD(v5, v4, v9 / 2, (v4[2] - v10) / 2);
+		result = (_DWORD *)InvalidateRect(hWnda, 0, 0);
+	}
+	return result;
+} */
+
+// ref: 0x10006719
+int __fastcall Doom_10006719(int a1, HWND a2, int a3) { return 0; }
+/* {
+	HWND v3; // edi
+	_DWORD *v4; // eax
+	_DWORD *v5; // esi
+	struct tagRECT Rect; // [esp+8h] [ebp-10h]
+
+	v3 = a2;
+	GetClientRect(a2, &Rect);
+	v4 = (_DWORD *)local_10007F46();
+	v5 = v4;
+	v4[1] = Rect.right;
+	v4[2] = Rect.bottom;
+	*v4 = SMemAlloc(Rect.right * Rect.bottom, "C:\\Src\\Diablo\\DiabloUI\\Doom.cpp", 139, 0);
+	SetWindowLongA(v3, -21, (LONG)v5);
+	return SDlgSetBitmapI(v3, 0, &byte_10029448, -1, a3, *v5, 0, v5[1], v5[2], -1);
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000678A
+_DWORD *__fastcall Doom_1000678A(HWND hWnd, HWND a2) { return 0; }
+/* {
+	HWND v2; // edi
+	_DWORD *v3; // ebx
+	_DWORD *result; // eax
+	_DWORD *v5; // esi
+	struct tagRECT Rect; // [esp+Ch] [ebp-14h]
+	HWND hWnda; // [esp+1Ch] [ebp-4h]
+
+	v2 = a2;
+	hWnda = hWnd;
+	v3 = (_DWORD *)GetWindowLongA(hWnd, -21);
+	result = (_DWORD *)GetWindowLongA(v2, -21);
+	v5 = result;
+	if ( v3 && *v3 && result )
+	{
+		if ( *result )
+		{
+			GetWindowRect(v2, &Rect);
+			ScreenToClient(hWnda, (LPPOINT)&Rect);
+			ScreenToClient(hWnda, (LPPOINT)&Rect.right);
+			result = (_DWORD *)SBltROP3(
+								   *v5,
+								   Rect.left + *v3 + Rect.top * v3[1],
+								   v5[1],
+								   v5[2],
+								   v5[1],
+								   v3[1],
+								   0,
+								   13369376);
+		}
+	}
+	return result;
+} */
+// 100103F4: using guessed type int __stdcall SBltROP3(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000680A
+int __fastcall Doom_1000680A(HWND hDlg, int *a2, int a3, int a4) { return 0; }
+/* {
+	int *v4; // esi
+	HWND v5; // edi
+	HWND v6; // eax
+	int result; // eax
+
+	v4 = a2;
+	v5 = hDlg;
+	while ( 1 )
+	{
+		result = *v4;
+		if ( !*v4 )
+			break;
+		v6 = GetDlgItem(v5, result);
+		Doom_10006839(v5, v6, (char *)a3, a4);
+		++v4;
+	}
+	return result;
+} */
+
+// ref: 0x10006839
+void __fastcall Doom_10006839(HWND a1, HWND a2, char *a3, int a4) { return; }
+/* {
+	HWND v4; // esi
+	int v5; // eax
+	CHAR String; // [esp+4h] [ebp-100h]
+
+	v4 = a2;
+	if ( a2 )
+	{
+		Doom_1000678A(a1, a2);
+		artfont_10001058(a3);
+		Doom_1000663F(v4, a4);
+		GetWindowTextA(v4, &String, 255);
+		if ( strlen(&String) )
+		{
+			v5 = GetWindowLongA(v4, -21);
+			local_10007FA4(v5, &String);
+			SetWindowTextA(v4, &byte_10029448);
+		}
+	}
+} */
+
+// ref: 0x100068AB
+int __fastcall Doom_100068AB(HWND hWnd, int *a2, int a3) { return 0; }
+/* {
+	int *v3; // esi
+	HWND v4; // edi
+	HWND v5; // eax
+	int result; // eax
+
+	v3 = a2;
+	v4 = hWnd;
+	while ( 1 )
+	{
+		result = *v3;
+		if ( !*v3 )
+			break;
+		v5 = GetDlgItem(v4, result);
+		Doom_100068D6(v4, v5, a3);
+		++v3;
+	}
+	return result;
+} */
+
+// ref: 0x100068D6
+void __fastcall Doom_100068D6(HWND hWnd, HWND a2, int a3) { return; }
+/* {
+	HWND v3; // esi
+	HWND v4; // edi
+	int v5; // eax
+	int v6; // eax
+	CHAR String; // [esp+8h] [ebp-100h]
+
+	v3 = a2;
+	v4 = hWnd;
+	if ( a2 )
+	{
+		Doom_10006719((int)hWnd, a2, 1);
+		Doom_1000678A(v4, v3);
+		artfont_10001058((char *)a3);
+		v5 = GetWindowLongA(v3, -16);
+		Doom_1000695D(v3, v5);
+		GetWindowTextA(v3, &String, 255);
+		if ( strlen(&String) )
+		{
+			v6 = GetWindowLongA(v3, -21);
+			local_10007FA4(v6, &String);
+			SetWindowTextA(v3, &byte_10029448);
+		}
+	}
+} */
+
+// ref: 0x1000695D
+_DWORD *__fastcall Doom_1000695D(HWND hWnd, int a2) { return 0; }
+/* {
+	_DWORD *result; // eax
+	_DWORD *v3; // esi
+	unsigned char *v4; // edi
+	int v5; // eax
+	CHAR String; // [esp+4h] [ebp-108h]
+	int v7; // [esp+104h] [ebp-8h]
+	HWND hWnda; // [esp+108h] [ebp-4h]
+
+	v7 = a2;
+	hWnda = hWnd;
+	result = (_DWORD *)GetWindowLongA(hWnd, -21);
+	v3 = result;
+	if ( result && *result )
+	{
+		GetWindowTextA(hWnda, &String, 255);
+		v4 = (unsigned char *)&String;
+		if ( !strlen(&String) )
+			v4 = (unsigned char *)(v3 + 4);
+		if ( v7 & 2 )
+		{
+			v5 = v3[1] - artfont_10001329(v4) - 1;
+		}
+		else if ( v7 & 1 )
+		{
+			v5 = (v3[1] - artfont_10001329(v4) - 1) / 2;
+		}
+		else
+		{
+			v5 = 0;
+		}
+		artfont_100013CD(v4, v3, v5, 0);
+		result = (_DWORD *)InvalidateRect(hWnda, 0, 0);
+	}
+	return result;
+} */
+
+// ref: 0x10006A13
+int __fastcall Doom_10006A13(HWND hDlg, int *a2, int a3) { return 0; }
+/* {
+	int *v3; // esi
+	HWND v4; // edi
+	HWND v5; // eax
+	int result; // eax
+
+	v3 = a2;
+	v4 = hDlg;
+	while ( 1 )
+	{
+		result = *v3;
+		if ( !*v3 )
+			break;
+		v5 = GetDlgItem(v4, result);
+		Doom_10006A3E(v4, v5, (char *)a3);
+		++v3;
+	}
+	return result;
+} */
+
+// ref: 0x10006A3E
+void __fastcall Doom_10006A3E(HWND a1, HWND a2, char *a3) { return; }
+/* {
+	HWND v3; // edi
+	int v4; // eax
+	int v5; // eax
+	CHAR String; // [esp+8h] [ebp-100h]
+
+	v3 = a2;
+	if ( a2 )
+	{
+		Doom_1000678A(a1, a2);
+		artfont_10001058(a3);
+		v4 = GetWindowLongA(v3, -16);
+		Doom_1000695D(v3, v4);
+		GetWindowTextA(v3, &String, 255);
+		if ( strlen(&String) )
+		{
+			v5 = GetWindowLongA(v3, -21);
+			local_10007FA4(v5, &String);
+			SetWindowTextA(v3, &byte_10029448);
+		}
+	}
+} */
+
+// ref: 0x10006AB8
+int __fastcall Doom_10006AB8(HWND hWnd, int *a2, int a3) { return 0; }
+/* {
+	int *v3; // esi
+	HWND v4; // edi
+	HWND v5; // eax
+	int result; // eax
+
+	v3 = a2;
+	v4 = hWnd;
+	while ( 1 )
+	{
+		result = *v3;
+		if ( !*v3 )
+			break;
+		v5 = GetDlgItem(v4, result);
+		Doom_10006AE3(v4, v5, a3);
+		++v3;
+	}
+	return result;
+} */
+
+// ref: 0x10006AE3
+void __fastcall Doom_10006AE3(HWND hWnd, HWND a2, int a3) { return; }
+/* {
+	HWND v3; // esi
+	HWND v4; // edi
+
+	v3 = a2;
+	v4 = hWnd;
+	if ( a2 )
+	{
+		Doom_10006719((int)hWnd, a2, 1);
+		Doom_1000678A(v4, v3);
+		artfont_10001058((char *)a3);
+		Doom_10006B12(v3);
+	}
+} */
+
+// ref: 0x10006B12
+void UNKCALL Doom_10006B12(HWND hWnd) { return; }
+/* {
+	HWND v1; // ebx
+	_DWORD *v2; // eax
+	int v3; // edi
+	int v4; // edi
+	int v5; // esi
+	int v6; // esi
+	unsigned char *v7; // ebx
+	int v8; // eax
+	char v9; // [esp+3h] [ebp-11Dh]
+	CHAR String; // [esp+4h] [ebp-11Ch]
+	struct tagRECT Rect; // [esp+104h] [ebp-1Ch]
+	LRESULT v12; // [esp+114h] [ebp-Ch]
+	_DWORD *v13; // [esp+118h] [ebp-8h]
+	size_t v14; // [esp+11Ch] [ebp-4h]
+
+	v1 = hWnd;
+	v2 = (_DWORD *)GetWindowLongA(hWnd, -21);
+	v13 = v2;
+	if ( v2 && *v2 )
+	{
+		GetWindowTextA(v1, &String, 255);
+		v14 = strlen(&String);
+		v3 = Focus_10007482();
+		v4 = artfont_10001310() + v3;
+		GetClientRect(v1, &Rect);
+		v5 = Focus_10007482();
+		v6 = Rect.right - 2 * (artfont_10001310() + v5);
+		v12 = SendMessageA(v1, 0x403u, 0, 0);
+		if ( v12 == 1 )
+			*(&v9 + v14) = 0;
+		v7 = (unsigned char *)&String;
+		if ( String )
+		{
+			do
+			{
+				if ( artfont_10001329(v7) <= v6 )
+					break;
+				++v7;
+			}
+			while ( *v7 );
+		}
+		if ( v12 )
+			*(&v9 + v14) = 124;
+		v8 = artfont_100012F6();
+		artfont_100013CD(v7, v13, v4, (v13[2] - v8) / 2);
+	}
+} */
+
+// ref: 0x10006C08
+int __fastcall Doom_10006C08(HWND hDlg, int *a2, int a3) { return 0; }
+/* {
+	int *v3; // esi
+	HWND v4; // edi
+	HWND v5; // eax
+	int result; // eax
+
+	v3 = a2;
+	v4 = hDlg;
+	while ( 1 )
+	{
+		result = *v3;
+		if ( !*v3 )
+			break;
+		v5 = GetDlgItem(v4, result);
+		Doom_10006C33(v4, v5, (char *)a3);
+		++v3;
+	}
+	return result;
+} */
+
+// ref: 0x10006C33
+void __fastcall Doom_10006C33(HWND a1, HWND a2, char *a3) { return; }
+/* {
+	HWND v3; // esi
+
+	v3 = a2;
+	if ( a2 )
+	{
+		Doom_1000678A(a1, a2);
+		artfont_10001058(a3);
+		Doom_10006B12(v3);
+	}
+} */
+
+// ref: 0x10006C53
+int __fastcall Doom_10006C53(HWND hDlg, int *a2) { return 0; }
+/* {
+	int *v2; // edi
+	HWND v3; // ebx
+	int result; // eax
+	HWND v5; // eax
+	HWND v6; // esi
+	_DWORD *v7; // eax
+
+	v2 = a2;
+	v3 = hDlg;
+	for ( result = *a2; *v2; result = *v2 )
+	{
+		v5 = GetDlgItem(v3, result);
+		v6 = v5;
+		if ( v5 )
+		{
+			v7 = (_DWORD *)GetWindowLongA(v5, -21);
+			local_10007F72(v7);
+			SetWindowLongA(v6, -21, 0);
+		}
+		++v2;
+	}
+	return result;
+} */

--- a/DiabloUI/entdial.cpp
+++ b/DiabloUI/entdial.cpp
@@ -1,0 +1,188 @@
+// ref: 0x10006C96
+int __stdcall EntDial_10006C96(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	int v4; // edx
+	HWND v5; // eax
+	HWND v7; // eax
+	int savedregs; // [esp+Ch] [ebp+0h]
+
+	v4 = 2;
+	if ( Msg == 2 )
+	{
+		EntDial_10006D78(hDlg);
+	}
+	else if ( Msg > 0x103 )
+	{
+		if ( Msg <= 0x105 )
+		{
+			v7 = (HWND)SDrawGetFrameWindow();
+			SendMessageA(v7, Msg, wParam, lParam);
+		}
+		else
+		{
+			if ( Msg == 272 )
+			{
+				lpString = (LPSTR)lParam;
+				EntDial_10006DB8(hDlg, (int)&savedregs);
+				return 0;
+			}
+			if ( Msg != 273 )
+			{
+				if ( Msg != 275 )
+				{
+					if ( Msg == 513 )
+						EntDial_10006F16(hDlg, (unsigned short)lParam, (unsigned int)lParam >> 16);
+					return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+				}
+				v5 = GetFocus();
+				Focus_100075DC(hDlg, v5);
+				return 0;
+			}
+			if ( (unsigned short)wParam == 1 )
+			{
+				v4 = 1;
+			}
+			else if ( (unsigned short)wParam != 2 )
+			{
+				if ( (unsigned short)wParam == 1116 )
+					EntDial_10006EE8(hDlg, wParam, lParam);
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+			}
+			EntDial_10006EA7(hDlg, v4);
+		}
+	}
+	return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x10006D78
+HWND UNKCALL EntDial_10006D78(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // eax
+
+	v1 = hDlg;
+	Focus_100076C3();
+	Doom_10006C53(v1, (int *)&unk_10022B10);
+	Doom_10006C53(v1, (int *)&unk_10022B04);
+	Doom_10006C53(v1, (int *)&unk_10022AFC);
+	v2 = GetParent(v1);
+	return Modem_10008563(v2, 0, 0);
+} */
+
+// ref: 0x10006DB8
+HWND USERCALL EntDial_10006DB8(HWND hWnd, int a2) { return 0; }
+/* {
+	HWND v2; // esi
+	HWND v3; // eax
+	LONG v4; // eax
+	HWND v5; // ebx
+	HWND v6; // eax
+	int v8; // [esp-138h] [ebp-144h]
+	int v9; // [esp-38h] [ebp-44h]
+	int v10; // [esp+8h] [ebp-4h]
+
+	v2 = hWnd;
+	v3 = GetParent(hWnd);
+	v4 = GetWindowLongA(v3, -21);
+	SetWindowLongA(v2, -21, v4);
+	Doom_100068AB(v2, (int *)&unk_10022AFC, 5);
+	Doom_1000658C(v2, (int *)&unk_10022B04, 4, 0);
+	Doom_10006AB8(v2, (int *)&unk_10022B10, 2);
+	Focus_10007719("ui_art\\focus.pcx");
+	SDlgSetTimer(v2, 1, 55, 0);
+	v5 = GetDlgItem(v2, 1116);
+	SendMessageA(v5, 0x401u, 0x1Fu, 0);
+	SendMessageA(v5, 0x404u, 0, (LPARAM)"<>%&?");
+	v10 = a2;
+	LoadStringA(hInstance, 0x3Bu, (LPSTR)&v9, 63);
+	LoadStringA(hInstance, 0x3Au, (LPSTR)&v8, 255);
+	v6 = GetParent(v2);
+	return Modem_10008563(v6, (const char *)&v9, (int)&v8);
+} */
+// 10006DB8: could not find valid save-restore pair for ebp
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10006EA7
+int __fastcall EntDial_10006EA7(HWND hDlg, int a2) { return 0; }
+/* {
+	int v2; // edi
+	HWND v3; // esi
+	CHAR *v4; // ST08_4
+	HWND v5; // eax
+
+	v2 = a2;
+	v3 = hDlg;
+	TitleSnd_1001031F();
+	SDlgKillTimer(v3, 1);
+	v4 = lpString;
+	v5 = GetDlgItem(v3, 1116);
+	GetWindowTextA(v5, v4, 32);
+	lpString[31] = 0;
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x10006EE8
+void __fastcall EntDial_10006EE8(HWND hWnd, unsigned int a2, int a3) { return; }
+/* {
+	int v3; // edx
+	HWND v4; // esi
+	HWND v5; // eax
+
+	v3 = (a2 >> 16) - 1;
+	v4 = hWnd;
+	if ( v3 )
+	{
+		if ( v3 == 2 )
+			Doom_10006C08(hWnd, (int *)&unk_10022B10, 2);
+	}
+	else
+	{
+		v5 = GetFocus();
+		Focus_100075DC(v4, v5);
+	}
+} */
+
+// ref: 0x10006F16
+int __fastcall EntDial_10006F16(HWND hDlg, int a2, int a3) { return 0; }
+/* {
+	int v3; // ebx
+	HWND v4; // esi
+	int v5; // ST08_4
+	HWND v6; // eax
+	int v7; // edx
+	HWND v8; // eax
+	int result; // eax
+
+	v3 = a2;
+	v4 = hDlg;
+	v5 = a2;
+	v6 = GetDlgItem(hDlg, 1056);
+	if ( local_10007C3B(v4, v6, v5, a3) )
+	{
+		v7 = 1;
+	}
+	else
+	{
+		v8 = GetDlgItem(v4, 1054);
+		result = local_10007C3B(v4, v8, v3, a3);
+		if ( !result )
+			return result;
+		v7 = 2;
+	}
+	return EntDial_10006EA7(v4, v7);
+} */
+
+// ref: 0x10006F71
+signed int EntDial_10006F71() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002985C = 2139095040;
+	return result;
+} */
+// 1002985C: using guessed type int dword_1002985C;

--- a/DiabloUI/entname.cpp
+++ b/DiabloUI/entname.cpp
@@ -1,0 +1,167 @@
+// ref: 0x10006F7C
+int __stdcall EntName_10006F7C(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	int v4; // edx
+	HWND v5; // eax
+	HWND v6; // eax
+	HWND v7; // eax
+	HWND v9; // eax
+
+	v4 = 2;
+	if ( Msg == 2 )
+	{
+		EntName_1000709E(hDlg);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v9 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v9, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	switch ( Msg )
+	{
+		case 0x110u:
+			dword_10029864 = (LPSTR)lParam;
+			EntName_100070DB(hDlg);
+			return 0;
+		case 0x111u:
+			if ( (unsigned short)wParam != 1 )
+			{
+				if ( (unsigned short)wParam != 2 )
+				{
+					if ( (unsigned short)wParam == 1065 )
+						EntName_100071ED(hDlg, wParam, lParam);
+					return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+				}
+				goto LABEL_11;
+			}
+			goto LABEL_18;
+		case 0x113u:
+			v7 = GetFocus();
+			Focus_100075DC(hDlg, v7);
+			return 0;
+	}
+	if ( Msg != 513 )
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	v5 = GetDlgItem(hDlg, 1056);
+	if ( local_10007C3B(hDlg, v5, (unsigned short)lParam, (unsigned int)lParam >> 16) )
+	{
+LABEL_18:
+		v4 = 1;
+		goto LABEL_11;
+	}
+	v6 = GetDlgItem(hDlg, 1054);
+	if ( local_10007C3B(hDlg, v6, (unsigned short)lParam, (unsigned int)lParam >> 16) )
+	{
+		v4 = 2;
+LABEL_11:
+		EntName_100071AC(hDlg, v4);
+	}
+	return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x1000709E
+HWND UNKCALL EntName_1000709E(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // eax
+
+	v1 = hDlg;
+	Focus_100076C3();
+	Doom_10006C53(v1, (int *)&unk_10022B48);
+	Doom_10006C53(v1, (int *)&unk_10022B3C);
+	Doom_10006C53(v1, (int *)&unk_10022B34);
+	v2 = GetParent(v1);
+	return SelHero_1000BA7B(v2, 0);
+} */
+
+// ref: 0x100070DB
+int UNKCALL EntName_100070DB(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // edi
+	LONG v3; // eax
+	HWND v4; // ebx
+	int result; // eax
+	CHAR Buffer; // [esp+Ch] [ebp-20h]
+
+	v1 = hWnd;
+	v2 = GetParent(hWnd);
+	if ( SelHero_1000B7CA() == 1 )
+		LoadStringA(hInstance, 0x20u, &Buffer, 31);
+	else
+		LoadStringA(hInstance, 0x1Fu, &Buffer, 31);
+	SelHero_1000BA7B(v2, &Buffer);
+	v3 = GetWindowLongA(v2, -21);
+	SetWindowLongA(v1, -21, v3);
+	Doom_100068AB(v1, (int *)&unk_10022B34, 5);
+	Doom_1000658C(v1, (int *)&unk_10022B3C, 4, 0);
+	Doom_10006AB8(v1, (int *)&unk_10022B48, 2);
+	Focus_10007719("ui_art\\focus.pcx");
+	SDlgSetTimer(v1, 1, 55, 0);
+	v4 = GetDlgItem(v1, 1065);
+	SendMessageA(v4, 0x401u, 0xFu, 0);
+	result = SelHero_1000B7CA();
+	if ( result == 1 )
+		result = SendMessageA(v4, 0x404u, 0, (LPARAM)" ,<>%&\\\"?*#/");
+	return result;
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x100071AC
+int __fastcall EntName_100071AC(HWND hDlg, int a2) { return 0; }
+/* {
+	int v2; // edi
+	HWND v3; // esi
+	CHAR *v4; // ST08_4
+	HWND v5; // eax
+
+	v2 = a2;
+	v3 = hDlg;
+	TitleSnd_1001031F();
+	SDlgKillTimer(v3, 1);
+	v4 = dword_10029864;
+	v5 = GetDlgItem(v3, 1065);
+	GetWindowTextA(v5, v4, 16);
+	dword_10029864[15] = 0;
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x100071ED
+void __fastcall EntName_100071ED(HWND hWnd, unsigned int a2, int a3) { return; }
+/* {
+	int v3; // edx
+	HWND v4; // esi
+	HWND v5; // eax
+
+	v3 = (a2 >> 16) - 1;
+	v4 = hWnd;
+	if ( v3 )
+	{
+		if ( v3 == 2 )
+			Doom_10006C08(hWnd, (int *)&unk_10022B48, 2);
+	}
+	else
+	{
+		v5 = GetFocus();
+		Focus_100075DC(v4, v5);
+	}
+} */
+
+// ref: 0x10007220
+signed int EntName_10007220() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029860 = 2139095040;
+	return result;
+} */
+// 10029860: using guessed type int dword_10029860;

--- a/DiabloUI/fade.cpp
+++ b/DiabloUI/fade.cpp
@@ -1,0 +1,186 @@
+// ref: 0x1000722B
+int __fastcall Fade_1000722B(int a1, int a2) { return 0; }
+/* {
+	int v2; // ebx
+	int v3; // edi
+	char *v4; // eax
+	char *v5; // ecx
+	BYTE *v6; // esi
+	BYTE v7; // al
+
+	v2 = a1;
+	v3 = a2;
+	v4 = local_10007895(0);
+	v5 = v4;
+	if ( v2 == v3 )
+	{
+		memcpy(&pPalEntries, v4, 0x400u);
+	}
+	else if ( v3 )
+	{
+		v6 = &pPalEntries.peGreen;
+		do
+		{
+			v7 = v3 * (unsigned char)*v5 / v2;
+			v5 += 4;
+			*(v6 - 1) = v7;
+			*v6 = v3 * (unsigned char)*(v5 - 3) / v2;
+			v6 += 4;
+			*(v6 - 3) = v3 * (unsigned char)*(v5 - 2) / v2;
+		}
+		while ( (signed int)v6 < (signed int)&dword_10029C70 + 1 );
+	}
+	else
+	{
+		memcpy(&pPalEntries, v4, 0x400u);
+		local_1000789D((char *)&pPalEntries);
+	}
+	return SDrawUpdatePalette(0, 256, &pPalEntries, 1);
+} */
+// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029C70: using guessed type int dword_10029C70;
+
+// ref: 0x100072BE
+int __fastcall Fade_100072BE(int a1) { return 0; }
+/* {
+	int v1; // ebx
+	char *v2; // eax
+	char *v3; // edi
+	BYTE *v4; // ecx
+	char v5; // al
+	HPALETTE v6; // ebx
+	int v8; // [esp+10h] [ebp-4h]
+
+	v1 = a1;
+	v2 = local_10007895(0);
+	memcpy(&pPalEntries, v2, 0x400u);
+	if ( v1 > 0 )
+	{
+		v8 = v1;
+		do
+		{
+			v3 = local_10007895(0);
+			v4 = &pPalEntries.peGreen;
+			do
+			{
+				v5 = (unsigned char)*v3 / v1;
+				v3 += 4;
+				*(v4 - 1) -= v5;
+				*v4 -= (unsigned char)*(v3 - 3) / v1;
+				v4 += 4;
+				*(v4 - 3) -= (unsigned char)*(v3 - 2) / v1;
+			}
+			while ( (signed int)v4 < (signed int)&dword_10029C70 + 1 );
+			SDrawUpdatePalette(0, 256, &pPalEntries, 1);
+			--v8;
+		}
+		while ( v8 );
+	}
+	local_1000789D((char *)&pPalEntries);
+	SDrawUpdatePalette(0, 256, &pPalEntries, 1);
+	local_1000811B();
+	SDrawClearSurface();
+	v6 = (HPALETTE)GetStockObject(15);
+	GetPaletteEntries(v6, 0, 0xAu, &pPalEntries);
+	GetPaletteEntries(v6, 0xAu, 0xAu, &stru_10029C48);
+	return SDrawUpdatePalette(0, 256, &pPalEntries, 1);
+} */
+// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1001043C: using guessed type _DWORD __stdcall SDrawClearSurface();
+// 10029C70: using guessed type int dword_10029C70;
+
+// ref: 0x1000739F
+signed int Fade_1000739F() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 0;
+	if ( dword_10029C70 )
+	{
+		if ( dword_1002986C <= 5 )
+			result = 1;
+	}
+	return result;
+} */
+// 1002986C: using guessed type int dword_1002986C;
+// 10029C70: using guessed type int dword_10029C70;
+
+// ref: 0x100073B4
+signed int Fade_100073B4() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = Fade_1000739F();
+	if ( result )
+		dword_10029C70 = 0;
+	return result;
+} */
+// 10029C70: using guessed type int dword_10029C70;
+
+// ref: 0x100073C5
+int __fastcall Fade_100073C5(HWND hWnd, int a2) { return 0; }
+/* {
+	int v2; // esi
+	HWND v3; // eax
+	int result; // eax
+
+	v2 = a2;
+	v3 = GetParent(hWnd);
+	result = local_10007F04(v3);
+	if ( v2 )
+		result = local_100080F1();
+	dword_10029C70 = 0;
+	dword_1002986C = 0;
+	return result;
+} */
+// 1002986C: using guessed type int dword_1002986C;
+// 10029C70: using guessed type int dword_10029C70;
+
+// ref: 0x100073EF
+BOOL UNKCALL Fade_100073EF(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // eax
+
+	v1 = GetParent(hWnd);
+	return local_10007F04(v1);
+} */
+
+// ref: 0x100073FD
+int UNKCALL Fade_100073FD(void *arg, int a2) { return 0; }
+/* {
+	int result; // eax
+
+	if ( !dword_10029C70 )
+	{
+		result = SDlgSetTimer(arg, 16, 50, Fade_10007420);
+		dword_10029C70 = 1;
+	}
+	return result;
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029C70: using guessed type int dword_10029C70;
+
+// ref: 0x10007420
+int __stdcall Fade_10007420(int a1, int a2, int a3, int a4) { return 0; }
+/* {
+	int result; // eax
+
+	if ( dword_1002986C > 5 )
+		return SDlgKillTimer(a1, 16);
+	result = Fade_1000722B(5, dword_1002986C);
+	++dword_1002986C;
+	return result;
+} */
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 1002986C: using guessed type int dword_1002986C;
+
+// ref: 0x1000744D
+signed int Fade_1000744D() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029868 = 2139095040;
+	return result;
+} */
+// 10029868: using guessed type int dword_10029868;

--- a/DiabloUI/focus.cpp
+++ b/DiabloUI/focus.cpp
@@ -1,0 +1,288 @@
+// ref: 0x10007458
+int (__stdcall *UNKCALL Focus_10007458(void *arg))(_DWORD) { return 0; }
+/* {
+	int v1; // esi
+	int (__stdcall *result)(_DWORD); // eax
+
+	v1 = (int)arg;
+	if ( dword_10029CA4 && arg != (void *)dword_10029CA8 )
+	{
+		if ( dword_10029CAC )
+			result = TitleSnd_10010315();
+		dword_10029CA8 = v1;
+	}
+	return result;
+} */
+// 10029CA4: using guessed type int dword_10029CA4;
+// 10029CA8: using guessed type int dword_10029CA8;
+// 10029CAC: using guessed type int dword_10029CAC;
+
+// ref: 0x10007482
+int Focus_10007482() { return 0; }
+/* {
+	return dword_10029CA4 != 0 ? dword_10029C98 : 0;
+} */
+// 10029C98: using guessed type int dword_10029C98;
+// 10029CA4: using guessed type int dword_10029CA4;
+
+// ref: 0x10007492
+_DWORD *__fastcall Focus_10007492(HWND hWnd, HWND a2) { return 0; }
+/* {
+	_DWORD *v2; // edi
+	_DWORD *result; // eax
+	_DWORD *v4; // esi
+	int v5; // eax
+	int v6; // ST14_4
+	int v7; // eax
+	struct tagRECT Rect; // [esp+8h] [ebp-18h]
+	HWND v9; // [esp+18h] [ebp-8h]
+	HWND hWnda; // [esp+1Ch] [ebp-4h]
+
+	hWnda = a2;
+	v9 = hWnd;
+	v2 = (_DWORD *)GetWindowLongA(hWnd, -21);
+	result = (_DWORD *)GetWindowLongA(hWnda, -21);
+	v4 = result;
+	if ( v2 && result && *v2 )
+	{
+		if ( *result )
+		{
+			GetWindowRect(hWnda, &Rect);
+			ScreenToClient(v9, (LPPOINT)&Rect);
+			ScreenToClient(v9, (LPPOINT)&Rect.right);
+			SBltROP3(*v4, Rect.left + *v2 + Rect.top * v2[1], dword_10029C98, v4[2], v4[1], v2[1], 0, 13369376);
+			v5 = v2[1];
+			v6 = v5;
+			v7 = *v2 + Rect.top * v5;
+			v9 = (HWND)v4[1];
+			SBltROP3(
+				(char *)v9 + *v4 - dword_10029C98,
+				(char *)v9 + v7 - dword_10029C98 + Rect.left,
+				dword_10029C98,
+				v4[2],
+				v9,
+				v6,
+				0,
+				13369376);
+			result = (_DWORD *)Focus_10007566(hWnda);
+		}
+	}
+	return result;
+} */
+// 100103F4: using guessed type int __stdcall SBltROP3(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029C98: using guessed type int dword_10029C98;
+
+// ref: 0x10007566
+BOOL UNKCALL Focus_10007566(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	struct tagRECT Rect; // [esp+8h] [ebp-10h]
+
+	v1 = hWnd;
+	GetClientRect(hWnd, &Rect);
+	--Rect.bottom;
+	Rect.left = --Rect.right - dword_10029C98;
+	InvalidateRect(v1, &Rect, 0);
+	Rect.left = 0;
+	Rect.right = dword_10029C98 - 1;
+	return InvalidateRect(v1, &Rect, 0);
+} */
+// 10029C98: using guessed type int dword_10029C98;
+
+// ref: 0x100075B7
+_DWORD *__fastcall Focus_100075B7(HWND hWnd, HWND a2) { return 0; }
+/* {
+	HWND v2; // esi
+	HWND v3; // edi
+	_DWORD *result; // eax
+
+	v2 = a2;
+	v3 = hWnd;
+	GetWindowLongA(a2, -12);
+	result = Focus_10007492(v3, v2);
+	dword_10029CAC = 1;
+	return result;
+} */
+// 10029CAC: using guessed type int dword_10029CAC;
+
+// ref: 0x100075DC
+int __fastcall Focus_100075DC(HWND hWnd, HWND a2) { return 0; }
+/* {
+	HWND v2; // edi
+	HWND v3; // ebx
+	_DWORD *v4; // eax
+	_DWORD *v5; // esi
+	int v7; // edi
+	struct tagRECT Rect; // [esp+Ch] [ebp-14h]
+	HWND hWnda; // [esp+1Ch] [ebp-4h]
+
+	v2 = hWnd;
+	v3 = a2;
+	hWnda = hWnd;
+	if ( !dword_10029CA4 )
+		return 0;
+	if ( !a2 )
+		return 0;
+	GetWindowLongA(a2, -12);
+	if ( v2 != GetParent(v3) )
+		return 0;
+	Focus_10007492(v2, v3);
+	v4 = (_DWORD *)GetWindowLongA(v3, -21);
+	v5 = v4;
+	if ( !v4 || !*v4 )
+		return 0;
+	GetWindowRect(v3, &Rect);
+	ScreenToClient(v2, (LPPOINT)&Rect);
+	ScreenToClient(hWnda, (LPPOINT)&Rect.right);
+	if ( dword_10029C78[dword_10029CB0] )
+	{
+		v7 = (v5[2] - dword_10029C9C) / 2;
+		STransBlt(*v5, 0, v7, v5[1], dword_10029C78[dword_10029CB0]);
+		STransBlt(*v5, v5[1] - dword_10029C98, v7, v5[1], dword_10029C78[dword_10029CB0]);
+		Focus_10007566(v3);
+	}
+	if ( ++dword_10029CB0 >= 8 )
+		dword_10029CB0 = 0;
+	return 1;
+} */
+// 1001036A: using guessed type int __stdcall STransBlt(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029C98: using guessed type int dword_10029C98;
+// 10029C9C: using guessed type int dword_10029C9C;
+// 10029CA4: using guessed type int dword_10029CA4;
+// 10029CB0: using guessed type int dword_10029CB0;
+
+// ref: 0x100076C3
+int Focus_100076C3() { return 0; }
+/* {
+	int *v0; // esi
+	int result; // eax
+
+	v0 = dword_10029C78;
+	do
+	{
+		result = *v0;
+		if ( *v0 )
+		{
+			result = STransDelete(*v0);
+			*v0 = 0;
+		}
+		++v0;
+	}
+	while ( (signed int)v0 < (signed int)&dword_10029C98 );
+	dword_10029CAC = 0;
+	dword_10029CA8 = 0;
+	dword_10029CA4 = 0;
+	return result;
+} */
+// 1001033A: using guessed type int __stdcall STransDelete(_DWORD);
+// 10029C98: using guessed type int dword_10029C98;
+// 10029CA4: using guessed type int dword_10029CA4;
+// 10029CA8: using guessed type int dword_10029CA8;
+// 10029CAC: using guessed type int dword_10029CAC;
+
+// ref: 0x100076FA
+void Focus_100076FA() { return; }
+/* {
+	dword_10029CAC = 0;
+	dword_10029CA8 = 0;
+} */
+// 10029CA8: using guessed type int dword_10029CA8;
+// 10029CAC: using guessed type int dword_10029CAC;
+
+// ref: 0x1000770E
+signed int Focus_1000770E() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029CA0 = 2139095040;
+	return result;
+} */
+// 10029CA0: using guessed type int dword_10029CA0;
+
+// ref: 0x10007719
+void UNKCALL Focus_10007719(void *arg) { return; }
+/* {
+	int *v1; // esi
+	int v2; // ecx
+	int v3; // eax
+	int v4; // ebx
+	int v5; // [esp+4h] [ebp-1Ch]
+	int v6; // [esp+8h] [ebp-18h]
+	int v7; // [esp+Ch] [ebp-14h]
+	int v8; // [esp+10h] [ebp-10h]
+	int v9; // [esp+14h] [ebp-Ch]
+	int v10; // [esp+18h] [ebp-8h]
+	int v11; // [esp+1Ch] [ebp-4h]
+
+	if ( !dword_10029CA4 )
+	{
+		v11 = 0;
+		dword_10029CAC = 0;
+		dword_10029CA8 = 0;
+		local_100078BE((int)arg, &v11, &v9);
+		v1 = dword_10029C78;
+		memset(dword_10029C78, 0, 0x20u);
+		if ( v11 )
+		{
+			v2 = v9;
+			dword_10029C98 = v9;
+			v3 = v10 / 8;
+			v4 = 0;
+			dword_10029C9C = v10 / 8;
+			while ( 1 )
+			{
+				v7 = v2 - 1;
+				v6 = v4 * v3;
+				v5 = 0;
+				v8 = v3 + v4 * v3 - 1;
+				STransCreateI(v11, v2, v3, 8, &v5, 16777466, v1);
+				++v1;
+				++v4;
+				if ( (signed int)v1 >= (signed int)&dword_10029C98 )
+					break;
+				v3 = dword_10029C9C;
+				v2 = dword_10029C98;
+			}
+			SMemFree(v11, "C:\\Src\\Diablo\\DiabloUI\\Focus.cpp", 246, 0);
+		}
+		dword_10029CB0 = 0;
+		dword_10029CA4 = 1;
+	}
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010346: using guessed type int __stdcall STransCreateI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029C98: using guessed type int dword_10029C98;
+// 10029C9C: using guessed type int dword_10029C9C;
+// 10029CA4: using guessed type int dword_10029CA4;
+// 10029CA8: using guessed type int dword_10029CA8;
+// 10029CAC: using guessed type int dword_10029CAC;
+// 10029CB0: using guessed type int dword_10029CB0;
+
+// ref: 0x100077E9
+int __fastcall Focus_100077E9(int a1, void *a2, HWND hWnd) { return 0; }
+/* {
+	int v3; // esi
+
+	v3 = a1;
+	Focus_10007719(a2);
+	return SDlgSetTimer(v3, 1, 55, Focus_10007804);
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10007804
+int __stdcall Focus_10007804(HWND hWnd, int a2, int a3, int a4) { return 0; }
+/* {
+	HWND v4; // eax
+
+	v4 = GetFocus();
+	return Focus_100075DC(hWnd, v4);
+} */
+
+// ref: 0x10007818
+int UNKCALL Focus_10007818(void *arg) { return 0; }
+/* {
+	SDlgKillTimer(arg, 1);
+	return Focus_100076C3();
+} */
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);

--- a/DiabloUI/local.cpp
+++ b/DiabloUI/local.cpp
@@ -1,0 +1,664 @@
+// ref: 0x10007825
+LOGPALETTE *local_10007825() { return 0; }
+/* {
+	LOGPALETTE *result; // eax
+	const LOGPALETTE *v1; // esi
+	int v2; // eax
+	signed int v3; // ecx
+
+	result = (LOGPALETTE *)SMemAlloc(1028, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 27, 0);
+	v1 = result;
+	if ( result )
+	{
+		result->palVersion = 768;
+		result->palNumEntries = 256;
+		v2 = (int)result->palPalEntry;
+		v3 = 0;
+		do
+		{
+			*(_DWORD *)v2 = v3;
+			*(_BYTE *)(v2 + 3) = 2;
+			++v3;
+			v2 += 4;
+		}
+		while ( v3 < 256 );
+		dword_1002A0C8 = CreatePalette(v1);
+		result = (LOGPALETTE *)SMemFree(v1, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 41, 0);
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000787D
+HGDIOBJ local_1000787D() { return 0; }
+/* {
+	HGDIOBJ result; // eax
+
+	result = dword_1002A0C8;
+	if ( dword_1002A0C8 )
+	{
+		result = (HGDIOBJ)DeleteObject(dword_1002A0C8);
+		dword_1002A0C8 = 0;
+	}
+	return result;
+} */
+
+// ref: 0x10007895
+char *__fastcall local_10007895(int a1) { return 0; }
+/* {
+	return (char *)&unk_10029CC8 + 4 * a1;
+} */
+
+// ref: 0x1000789D
+_BYTE *UNKCALL local_1000789D(char *arg) { return 0; }
+/* {
+	_BYTE *result; // eax
+	signed int v2; // ecx
+
+	result = arg + 2;
+	v2 = 256;
+	do
+	{
+		*(result - 2) = 0;
+		*(result - 1) = 0;
+		*result = 0;
+		result += 4;
+		--v2;
+	}
+	while ( v2 );
+	return result;
+} */
+
+// ref: 0x100078B6
+int local_100078B6() { return 0; }
+/* {
+	return SDrawClearSurface();
+} */
+// 1001043C: using guessed type _DWORD __stdcall SDrawClearSurface();
+
+// ref: 0x100078BE
+signed int __fastcall local_100078BE(int a1, int *a2, _DWORD *a3) { return 0; }
+/* {
+	int *v3; // edi
+	int v4; // eax
+	int v5; // ecx
+	int v7; // [esp+Ch] [ebp-Ch]
+	int v8; // [esp+10h] [ebp-8h]
+	int v9; // [esp+14h] [ebp-4h]
+
+	v3 = a2;
+	v7 = a1;
+	*a2 = 0;
+	if ( !SBmpLoadImage(a1, 0, 0, 0, &v9, &v8, 0) )
+		return 0;
+	v4 = SMemAlloc(v8 * v9, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 93, 0);
+	v5 = v9;
+	*v3 = v4;
+	if ( !SBmpLoadImage(v7, 0, v4, v8 * v5, 0, 0, 0) )
+	{
+		SMemFree(*v3, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 95, 0);
+		*v3 = 0;
+		return 0;
+	}
+	if ( a3 )
+	{
+		*a3 = v9;
+		a3[1] = v8;
+	}
+	return 1;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100103BE: using guessed type int __stdcall SBmpLoadImage(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10007944
+signed int __fastcall local_10007944(int a1, int a2, _BYTE *a3, int a4, int a5, int a6, int *a7, _DWORD *a8, int a9) { return 0; }
+/* {
+	int v9; // edi
+	int v10; // eax
+	int v11; // ST18_4
+	HPALETTE v13; // edi
+	struct tagPALETTEENTRY pPalEntries; // [esp+Ch] [ebp-40Ch]
+	struct tagPALETTEENTRY v15; // [esp+3E4h] [ebp-34h]
+	int v16; // [esp+40Ch] [ebp-Ch]
+	int v17; // [esp+410h] [ebp-8h]
+	int v18; // [esp+414h] [ebp-4h]
+
+	v9 = a2;
+	v16 = a1;
+	if ( !SBmpLoadImage(a6, 0, 0, 0, &v17, &v18, 0) )
+		return 0;
+	v10 = SMemAlloc(v18 * v17, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 129, 0);
+	v11 = v18 * v17;
+	*a7 = v10;
+	if ( !SBmpLoadImage(a6, &pPalEntries, v10, v11, 0, 0, 0)
+	  || !SDlgSetBitmapI(v16, v9, a3, a4, a5, *a7, 0, v17, v18, -1) )
+	{
+		return 0;
+	}
+	if ( !a3 || !*a3 )
+	{
+		v13 = (HPALETTE)GetStockObject(15);
+		GetPaletteEntries(v13, 0, 0xAu, &pPalEntries);
+		GetPaletteEntries(v13, 0xAu, 0xAu, &v15);
+		memcpy(&unk_10029CC8, &pPalEntries, 0x400u);
+		if ( a9 )
+		{
+			SDrawUpdatePalette(0, 255, &unk_10029CC8, 1);
+		}
+		else
+		{
+			local_1000789D((char *)&pPalEntries);
+			SDrawUpdatePalette(0, 256, &pPalEntries, 1);
+		}
+	}
+	if ( a8 )
+	{
+		*a8 = v17;
+		a8[1] = v18;
+	}
+	return 1;
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100103BE: using guessed type int __stdcall SBmpLoadImage(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10007A68
+int __fastcall local_10007A68(_DWORD *a1, int a2, int a3) { return 0; }
+/* {
+	int v3; // eax
+	int result; // eax
+	int v5; // edx
+
+	v3 = a2 - *a1;
+	*a1 = a2;
+	a1[2] += v3 - 1;
+	result = a3;
+	v5 = a3 - a1[1];
+	a1[1] = a3;
+	a1[3] += v5 - 1;
+	return result;
+} */
+
+// ref: 0x10007A85
+int __fastcall local_10007A85(HWND hWnd, int nIDDlgItem, int a3, int a4) { return 0; }
+/* {
+	HWND v4; // edi
+	HWND v5; // ebx
+	struct tagRECT Rect; // [esp+Ch] [ebp-10h]
+
+	v4 = hWnd;
+	v5 = GetDlgItem(hWnd, nIDDlgItem);
+	GetWindowRect(v5, &Rect);
+	ScreenToClient(v4, (LPPOINT)&Rect);
+	ScreenToClient(v4, (LPPOINT)&Rect.right);
+	SDlgSetBitmapI(v5, 0, "Static", -1, 1, a3, &Rect, *(_DWORD *)a4, *(_DWORD *)(a4 + 4), -1);
+	return 1;
+} */
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10007AEA
+signed int local_10007AEA() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_10029CB8 = 2139095040;
+	return result;
+} */
+// 10029CB8: using guessed type int dword_10029CB8;
+
+// ref: 0x10007AF5
+int __fastcall local_10007AF5(int a1, int a2, int a3, int a4, _DWORD *a5) { return 0; }
+/* {
+	return SDlgSetBitmapI(a1, 0, "Button", -1, a2, a4, a3, *a5, a5[1], -1);
+} */
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10007B1B
+int __fastcall local_10007B1B(HWND a1, int *a2, int a3, _DWORD *a4) { return 0; }
+/* {
+	int result; // eax
+	HWND v5; // esi
+	struct tagRECT Rect; // [esp+0h] [ebp-1Ch]
+	HWND hDlg; // [esp+10h] [ebp-Ch]
+	int v8; // [esp+14h] [ebp-8h]
+	int *v9; // [esp+18h] [ebp-4h]
+
+	result = *a2;
+	v8 = 0;
+	v9 = a2;
+	hDlg = a1;
+	if ( result )
+	{
+		do
+		{
+			v5 = GetDlgItem(hDlg, result);
+			if ( v5 )
+			{
+				GetClientRect(v5, &Rect);
+				local_10007A68(&Rect, 0, v8);
+				local_10007AF5((int)v5, 16, (int)&Rect, a3, a4);
+				++Rect.bottom;
+				++Rect.right;
+				local_10007A68(&Rect, 0, Rect.bottom);
+				local_10007AF5((int)v5, 64, (int)&Rect, a3, a4);
+				++Rect.bottom;
+				++Rect.right;
+				local_10007A68(&Rect, 0, Rect.bottom);
+				local_10007AF5((int)v5, 32, (int)&Rect, a3, a4);
+				++Rect.bottom;
+				++Rect.right;
+				local_10007A68(&Rect, 0, Rect.bottom);
+				local_10007AF5((int)v5, 128, (int)&Rect, a3, a4);
+				++Rect.bottom;
+				++Rect.right;
+				local_10007A68(&Rect, 0, Rect.bottom);
+				local_10007AF5((int)v5, 1280, (int)&Rect, a3, a4);
+				++Rect.bottom;
+				++Rect.right;
+				v8 = Rect.bottom;
+			}
+			++v9;
+			result = *v9;
+		}
+		while ( *v9 );
+	}
+	return result;
+} */
+
+// ref: 0x10007C2E
+COLORREF UNKCALL local_10007C2E(HDC hdc) { return 0; }
+/* {
+	return SetTextColor(hdc, 0xFFFFu);
+} */
+
+// ref: 0x10007C3B
+BOOL __fastcall local_10007C3B(HWND hWnd, HWND a2, int a3, int a4) { return 0; }
+/* {
+	HWND v4; // edi
+	BOOL result; // eax
+	struct tagRECT Rect; // [esp+4h] [ebp-10h]
+
+	v4 = hWnd;
+	if ( hWnd
+	  && a2
+	  && (GetWindowRect(a2, &Rect),
+		  ScreenToClient(v4, (LPPOINT)&Rect),
+		  ScreenToClient(v4, (LPPOINT)&Rect.right),
+		  a3 >= Rect.left)
+	  && a3 < Rect.right
+	  && a4 >= Rect.top )
+	{
+		result = a4 < Rect.bottom;
+	}
+	else
+	{
+		result = 0;
+	}
+	return result;
+} */
+
+// ref: 0x10007C95
+int UNKCALL local_10007C95(void *arg) { return 0; }
+/* {
+	void *v1; // esi
+	char v3; // [esp+4h] [ebp-40h]
+
+	v1 = arg;
+	SDlgBeginPaint(arg, &v3);
+	return SDlgEndPaint(v1, &v3);
+} */
+// 10010442: using guessed type int __stdcall SDlgEndPaint(_DWORD, _DWORD);
+// 10010448: using guessed type int __stdcall SDlgBeginPaint(_DWORD, _DWORD);
+
+// ref: 0x10007CB5
+int __fastcall local_10007CB5(HWND hDlg, int *a2) { return 0; }
+/* {
+	int *v2; // edi
+	HWND v3; // ebx
+	int result; // eax
+	HWND v5; // eax
+	HWND v6; // esi
+	void *v7; // eax
+
+	v2 = a2;
+	v3 = hDlg;
+	for ( result = *a2; *v2; result = *v2 )
+	{
+		v5 = GetDlgItem(v3, result);
+		v6 = v5;
+		if ( v5 )
+		{
+			v7 = (void *)GetWindowLongA(v5, -4);
+			SetPropA(v6, "UIWNDPROC", v7);
+			SetWindowLongA(v6, -4, (LONG)local_10007D01);
+		}
+		++v2;
+	}
+	return result;
+} */
+
+// ref: 0x10007D01
+LRESULT __stdcall local_10007D01(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	LRESULT (__stdcall *v4)(HWND, UINT, WPARAM, LPARAM); // ebx
+	HWND v5; // eax
+	HWND v6; // eax
+	HWND v7; // eax
+	WPARAM v9; // [esp-8h] [ebp-14h]
+	BOOL v10; // [esp-4h] [ebp-10h]
+
+	v4 = (LRESULT (__stdcall *)(HWND, UINT, WPARAM, LPARAM))GetPropA(hWnd, "UIWNDPROC");
+	switch ( Msg )
+	{
+		case 2u:
+			RemovePropA(hWnd, "UIWNDPROC");
+			if ( !v4 )
+				return DefWindowProcA(hWnd, Msg, wParam, lParam);
+			SetWindowLongA(hWnd, -4, (LONG)v4);
+			goto LABEL_21;
+		case 0xFu:
+			local_10007C95(hWnd);
+			return 0;
+		case 0x87u:
+			return 4;
+	}
+	if ( Msg != 256 )
+		goto LABEL_21;
+	switch ( wParam )
+	{
+		case 0xDu:
+			goto LABEL_26;
+		case 0x1Bu:
+			v9 = 2;
+LABEL_15:
+			v7 = GetParent(hWnd);
+			SendMessageA(v7, 0x111u, v9, 0);
+			goto LABEL_21;
+		case 0x20u:
+LABEL_26:
+			v9 = 1;
+			goto LABEL_15;
+	}
+	if ( wParam <= 0x24 )
+		goto LABEL_21;
+	if ( wParam <= 0x26 )
+	{
+		v10 = 1;
+	}
+	else
+	{
+		if ( wParam > 0x28 )
+			goto LABEL_21;
+		v10 = 0;
+	}
+	v5 = GetParent(hWnd);
+	v6 = GetNextDlgGroupItem(v5, hWnd, v10);
+	SetFocus(v6);
+LABEL_21:
+	if ( v4 )
+		return CallWindowProcA(v4, hWnd, Msg, wParam, lParam);
+	return DefWindowProcA(hWnd, Msg, wParam, lParam);
+} */
+
+// ref: 0x10007DE9
+int __fastcall local_10007DE9(HWND hDlg, int *a2) { return 0; }
+/* {
+	int *v2; // edi
+	HWND v3; // ebx
+	int result; // eax
+	HWND v5; // eax
+	HWND v6; // esi
+	void *v7; // eax
+
+	v2 = a2;
+	v3 = hDlg;
+	for ( result = *a2; *v2; result = *v2 )
+	{
+		v5 = GetDlgItem(v3, result);
+		v6 = v5;
+		if ( v5 )
+		{
+			v7 = (void *)GetWindowLongA(v5, -4);
+			SetPropA(v6, "UIWNDPROC", v7);
+			SetWindowLongA(v6, -4, (LONG)local_10007E35);
+		}
+		++v2;
+	}
+	return result;
+} */
+
+// ref: 0x10007E35
+LRESULT __stdcall local_10007E35(HWND hWnd, HWND a2, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	LRESULT (__stdcall *v4)(HWND, UINT, WPARAM, LPARAM); // ebx
+	WPARAM v5; // ST0C_4
+	HWND v6; // eax
+	HWND v8; // [esp+18h] [ebp+Ch]
+
+	v4 = (LRESULT (__stdcall *)(HWND, UINT, WPARAM, LPARAM))GetPropA(hWnd, "UIWNDPROC");
+	if ( a2 == (HWND)2 )
+	{
+		RemovePropA(hWnd, "UIWNDPROC");
+		if ( !v4 )
+			return DefWindowProcA(hWnd, (UINT)a2, wParam, lParam);
+		SetWindowLongA(hWnd, -4, (LONG)v4);
+	}
+	else
+	{
+		if ( a2 == (HWND)15 )
+		{
+			local_10007C95(hWnd);
+			return 0;
+		}
+		if ( (HWND)((char *)a2 - 15) == (HWND)498 )
+		{
+			v8 = GetFocus();
+			SetFocus(hWnd);
+			InvalidateRect(v8, 0, 0);
+			InvalidateRect(hWnd, 0, 0);
+			UpdateWindow(v8);
+			UpdateWindow(hWnd);
+			v5 = (unsigned short)GetWindowLongA(hWnd, -12);
+			v6 = GetParent(hWnd);
+			PostMessageA(v6, 0x111u, v5, (LPARAM)hWnd);
+			return 0;
+		}
+	}
+	if ( v4 )
+		return CallWindowProcA(v4, hWnd, (UINT)a2, wParam, lParam);
+	return DefWindowProcA(hWnd, (UINT)a2, wParam, lParam);
+} */
+
+// ref: 0x10007F04
+BOOL UNKCALL local_10007F04(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	BOOL result; // eax
+	struct tagMSG Msg; // [esp+8h] [ebp-1Ch]
+
+	v1 = hWnd;
+	do
+	{
+		while ( PeekMessageA(&Msg, v1, 0x100u, 0x108u, 1u) )
+			;
+		result = PeekMessageA(&Msg, v1, 0x200u, 0x209u, 1u);
+	}
+	while ( result );
+	return result;
+} */
+
+// ref: 0x10007F46
+int local_10007F46() { return 0; }
+/* {
+	int result; // eax
+
+	result = SMemAlloc(272, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 480, 0);
+	if ( result )
+	{
+		*(_DWORD *)result = 0;
+		*(_DWORD *)(result + 4) = 0;
+		*(_DWORD *)(result + 8) = 0;
+		*(_DWORD *)(result + 12) = 0;
+		*(_BYTE *)(result + 16) = 0;
+	}
+	return result;
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10007F72
+void UNKCALL local_10007F72(_DWORD *arg) { return; }
+/* {
+	_DWORD *v1; // esi
+
+	v1 = arg;
+	if ( arg )
+	{
+		if ( *arg )
+			SMemFree(*arg, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 498, 0);
+		SMemFree(v1, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 499, 0);
+	}
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10007FA4
+char *__fastcall local_10007FA4(int a1, const char *a2) { return 0; }
+/* {
+	int v2; // esi
+	char *result; // eax
+
+	v2 = a1;
+	if ( a1 )
+	{
+		if ( a2 )
+		{
+			result = strncpy((char *)(a1 + 16), a2, 0xFFu);
+			*(_BYTE *)(v2 + 271) = 0;
+		}
+		else
+		{
+			*(_BYTE *)(a1 + 16) = 0;
+		}
+	}
+	return result;
+} */
+
+// ref: 0x10007FD0
+_BYTE *local_10007FD0() { return 0; }
+/* {
+	_BYTE *result; // eax
+	int v1; // [esp+8h] [ebp-8h]
+	int v2; // [esp+Ch] [ebp-4h]
+
+	result = (_BYTE *)SBmpLoadImage("ui_art\\cursor.pcx", 0, 0, 0, &v2, &v1, 0);
+	if ( result )
+	{
+		dword_1002A0CC = SMemAlloc(v1 * v2, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 553, 0);
+		dword_1002A0D0 = SMemAlloc(v1 * v2, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 554, 0);
+		result = (_BYTE *)SBmpLoadImage("ui_art\\cursor.pcx", 0, dword_1002A0CC, v1 * v2, 0, 0, 0);
+		if ( result )
+		{
+			dword_10029CC0 = v2;
+			dword_10029CC4 = v1;
+			result = local_10008062();
+		}
+	}
+	return result;
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100103BE: using guessed type int __stdcall SBmpLoadImage(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10029CC0: using guessed type int dword_10029CC0;
+// 10029CC4: using guessed type int dword_10029CC4;
+// 1002A0CC: using guessed type int dword_1002A0CC;
+// 1002A0D0: using guessed type int dword_1002A0D0;
+
+// ref: 0x10008062
+_BYTE *local_10008062() { return 0; }
+/* {
+	_BYTE *result; // eax
+	char *v1; // ecx
+	int i; // esi
+	char v3; // dl
+
+	result = (_BYTE *)dword_1002A0D0;
+	v1 = (char *)dword_1002A0CC;
+	if ( dword_1002A0D0 )
+	{
+		if ( dword_1002A0CC )
+		{
+			for ( i = 0; i < dword_10029CC0 * dword_10029CC4; ++i )
+			{
+				v3 = *v1++;
+				if ( v3 )
+					*result = 0;
+				else
+					*result = -1;
+				++result;
+			}
+		}
+	}
+	return result;
+} */
+// 10029CC0: using guessed type int dword_10029CC0;
+// 10029CC4: using guessed type int dword_10029CC4;
+// 1002A0CC: using guessed type int dword_1002A0CC;
+// 1002A0D0: using guessed type int dword_1002A0D0;
+
+// ref: 0x100080AD
+int local_100080AD() { return 0; }
+/* {
+	int result; // eax
+
+	if ( dword_1002A0CC )
+	{
+		SMemFree(dword_1002A0CC, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 571, 0);
+		dword_1002A0CC = 0;
+	}
+	result = dword_1002A0D0;
+	if ( dword_1002A0D0 )
+	{
+		result = SMemFree(dword_1002A0D0, "C:\\Src\\Diablo\\DiabloUI\\local.cpp", 575, 0);
+		dword_1002A0D0 = 0;
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A0CC: using guessed type int dword_1002A0CC;
+// 1002A0D0: using guessed type int dword_1002A0D0;
+
+// ref: 0x100080F1
+int local_100080F1() { return 0; }
+/* {
+	if ( !dword_1002A0CC )
+		local_10007FD0();
+	return SDlgSetSystemCursor(dword_1002A0D0, dword_1002A0CC, &dword_10029CC0, 32512);
+} */
+// 1001044E: using guessed type int __stdcall SDlgSetSystemCursor(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029CC0: using guessed type int dword_10029CC0;
+// 1002A0CC: using guessed type int dword_1002A0CC;
+// 1002A0D0: using guessed type int dword_1002A0D0;
+
+// ref: 0x1000811B
+int local_1000811B() { return 0; }
+/* {
+	return SDlgSetSystemCursor(0, 0, 0, 32512);
+} */
+// 1001044E: using guessed type int __stdcall SDlgSetSystemCursor(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000812B
+int UNKCALL local_1000812B(void *arg) { return 0; }
+/* {
+	void *v1; // esi
+	HCURSOR v2; // eax
+	int v4; // [esp+4h] [ebp-4h]
+
+	v4 = 0;
+	v1 = arg;
+	local_1000811B();
+	v2 = LoadCursorA(hInstance, "DIABLOCURSOR");
+	return SDlgSetCursor(v1, v2, 32512, &v4);
+} */
+// 10010454: using guessed type int __stdcall SDlgSetCursor(_DWORD, _DWORD, _DWORD, _DWORD);

--- a/DiabloUI/mainmenu.cpp
+++ b/DiabloUI/mainmenu.cpp
@@ -1,0 +1,252 @@
+// ref: 0x10008164
+signed int MainMenu_10008164() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A0D4 = 2139095040;
+	return result;
+} */
+// 1002A0D4: using guessed type int dword_1002A0D4;
+
+// ref: 0x1000816F
+int __stdcall UiMainMenuDialog(char *name, int *a2, void *fnSound, int a4) { return 0; }
+/* {
+	int v4; // eax
+	int v5; // esi
+
+	dword_1002A118 = a4;
+	TitleSnd_10010306((void *)a3);
+	artfont_10001159();
+	byte_1002A0D8 = 0;
+	if ( a1 )
+		strncpy((char *)&byte_1002A0D8, a1, 0x40u);
+	v4 = SDrawGetFrameWindow();
+	v5 = SDlgDialogBoxParam(hInstance, "MAINMENU_DIALOG", v4, MainMenu_100081E3, 0);
+	if ( v5 == 5 )
+		artfont_100010C8();
+	if ( a2 )
+		*(_DWORD *)a2 = v5;
+	return 1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1002A118: using guessed type int dword_1002A118;
+
+// ref: 0x100081E3
+int __stdcall MainMenu_100081E3(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v5; // eax
+	int v6; // [esp+0h] [ebp-Ch]
+
+	if ( Msg <= 0x113 )
+	{
+		if ( Msg != 275 )
+		{
+			if ( Msg == 2 )
+			{
+				MainMenu_10008354(hWnd);
+			}
+			else if ( Msg > 0x103 )
+			{
+				if ( Msg <= 0x105 )
+				{
+					v5 = (HWND)SDrawGetFrameWindow();
+					SendMessageA(v5, Msg, wParam, lParam);
+				}
+				else
+				{
+					if ( Msg == 272 )
+					{
+						MainMenu_100083A8(hWnd);
+						PostMessageA(hWnd, 0x7E8u, 0, 0);
+						return 1;
+					}
+					if ( Msg == 273 )
+					{
+						MainMenu_10008391(hWnd);
+						switch ( HIWORD(wParam) )
+						{
+							case 7:
+								Focus_100075B7(hWnd, (HWND)lParam);
+								break;
+							case 6:
+								Focus_10007458((void *)lParam);
+								Focus_100075DC(hWnd, (HWND)lParam);
+								break;
+							case 0:
+								MainMenu_100084FA(hWnd, (unsigned short)wParam);
+								break;
+						}
+					}
+				}
+			}
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		if ( wParam == 3 && !DiabloUI_10005C2A() )
+		{
+			if ( dword_10029728 )
+				MainMenu_1000845A((int)hWnd, 6, 0);
+			else
+				MainMenu_10008391(hWnd);
+		}
+		return 0;
+	}
+	if ( Msg >= 0x200 )
+	{
+		if ( Msg <= 0x202 )
+			goto LABEL_34;
+		if ( Msg <= 0x203 )
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		if ( Msg <= 0x205 )
+		{
+LABEL_34:
+			MainMenu_10008391(hWnd);
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		if ( Msg == 2024 )
+		{
+			if ( !Fade_1000739F() )
+				Fade_100073FD(hWnd, v6);
+			return 0;
+		}
+	}
+	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10029728: using guessed type int dword_10029728;
+
+// ref: 0x10008354
+int UNKCALL MainMenu_10008354(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	Title_100100E7(hDlg);
+	Focus_10007818(v1);
+	Doom_10006C53(v1, (int *)&unk_10022BE8);
+	Doom_10006C53(v1, (int *)&unk_10022BE0);
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+	return local_1000811B();
+} */
+
+// ref: 0x10008391
+int UNKCALL MainMenu_10008391(void *arg) { return 0; }
+/* {
+	return SDlgSetTimer(arg, 3, 1000 * dword_1002A118, 0);
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A118: using guessed type int dword_1002A118;
+
+// ref: 0x100083A8
+int UNKCALL MainMenu_100083A8(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	int *v3; // edi
+	bool v4; // zf
+	const char *v5; // eax
+	HWND v6; // eax
+	HWND v7; // ST1C_4
+	HWND v9; // [esp+0h] [ebp-8h]
+
+	v1 = hWnd;
+	v2 = local_10007F46();
+	v3 = (int *)v2;
+	if ( v2 )
+	{
+		SetWindowLongA(v1, -21, v2);
+		v4 = DiabloUI_10005C2A() == 0;
+		v5 = "ui_art\\swmmenu.pcx";
+		if ( v4 )
+			v5 = "ui_art\\mainmenu.pcx";
+		local_10007944((int)v1, 0, &byte_10029448, -1, 1, (int)v5, v3, v3 + 1, 0);
+		Fade_100073C5(v1, 1);
+	}
+	v6 = GetDlgItem(v1, 1042);
+	SetWindowTextA(v6, &byte_1002A0D8);
+	Doom_100068AB(v1, (int *)&unk_10022BE0, 1);
+	Doom_1000658C(v1, (int *)&unk_10022BE8, 6, 1);
+	Focus_100077E9((int)v1, "ui_art\\focus42.pcx", v9);
+	Title_1001009E(v1, (int)"ui_art\\smlogo.pcx", v7);
+	MainMenu_10008391(v1);
+	return local_10007DE9(v1, (int *)&unk_10022BE8);
+} */
+
+// ref: 0x1000845A
+int __fastcall MainMenu_1000845A(int a1, int a2, int a3) { return 0; }
+/* {
+	int v3; // esi
+	int v4; // edi
+
+	v3 = a1;
+	v4 = a2;
+	SDlgKillTimer(a1, 3);
+	if ( DiabloUI_10005C2A() && v4 == 3 )
+	{
+		SelYesNo_1000FD77(v3, 0x46u, 1);
+		return SDlgSetTimer(v3, 3, 1000 * dword_1002A118, 0);
+	}
+	if ( v4 == 2 && !MainMenu_100084D5() )
+	{
+		SelYesNo_1000FD77(v3, 0x4Eu, 1);
+		return SDlgSetTimer(v3, 3, 1000 * dword_1002A118, 0);
+	}
+	Fade_100073B4();
+	if ( a3 )
+		TitleSnd_1001031F();
+	Fade_100072BE(10);
+	return SDlgEndDialog(v3, v4);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 1002A118: using guessed type int dword_1002A118;
+
+// ref: 0x100084D5
+BOOL MainMenu_100084D5() { return 0; }
+/* {
+	struct _MEMORYSTATUS Buffer; // [esp+0h] [ebp-20h]
+
+	Buffer.dwLength = 32;
+	GlobalMemoryStatus(&Buffer);
+	return Buffer.dwTotalPhys > 0xDAC000;
+} */
+
+// ref: 0x100084FA
+LRESULT __fastcall MainMenu_100084FA(HWND hWnd, int a2) { return 0; }
+/* {
+	HWND v2; // esi
+	LRESULT result; // eax
+	HWND v4; // eax
+	LONG v5; // eax
+	int v6; // [esp-8h] [ebp-Ch]
+
+	v2 = hWnd;
+	switch ( a2 )
+	{
+		case 1:
+			v4 = GetFocus();
+			v5 = GetWindowLongA(v4, -12);
+			return SendMessageA(v2, 0x111u, v5, 0);
+		case 2:
+			v6 = 5;
+			return MainMenu_1000845A((int)hWnd, v6, 1);
+		case 1001:
+			v6 = 2;
+			return MainMenu_1000845A((int)hWnd, v6, 1);
+		case 1002:
+			v6 = 3;
+			return MainMenu_1000845A((int)hWnd, v6, 1);
+		case 1003:
+			v6 = 4;
+			return MainMenu_1000845A((int)hWnd, v6, 1);
+	}
+	result = a2 - 1044;
+	if ( a2 == 1044 )
+		result = MainMenu_1000845A((int)hWnd, 1, 1);
+	return result;
+} */

--- a/DiabloUI/modem.cpp
+++ b/DiabloUI/modem.cpp
@@ -1,0 +1,477 @@
+// ref: 0x1000855D
+int Modem_1000855D() { return 0; }
+/* {
+	return dword_1002A124;
+} */
+// 1002A124: using guessed type int dword_1002A124;
+
+// ref: 0x10008563
+HWND __fastcall Modem_10008563(HWND hDlg, const char *a2, int a3) { return 0; }
+/* {
+	HWND v3; // esi
+	const char *v4; // ebp
+	HWND result; // eax
+
+	v3 = hDlg;
+	v4 = a2;
+	result = GetDlgItem(hDlg, 1108);
+	if ( result )
+	{
+		result = (HWND)GetWindowLongA(result, -21);
+		if ( result )
+		{
+			local_10007FA4((int)result, (const char *)a3);
+			Doom_10006A13(v3, (int *)&unk_10022C5C, 1);
+			result = GetDlgItem(v3, 1080);
+			if ( result )
+			{
+				result = (HWND)GetWindowLongA(result, -21);
+				if ( result )
+				{
+					local_10007FA4((int)result, v4);
+					result = (HWND)Doom_10006A13(v3, (int *)&unk_10022C54, 3);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x100085D8
+int __stdcall Modem_100085D8(int a1, char *a2, char *a3) { return 0; }
+/* {
+	dword_1002A150 = a1;
+	strcpy(&byte_1002A154, a2);
+	strcpy(&byte_1002A1D4, a3);
+	return 1;
+} */
+// 1002A150: using guessed type int dword_1002A150;
+
+// ref: 0x10008606
+BOOL Modem_10008606() { return 0; }
+/* {
+	BOOL result; // eax
+
+	dword_1002A150 = 0;
+	byte_1002A154 = 0;
+	byte_1002A1D4 = 0;
+	if ( SNetEnumGames(0, 0, Modem_100085D8, 0) )
+		result = dword_1002A150 != 0;
+	else
+		result = 0;
+	return result;
+} */
+// 10010436: using guessed type int __stdcall SNetEnumGames(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A150: using guessed type int dword_1002A150;
+
+// ref: 0x1000863D
+char *Modem_1000863D() { return 0; }
+/* {
+	return &byte_1002A154;
+} */
+
+// ref: 0x10008648
+signed int Modem_10008648() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A128 = 2139095040;
+	return result;
+} */
+// 1002A128: using guessed type int dword_1002A128;
+
+// ref: 0x10008653
+int Modem_10008653() { return 0; }
+/* {
+	return dword_1002A148;
+} */
+// 1002A148: using guessed type int dword_1002A148;
+
+// ref: 0x10008659
+int Modem_10008659() { return 0; }
+/* {
+	return dword_1002A134;
+} */
+// 1002A134: using guessed type int dword_1002A134;
+
+// ref: 0x1000865F
+int UNKCALL Modem_1000865F(char *arg) { return 0; }
+/* {
+	char v1; // al
+	int result; // eax
+
+	while ( 1 )
+	{
+		v1 = *arg;
+		if ( !*arg || (unsigned char)v1 >= 0x30u && (unsigned char)v1 <= 0x39u )
+			break;
+		++arg;
+	}
+	if ( *arg )
+		result = atoi(arg);
+	else
+		result = 0;
+	return result;
+} */
+
+// ref: 0x10008680
+BOOL __fastcall Modem_10008680(int a1, int a2, int a3, _DWORD *a4, int a5, int a6) { return 0; }
+/* {
+	int v6; // esi
+
+	dword_1002A13C = a3;
+	dword_1002A138 = a2;
+	dword_1002A144 = a5;
+	dword_1002A14C = a4;
+	dword_1002A140 = a6;
+	artfont_10001159();
+	v6 = SDlgDialogBoxParam(hInstance, "MODEM_DIALOG", a4[2], Modem_100086DE, 0);
+	artfont_100010C8();
+	return v6 == 1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A138: using guessed type int dword_1002A138;
+// 1002A13C: using guessed type int dword_1002A13C;
+// 1002A140: using guessed type int dword_1002A140;
+// 1002A144: using guessed type int dword_1002A144;
+
+// ref: 0x100086DE
+int __stdcall Modem_100086DE(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	int v6; // [esp+0h] [ebp-8h]
+
+	if ( Msg > 0x7E8 )
+	{
+		switch ( Msg )
+		{
+			case 0xBD0u:
+				Modem_100088DB(hWnd);
+				return 0;
+			case 0xBD1u:
+				Modem_10008BB7(hWnd);
+				return 0;
+			case 0xBD2u:
+				Modem_10008BFE(hWnd);
+				return 0;
+		}
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg == 2024 )
+	{
+		if ( !Fade_1000739F() )
+			Fade_100073FD(hWnd, v6);
+		return 0;
+	}
+	if ( Msg == 2 )
+	{
+		Modem_1000879E(hWnd);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v4 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v4, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg != 272 )
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	Modem_100087DB(hWnd);
+	PostMessageA(hWnd, 0x7E8u, 0, 0);
+	return 0;
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x1000879E
+_DWORD *UNKCALL Modem_1000879E(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	Doom_10006C53(hDlg, (int *)&unk_10022C5C);
+	Doom_10006C53(v1, (int *)&unk_10022C54);
+	Doom_10006C53(v1, (int *)&unk_10022C4C);
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+	return Title_100100E7(v1);
+} */
+
+// ref: 0x100087DB
+BOOL UNKCALL Modem_100087DB(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	int *v3; // edi
+	HWND v5; // [esp+0h] [ebp-10h]
+
+	v1 = hWnd;
+	Title_1001009E(hWnd, (int)"ui_art\\smlogo.pcx", v5);
+	v2 = local_10007F46();
+	v3 = (int *)v2;
+	if ( v2 )
+	{
+		SetWindowLongA(v1, -21, v2);
+		local_10007944((int)v1, 0, &byte_10029448, -1, 1, (int)"ui_art\\selgame.pcx", v3, v3 + 1, 0);
+		Fade_100073C5(v1, 1);
+	}
+	Doom_100068AB(v1, (int *)&unk_10022C4C, 5);
+	Doom_100068AB(v1, (int *)&unk_10022C54, 3);
+	Doom_100068AB(v1, (int *)&unk_10022C5C, 1);
+	Modem_10008888();
+	if ( dword_1002A124 )
+		return PostMessageA(v1, 0xBD2u, 0, 0);
+	dword_1002A134 = 1;
+	dword_1002A130 = 1;
+	return PostMessageA(v1, 0xBD0u, 0, 0);
+} */
+// 1002A124: using guessed type int dword_1002A124;
+// 1002A130: using guessed type int dword_1002A130;
+// 1002A134: using guessed type int dword_1002A134;
+
+// ref: 0x10008888
+int Modem_10008888() { return 0; }
+/* {
+	int result; // eax
+
+	dword_1002A150 = 0;
+	byte_1002A154 = 0;
+	byte_1002A1D4 = 0;
+	result = SNetEnumGames(0, 0, Modem_100085D8, 0);
+	if ( result )
+	{
+		dword_1002A124 = 1;
+	}
+	else
+	{
+		result = SErrGetLastError();
+		if ( result == 1222 )
+		{
+			dword_1002A124 = 0;
+			result = 1;
+			dword_1002A134 = 1;
+			dword_1002A130 = 1;
+		}
+	}
+	return result;
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010436: using guessed type int __stdcall SNetEnumGames(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A124: using guessed type int dword_1002A124;
+// 1002A130: using guessed type int dword_1002A130;
+// 1002A134: using guessed type int dword_1002A134;
+// 1002A150: using guessed type int dword_1002A150;
+
+// ref: 0x100088DB
+int UNKCALL Modem_100088DB(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	int v3; // eax
+	int v5; // [esp+4h] [ebp-20h]
+
+	v1 = hWnd;
+	v2 = SDlgDialogBoxParam(hInstance, "SELDIAL_DIALOG", hWnd, SelDial_1000B0CF, &v5) - 3;
+	if ( !v2 )
+		return Modem_1000893D(v1);
+	v3 = v2 - 1;
+	if ( !v3 )
+		return Modem_10008A38(v1, (int)&v5);
+	if ( v3 == 1 )
+		return PostMessageA(v1, 0xBD1u, 0, 0);
+	return SelHero_1000C3E2((int)v1, 2);
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000893D
+int UNKCALL Modem_1000893D(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	int result; // eax
+	CHAR v4; // [esp+8h] [ebp-C0h]
+	int v5; // [esp+48h] [ebp-80h]
+	HWND v6; // [esp+50h] [ebp-78h]
+	CHAR Buffer; // [esp+98h] [ebp-30h]
+	int v8; // [esp+B8h] [ebp-10h]
+	int v9; // [esp+BCh] [ebp-Ch]
+	int v10; // [esp+C0h] [ebp-8h]
+	int v11; // [esp+C4h] [ebp-4h]
+
+	v1 = hWnd;
+	memcpy(&v5, dword_1002A14C, 0x50u);
+	v5 = 80;
+	v6 = v1;
+	memset(&v8, 0, 0x10u);
+	v8 = 16;
+	v9 = 1297040461;
+	v2 = *(_DWORD *)(dword_1002A138 + 24);
+	v11 = 0;
+	v10 = v2;
+	LoadStringA(hInstance, 0x47u, &Buffer, 31);
+	wsprintfA(&v4, &Buffer, dword_1002A130);
+	if ( CreaDung_100051D8(
+			 (int)&v8,
+			 dword_1002A138,
+			 dword_1002A13C,
+			 (int)&v5,
+			 dword_1002A144,
+			 dword_1002A140,
+			 1,
+			 (int)&v4) )
+	{
+		++dword_1002A130;
+		result = SelHero_1000C3E2((int)v1, 1);
+	}
+	else if ( dword_1002A124 )
+	{
+		if ( SErrGetLastError() == 183 )
+			++dword_1002A130;
+		result = PostMessageA(v1, 0xBD2u, 0, 0);
+	}
+	else
+	{
+		result = PostMessageA(v1, 0xBD0u, 0, 0);
+	}
+	return result;
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 1002A124: using guessed type int dword_1002A124;
+// 1002A130: using guessed type int dword_1002A130;
+// 1002A138: using guessed type int dword_1002A138;
+// 1002A13C: using guessed type int dword_1002A13C;
+// 1002A140: using guessed type int dword_1002A140;
+// 1002A144: using guessed type int dword_1002A144;
+
+// ref: 0x10008A38
+int __fastcall Modem_10008A38(HWND hWnd, int a2) { return 0; }
+/* {
+	char *v2; // ebx
+	HWND v3; // edi
+	int v4; // eax
+	int result; // eax
+	CHAR Buffer; // [esp+Ch] [ebp-80h]
+
+	v2 = (char *)a2;
+	v3 = hWnd;
+	dword_1002A148 = 0;
+	_beginthread((int)Modem_10008B42, 0, a2);
+	ModmStat_10008C87(v3);
+	if ( !dword_1002A120 )
+	{
+		switch ( dword_1002A12C )
+		{
+			case -2062548871:
+				LoadStringA(hInstance, 0x32u, &Buffer, 127);
+				break;
+			case 54:
+				LoadStringA(hInstance, 0x42u, &Buffer, 127);
+				break;
+			case 1204:
+				LoadStringA(hInstance, 0x4Cu, &Buffer, 127);
+				break;
+			case 1222:
+				LoadStringA(hInstance, 0x41u, &Buffer, 127);
+				break;
+			case 1223:
+				goto LABEL_18;
+			case 2250:
+				LoadStringA(hInstance, 0x40u, &Buffer, 127);
+				break;
+			default:
+				LoadStringA(hInstance, 0x33u, &Buffer, 127);
+				break;
+		}
+		SelYesNo_1000FD39((int)v3, &Buffer, 0, 1);
+LABEL_18:
+		if ( dword_1002A124 )
+			result = PostMessageA(v3, 0xBD2u, 0, 0);
+		else
+			result = PostMessageA(v3, 0xBD0u, 0, 0);
+		return result;
+	}
+	if ( !dword_1002A124 )
+	{
+		SelDial_1000B011(v2);
+		Modem_10008606();
+	}
+	v4 = Modem_1000865F(&byte_1002A154);
+	dword_1002A134 = v4;
+	dword_1002A130 = v4 + 1;
+	return SelHero_1000C3E2((int)v3, 1);
+} */
+// 1002A120: using guessed type int dword_1002A120;
+// 1002A124: using guessed type int dword_1002A124;
+// 1002A12C: using guessed type int dword_1002A12C;
+// 1002A130: using guessed type int dword_1002A130;
+// 1002A134: using guessed type int dword_1002A134;
+// 1002A148: using guessed type int dword_1002A148;
+
+// ref: 0x10008B42
+void __cdecl Modem_10008B42(char *a1) { return; }
+/* {
+	char *v1; // eax
+	char v2; // [esp+0h] [ebp-100h]
+	char v3; // [esp+80h] [ebp-80h]
+
+	Connect_10004028((int)&v2, 128, (int)&v3, 128);
+	dword_1002A148 = 0;
+	v1 = &byte_1002A154;
+	if ( !dword_1002A124 )
+		v1 = a1;
+	dword_1002A120 = SNetJoinGame(0, v1, 0, &v2, &v3, dword_1002A140);
+	if ( !dword_1002A120 )
+		dword_1002A12C = SErrGetLastError();
+	dword_1002A148 = 1;
+	_endthread();
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010430: using guessed type int __stdcall SNetJoinGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10011E20: using guessed type int _endthread(void);
+// 1002A120: using guessed type int dword_1002A120;
+// 1002A124: using guessed type int dword_1002A124;
+// 1002A12C: using guessed type int dword_1002A12C;
+// 1002A140: using guessed type int dword_1002A140;
+// 1002A148: using guessed type int dword_1002A148;
+
+// ref: 0x10008BB7
+int UNKCALL Modem_10008BB7(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int result; // eax
+	int v3; // [esp+4h] [ebp-20h]
+
+	v1 = hWnd;
+	if ( SDlgDialogBoxParam(hInstance, "ENTERDIAL_DIALOG", hWnd, EntDial_10006C96, &v3) == 1 )
+		result = Modem_10008A38(v1, (int)&v3);
+	else
+		result = PostMessageA(v1, 0xBD0u, 0, 0);
+	return result;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10008BFE
+int UNKCALL Modem_10008BFE(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	int v3; // eax
+
+	v1 = hWnd;
+	v2 = SDlgDialogBoxParam(hInstance, "SELCRE8JOIN_DIALOG", hWnd, SelDial_1000B0CF, 0) - 3;
+	if ( !v2 )
+		return Modem_1000893D(v1);
+	v3 = v2 - 2;
+	if ( !v3 )
+		return Modem_10008A38(v1, (int)&byte_1002A154);
+	if ( v3 != 1217 )
+		return SelHero_1000C3E2((int)v1, 2);
+	dword_1002A124 = 0;
+	return PostMessageA(v1, 0xBD0u, 0, 0);
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A124: using guessed type int dword_1002A124;

--- a/DiabloUI/modmstat.cpp
+++ b/DiabloUI/modmstat.cpp
@@ -1,0 +1,196 @@
+// ref: 0x10008C62
+int __stdcall ModmStat_10008C62(char *a1, int a2, int a3, int a4, int a5) { return 0; }
+/* {
+	int result; // eax
+
+	strcpy(&byte_1002A264, a1);
+	result = 1;
+	dword_1002A258 = 1;
+	dword_1002A260 = (int (*)(void))a5;
+	return result;
+} */
+// 1002A258: using guessed type int dword_1002A258;
+// 1002A260: using guessed type int (*dword_1002A260)(void);
+
+// ref: 0x10008C87
+int UNKCALL ModmStat_10008C87(void *arg) { return 0; }
+/* {
+	return SDlgDialogBoxParam(hInstance, "MODMSTAT_DIALOG", arg, ModmStat_10008CA0, 0);
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10008CA0
+int __stdcall ModmStat_10008CA0(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	HWND v6; // eax
+
+	if ( Msg == 2 )
+	{
+		ModmStat_10008DB3(hWnd);
+	}
+	else if ( Msg > 0x103 )
+	{
+		if ( Msg <= 0x105 )
+		{
+			v6 = (HWND)SDrawGetFrameWindow();
+			SendMessageA(v6, Msg, wParam, lParam);
+		}
+		else
+		{
+			switch ( Msg )
+			{
+				case 0x110u:
+					ModmStat_10008DE4(hWnd);
+					return 0;
+				case 0x111u:
+					if ( HIWORD(wParam) == 7 )
+					{
+						Focus_100075B7(hWnd, (HWND)lParam);
+					}
+					else if ( HIWORD(wParam) == 6 )
+					{
+						Focus_10007458((void *)lParam);
+						Focus_100075DC(hWnd, (HWND)lParam);
+					}
+					else if ( (_WORD)wParam == 1 || (_WORD)wParam == 2 )
+					{
+						ModmStat_10008E89((int)hWnd, 1);
+					}
+					break;
+				case 0x113u:
+					if ( dword_1002A258 )
+						ModmStat_10008EBF(hWnd);
+					if ( Modem_10008653() )
+					{
+						dword_1002A25C = 1;
+						ModmStat_10008E89((int)hWnd, 0);
+					}
+					v4 = GetFocus();
+					Focus_100075DC(hWnd, v4);
+					return 0;
+			}
+		}
+	}
+	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1002A258: using guessed type int dword_1002A258;
+// 1002A25C: using guessed type int dword_1002A25C;
+
+// ref: 0x10008DB3
+int UNKCALL ModmStat_10008DB3(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	v2 = (_DWORD *)GetWindowLongA(hDlg, -21);
+	local_10007F72(v2);
+	Focus_100076C3();
+	Doom_10006C53(v1, (int *)&unk_10022CB4);
+	return Doom_10006C53(v1, (int *)&unk_10022CAC);
+} */
+
+// ref: 0x10008DE4
+BOOL UNKCALL ModmStat_10008DE4(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	int *v3; // edi
+	HWND v4; // eax
+	BOOL result; // eax
+
+	v1 = hWnd;
+	v2 = local_10007F46();
+	v3 = (int *)v2;
+	if ( v2 )
+	{
+		SetWindowLongA(v1, -21, v2);
+		local_10007944((int)v1, 0, "Popup", -1, 1, (int)"ui_art\\black.pcx", v3, v3 + 1, 1);
+	}
+	Doom_100068AB(v1, (int *)&unk_10022CAC, 3);
+	Doom_1000658C(v1, (int *)&unk_10022CB4, 4, 1);
+	Focus_10007719("ui_art\\focus.pcx");
+	SDlgSetTimer(v1, 1, 55, 0);
+	local_10007DE9(v1, (int *)&unk_10022CB4);
+	byte_1002A264 = 0;
+	dword_1002A258 = 0;
+	dword_1002A260 = 0;
+	v4 = GetDlgItem(v1, 2);
+	result = ShowWindow(v4, 0);
+	dword_1002A25C = 0;
+	return result;
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A258: using guessed type int dword_1002A258;
+// 1002A25C: using guessed type int dword_1002A25C;
+// 1002A260: using guessed type int (*dword_1002A260)(void);
+
+// ref: 0x10008E89
+int __fastcall ModmStat_10008E89(int a1, int a2) { return 0; }
+/* {
+	int v2; // edi
+	int v3; // esi
+	int result; // eax
+
+	v2 = a2;
+	v3 = a1;
+	if ( dword_1002A25C )
+	{
+		TitleSnd_1001031F();
+		SDlgKillTimer(v3, 1);
+		if ( v2 )
+		{
+			if ( dword_1002A260 )
+				dword_1002A260();
+		}
+		result = SDlgEndDialog(v3, 0);
+	}
+	return result;
+} */
+// 1002A260: invalid function type has been ignored
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 1002A25C: using guessed type int dword_1002A25C;
+// 1002A260: using guessed type int (*dword_1002A260)(void);
+
+// ref: 0x10008EBF
+void UNKCALL ModmStat_10008EBF(HWND hDlg) { return; }
+/* {
+	HWND v1; // edi
+	HWND v2; // eax
+	int v3; // eax
+	HWND v4; // eax
+
+	dword_1002A258 = 0;
+	v1 = hDlg;
+	if ( dword_1002A260 )
+	{
+		v2 = GetDlgItem(hDlg, 1026);
+		if ( v2 )
+		{
+			v3 = GetWindowLongA(v2, -21);
+			local_10007FA4(v3, &byte_1002A264);
+			Doom_10006A13(v1, (int *)&unk_10022CAC, 3);
+			v4 = GetDlgItem(v1, 2);
+			ShowWindow(v4, 1);
+			dword_1002A25C = 1;
+		}
+	}
+} */
+// 1002A258: using guessed type int dword_1002A258;
+// 1002A25C: using guessed type int dword_1002A25C;
+// 1002A260: using guessed type int (*dword_1002A260)(void);
+
+// ref: 0x10008F26
+signed int ModmStat_10008F26() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A254 = 2139095040;
+	return result;
+} */
+// 1002A254: using guessed type int dword_1002A254;

--- a/DiabloUI/okcancel.cpp
+++ b/DiabloUI/okcancel.cpp
@@ -1,0 +1,341 @@
+// ref: 0x10008F31
+int __fastcall OkCancel_10008F31(HWND hWnd, const CHAR *a2) { return 0; }
+/* {
+	HWND v2; // ebx
+	HDC v3; // edi
+	void *v4; // eax
+	int v5; // eax
+	int result; // eax
+	LONG v7; // [esp+14h] [ebp-20h]
+	LONG v8; // [esp+18h] [ebp-1Ch]
+	struct tagRECT Rect; // [esp+1Ch] [ebp-18h]
+	HGDIOBJ h; // [esp+2Ch] [ebp-8h]
+	LPCSTR lpchText; // [esp+30h] [ebp-4h]
+
+	lpchText = a2;
+	v2 = hWnd;
+	if ( !a2 || !*a2 )
+		goto LABEL_13;
+	if ( !hWnd )
+		goto LABEL_14;
+	GetClientRect(hWnd, &Rect);
+	--Rect.right;
+	--Rect.bottom;
+	v7 = Rect.right;
+	v8 = Rect.bottom;
+	v3 = GetDC(v2);
+	v4 = (void *)SendMessageA(v2, 0x31u, 0, 0);
+	h = SelectObject(v3, v4);
+	if ( !v3 )
+		goto LABEL_13;
+	v5 = strlen(lpchText);
+	DrawTextA(v3, lpchText, v5, &Rect, 0x410u);
+	if ( h )
+		SelectObject(v3, h);
+	ReleaseDC(v2, v3);
+	if ( Rect.bottom > v8 || Rect.right > v7 )
+LABEL_14:
+		result = 1;
+	else
+LABEL_13:
+		result = 0;
+	return result;
+} */
+
+// ref: 0x10008FEC
+signed int OkCancel_10008FEC() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A2E4 = 2139095040;
+	return result;
+} */
+// 1002A2E4: using guessed type int dword_1002A2E4;
+
+// ref: 0x10008FF7
+HGDIOBJ __stdcall OkCancel_10008FF7(HWND a1, UINT Msg, WPARAM wParam, HWND hWnd) { return 0; }
+/* {
+	HWND v5; // ecx
+	int v6; // edx
+	HWND v7; // eax
+	LONG v8; // eax
+	HWND v9; // eax
+
+	if ( Msg == 2 )
+	{
+		ShowCursor(0);
+		OkCancel_10009117(a1);
+		return (HGDIOBJ)SDlgDefDialogProc(a1, Msg, wParam, hWnd);
+	}
+	if ( Msg <= 0x103 )
+		return (HGDIOBJ)SDlgDefDialogProc(a1, Msg, wParam, hWnd);
+	if ( Msg <= 0x105 )
+	{
+		v9 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v9, Msg, wParam, (LPARAM)hWnd);
+		return (HGDIOBJ)SDlgDefDialogProc(a1, Msg, wParam, hWnd);
+	}
+	if ( Msg != 272 )
+	{
+		if ( Msg != 273 )
+		{
+			if ( Msg == 312 && GetWindowLongA(hWnd, -12) == 1038 )
+			{
+				local_10007C2E((HDC)wParam);
+				return GetStockObject(5);
+			}
+			return (HGDIOBJ)SDlgDefDialogProc(a1, Msg, wParam, hWnd);
+		}
+		if ( (unsigned short)wParam == 1 )
+		{
+			v7 = GetFocus();
+			v8 = GetWindowLongA(v7, -12);
+			v5 = a1;
+			if ( v8 == 1109 )
+			{
+				v6 = 1;
+				goto LABEL_16;
+			}
+		}
+		else
+		{
+			if ( (unsigned short)wParam != 2 )
+			{
+				if ( (unsigned short)wParam == 1109 )
+				{
+					v5 = a1;
+					v6 = 1;
+LABEL_16:
+					OkCancel_100092F5((int)v5, v6);
+				}
+				return (HGDIOBJ)SDlgDefDialogProc(a1, Msg, wParam, hWnd);
+			}
+			v5 = a1;
+		}
+		v6 = 2;
+		goto LABEL_16;
+	}
+	ShowCursor(1);
+	if ( !OkCancel_10009161(a1, (int)hWnd) )
+		SDlgEndDialog(a1, -16777216);
+	return (HGDIOBJ)1;
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x10009117
+_DWORD *UNKCALL OkCancel_10009117(HWND hWnd) { return 0; }
+/* {
+	_DWORD *result; // eax
+	_DWORD *v2; // esi
+	int v3; // eax
+	int v4; // eax
+
+	result = RemovePropA(hWnd, "DLGBMP");
+	v2 = result;
+	if ( result )
+	{
+		v3 = *result;
+		if ( v3 )
+			SMemFree(v3, "C:\\Src\\Diablo\\DiabloUI\\OkCancel.cpp", 48, 0);
+		v4 = v2[1];
+		if ( v4 )
+			SMemFree(v4, "C:\\Src\\Diablo\\DiabloUI\\OkCancel.cpp", 50, 0);
+		result = (_DWORD *)SMemFree(v2, "C:\\Src\\Diablo\\DiabloUI\\OkCancel.cpp", 51, 0);
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10009161
+signed int __fastcall OkCancel_10009161(HWND a1, int a2) { return 0; }
+/* {
+	int v2; // esi
+	bool v3; // zf
+	HWND v4; // edi
+	char *v5; // edi
+	HWND v6; // eax
+	HWND v7; // edi
+	HWND v8; // edi
+	HWND v9; // eax
+	const CHAR *v10; // ST1C_4
+	HWND v11; // eax
+	HWND v12; // edi
+	int v14; // [esp+Ch] [ebp-20h]
+	int v15; // [esp+10h] [ebp-1Ch]
+	int v16; // [esp+14h] [ebp-18h]
+	char v17; // [esp+18h] [ebp-14h]
+	HWND v18; // [esp+20h] [ebp-Ch]
+	const char *v19; // [esp+24h] [ebp-8h]
+	HWND hWnd; // [esp+28h] [ebp-4h]
+
+	v2 = a2;
+	hWnd = a1;
+	v14 = 1109;
+	v15 = 2;
+	v16 = 0;
+	v18 = (HWND)SMemAlloc(8, "C:\\Src\\Diablo\\DiabloUI\\OkCancel.cpp", 110, 0);
+	SetPropA(hWnd, "DLGBMP", v18);
+	if ( *(_DWORD *)(v2 + 8) )
+	{
+		v3 = *(_DWORD *)(v2 + 12) == 0;
+		v19 = "ui_art\\lrpopup.pcx";
+		if ( v3 )
+			v19 = "ui_art\\lpopup.pcx";
+	}
+	else if ( *(_DWORD *)(v2 + 12) )
+	{
+		v19 = "ui_art\\srpopup.pcx";
+	}
+	else
+	{
+		v19 = "ui_art\\spopup.pcx";
+	}
+	v4 = GetParent(hWnd);
+	if ( (HWND)SDrawGetFrameWindow() == v4 )
+	{
+		local_10007944((int)hWnd, 0, &byte_10029448, -1, 1, (int)v19, (int *)v18, 0, 1);
+		v5 = local_10007895(0);
+		SDrawUpdatePalette(0, 10, v5, 0);
+		SDrawUpdatePalette(112, 144, v5 + 448, 1);
+	}
+	else
+	{
+		v6 = GetParent(hWnd);
+		local_10007944((int)hWnd, (int)v6, "Popup", -1, 1, (int)v19, (int *)v18, 0, 1);
+	}
+	v7 = GetParent(hWnd);
+	if ( (HWND)SDrawGetFrameWindow() == v7 )
+		Fade_100073EF(hWnd);
+	v8 = v18 + 1;
+	local_100078BE((int)"ui_art\\but_sml.pcx", (int *)v18 + 1, &v17);
+	local_10007B1B(hWnd, &v14, *(_DWORD *)v8, &v17);
+	v9 = GetDlgItem(hWnd, 1026);
+	v10 = *(const CHAR **)(v2 + 4);
+	v18 = v9;
+	SetWindowTextA(v9, v10);
+	if ( *(_DWORD *)(v2 + 16) && OkCancel_10008F31(v18, *(const CHAR **)(v2 + 4)) )
+		return 0;
+	if ( *(_DWORD *)v2 )
+	{
+		v11 = GetDlgItem(hWnd, 1038);
+		v12 = v11;
+		if ( *(_DWORD *)(v2 + 16) && OkCancel_10008F31(v11, *(const CHAR **)v2) )
+			return 0;
+		if ( v12 )
+			SetWindowTextA(v12, *(LPCSTR *)v2);
+	}
+	return 1;
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x100092F5
+int __fastcall OkCancel_100092F5(int a1, int a2) { return 0; }
+/* {
+	int v2; // esi
+	int v3; // edi
+
+	v2 = a2;
+	v3 = a1;
+	TitleSnd_1001031F();
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+
+// ref: 0x1000930A
+int __fastcall OkCancel_1000930A(int a1, int a2, int a3) { return 0; }
+/* {
+	int v4; // [esp+0h] [ebp-14h]
+	int v5; // [esp+4h] [ebp-10h]
+	int v6; // [esp+8h] [ebp-Ch]
+	int v7; // [esp+Ch] [ebp-8h]
+	int v8; // [esp+10h] [ebp-4h]
+
+	v5 = a2;
+	v6 = 0;
+	v4 = 0;
+	v8 = 0;
+	v7 = a3;
+	return SDlgDialogBoxParam(hInstance, "OK_DIALOG", a1, OkCancel_10008FF7, &v4);
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10009342
+void __cdecl UiMessageBoxCallback() { return; }
+//LPCSTR __stdcall UiMessageBoxCallback(HWND hWnd, LPCSTR lpText, LPCSTR lpCaption, UINT uType) { return 0; }
+/* {
+	int v4; // eax
+	bool v5; // sf
+	unsigned char v6; // of
+	size_t v7; // eax
+	CHAR *v8; // eax
+	int v9; // ecx
+	LPCSTR v11; // [esp+0h] [ebp-24h]
+	LPCSTR v12; // [esp+4h] [ebp-20h]
+	int v13; // [esp+8h] [ebp-1Ch]
+	BOOL v14; // [esp+Ch] [ebp-18h]
+	int v15; // [esp+10h] [ebp-14h]
+	int v16; // [esp+14h] [ebp-10h]
+	LPCSTR v17; // [esp+18h] [ebp-Ch]
+	const char *v18; // [esp+1Ch] [ebp-8h]
+	LPCSTR v19; // [esp+20h] [ebp-4h]
+
+	v11 = lpCaption;
+	v12 = lpText;
+	v18 = "OK_DIALOG";
+	v15 = 1;
+	if ( uType & 0xF )
+		v18 = "OKCANCEL_DIALOG";
+	v14 = (uType & 0xF0) == 16 || (uType & 0xF0) == 48;
+	v4 = 0;
+	v13 = 0;
+	while ( 1 )
+	{
+		v19 = (LPCSTR)SDlgDialogBoxParam(hInstance, &v18[32 * v4], hWnd, OkCancel_10008FF7, &v11);
+		if ( v19 != (LPCSTR)-16777216 )
+			break;
+		v4 = v13 + 1;
+		v6 = __OFSUB__(v13 + 1, 2);
+		v5 = v13++ - 1 < 0;
+		if ( !(v5 ^ v6) )
+		{
+			v7 = strlen(lpText);
+			v8 = (CHAR *)SMemAlloc(v7 + 256, "C:\\Src\\Diablo\\DiabloUI\\OkCancel.cpp", 392, 0);
+			v16 = 0;
+			v17 = v8;
+			v19 = lpText;
+			if ( *lpText )
+			{
+				v9 = v16;
+				do
+				{
+					if ( *v19 <= 32 )
+						v9 = 0;
+					*v8++ = *v19;
+					if ( ++v9 > 18 )
+					{
+						*v8++ = 10;
+						v9 = 0;
+					}
+					++v19;
+				}
+				while ( *v19 );
+			}
+			*v8 = 0;
+			v12 = v17;
+			v19 = (LPCSTR)SDlgDialogBoxParam(hInstance, v18, hWnd, OkCancel_10008FF7, &v11);
+			SMemFree(v17, "C:\\Src\\Diablo\\DiabloUI\\OkCancel.cpp", 416, 0);
+			if ( v19 == (LPCSTR)-16777216 )
+				return (LPCSTR)MessageBoxA(hWnd, lpText, lpCaption, uType);
+			return v19;
+		}
+	}
+	return v19;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);

--- a/DiabloUI/progress.cpp
+++ b/DiabloUI/progress.cpp
@@ -1,0 +1,314 @@
+// ref: 0x10009480
+signed int Progress_10009480() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A2EC = 2139095040;
+	return result;
+} */
+// 1002A2EC: using guessed type int dword_1002A2EC;
+
+// ref: 0x1000948B
+int __stdcall UiProgressDialog(HWND window, char *msg, int a3, void *fnfunc, int a5) { return 0; }
+/* {
+	HWND v5; // eax
+	BOOL result; // eax
+
+	dword_1002A2E8 = -1;
+	dword_1002A2F8 = 0;
+	dword_1002A2F4 = a4;
+	bEnable = a3;
+	dword_1002A2F0 = a5;
+	v5 = (HWND)SDlgCreateDialogParam(hInstance, "PROGRESS_DIALOG", a1, Progress_100094F4, a2);
+	result = 0;
+	if ( v5 )
+	{
+		Progress_1000991C(v5);
+		if ( dword_1002A2E8 != 2 && dword_1002A2E8 != -1 )
+			result = 1;
+	}
+	return result;
+} */
+// 1001045A: using guessed type int __stdcall SDlgCreateDialogParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A2E8: using guessed type int dword_1002A2E8;
+// 1002A2F0: using guessed type int dword_1002A2F0;
+// 1002A2F4: using guessed type int (*dword_1002A2F4)(void);
+// 1002A2F8: using guessed type int dword_1002A2F8;
+
+// ref: 0x100094F4
+int __stdcall Progress_100094F4(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	void *v5; // eax
+	HWND v7; // eax
+
+	if ( Msg == 2 )
+	{
+		ShowCursor(0);
+		Progress_100095EC();
+	}
+	else if ( Msg > 0x103 )
+	{
+		if ( Msg <= 0x105 )
+		{
+			v7 = (HWND)SDrawGetFrameWindow();
+			SendMessageA(v7, Msg, wParam, lParam);
+		}
+		else
+		{
+			switch ( Msg )
+			{
+				case 0x110u:
+					Progress_10009675(hWnd, (const CHAR *)lParam);
+					v5 = (void *)SDrawGetFrameWindow();
+					local_1000812B(v5);
+					local_1000812B(hWnd);
+					ShowCursor(1);
+					return 1;
+				case 0x111u:
+					if ( (_WORD)wParam == 2 )
+					{
+						SDlgKillTimer(hWnd, 1);
+						v4 = GetParent(hWnd);
+						if ( (HWND)SDrawGetFrameWindow() == v4 )
+							Fade_100072BE(10);
+						Progress_100098B0();
+					}
+					break;
+				case 0x113u:
+					Progress_100098C5(hWnd);
+					break;
+			}
+		}
+	}
+	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x100095EC
+int Progress_100095EC() { return 0; }
+/* {
+	int result; // eax
+
+	if ( dword_1002A318 )
+	{
+		SMemFree(dword_1002A318, "C:\\Src\\Diablo\\DiabloUI\\Progress.cpp", 88, 0);
+		dword_1002A318 = 0;
+	}
+	if ( dword_1002A31C )
+	{
+		SMemFree(dword_1002A31C, "C:\\Src\\Diablo\\DiabloUI\\Progress.cpp", 92, 0);
+		dword_1002A31C = 0;
+	}
+	if ( dword_1002A320 )
+	{
+		SMemFree(dword_1002A320, "C:\\Src\\Diablo\\DiabloUI\\Progress.cpp", 96, 0);
+		dword_1002A320 = 0;
+	}
+	if ( dword_1002A324 )
+	{
+		SMemFree(dword_1002A324, "C:\\Src\\Diablo\\DiabloUI\\Progress.cpp", 100, 0);
+		dword_1002A324 = 0;
+	}
+	result = dword_1002A328;
+	if ( dword_1002A328 )
+	{
+		result = SMemFree(dword_1002A328, "C:\\Src\\Diablo\\DiabloUI\\Progress.cpp", 104, 0);
+		dword_1002A328 = 0;
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A318: using guessed type int dword_1002A318;
+// 1002A31C: using guessed type int dword_1002A31C;
+// 1002A320: using guessed type int dword_1002A320;
+// 1002A324: using guessed type int dword_1002A324;
+// 1002A328: using guessed type int dword_1002A328;
+
+// ref: 0x10009675
+BOOL __fastcall Progress_10009675(HWND hWnd, const CHAR *a2) { return 0; }
+/* {
+	HWND v2; // ebx
+	HWND v3; // esi
+	char *v4; // esi
+	HWND v5; // eax
+	HWND v6; // esi
+	struct tagRECT Rect; // [esp+Ch] [ebp-28h]
+	char v9; // [esp+1Ch] [ebp-18h]
+	int v10; // [esp+24h] [ebp-10h]
+	int v11; // [esp+28h] [ebp-Ch]
+	LPCSTR lpString; // [esp+2Ch] [ebp-8h]
+	HWND v13; // [esp+30h] [ebp-4h]
+
+	v2 = hWnd;
+	lpString = a2;
+	v10 = 2;
+	v11 = 0;
+	if ( dword_1002A2F0 )
+		SDlgSetTimer(hWnd, 1, 0x3E8u / dword_1002A2F0, 0);
+	else
+		SDlgSetTimer(hWnd, 1, 50, 0);
+	local_10007944((int)v2, 0, &byte_10029448, -1, 1, (int)"ui_art\\spopup.pcx", &dword_1002A318, 0, 0);
+	v3 = GetParent(v2);
+	if ( (HWND)SDrawGetFrameWindow() == v3 )
+		Fade_100073EF(v2);
+	v4 = local_10007895(0);
+	SDrawUpdatePalette(0, 10, v4, 0);
+	SDrawUpdatePalette(112, 144, v4 + 448, 1);
+	local_100078BE((int)"ui_art\\but_sml.pcx", &dword_1002A31C, &v9);
+	local_10007B1B(v2, &v10, dword_1002A31C, &v9);
+	local_100078BE((int)"ui_art\\prog_bg.pcx", &dword_1002A320, &dword_1002A310);
+	local_100078BE((int)"ui_art\\prog_fil.pcx", &dword_1002A324, &dword_1002A308);
+	v13 = GetDlgItem(v2, 1030);
+	GetClientRect(v13, &Rect);
+	dword_1002A328 = SMemAlloc(Rect.right * Rect.bottom, "C:\\Src\\Diablo\\DiabloUI\\Progress.cpp", 170, 0);
+	dword_1002A300 = Rect.right;
+	dword_1002A304 = Rect.bottom;
+	SDlgSetBitmapI(v13, 0, 0, -1, 1, dword_1002A328, 0, Rect.right, Rect.bottom, -1);
+	Progress_10009805(v2, 0);
+	v5 = GetDlgItem(v2, 1031);
+	SetWindowTextA(v5, lpString);
+	v6 = GetDlgItem(v2, 2);
+	ShowWindow(v6, bEnable != 0);
+	return EnableWindow(v6, bEnable);
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A2F0: using guessed type int dword_1002A2F0;
+// 1002A300: using guessed type int dword_1002A300;
+// 1002A304: using guessed type int dword_1002A304;
+// 1002A308: using guessed type int dword_1002A308;
+// 1002A310: using guessed type int dword_1002A310;
+// 1002A318: using guessed type int dword_1002A318;
+// 1002A31C: using guessed type int dword_1002A31C;
+// 1002A320: using guessed type int dword_1002A320;
+// 1002A324: using guessed type int dword_1002A324;
+// 1002A328: using guessed type int dword_1002A328;
+
+// ref: 0x10009805
+BOOL __fastcall Progress_10009805(HWND hWnd, int a2) { return 0; }
+/* {
+	HWND v2; // edi
+	struct tagRECT Rect; // [esp+8h] [ebp-18h]
+	HWND hWnda; // [esp+18h] [ebp-8h]
+	int v6; // [esp+1Ch] [ebp-4h]
+
+	v2 = hWnd;
+	v6 = a2;
+	hWnda = GetDlgItem(hWnd, 1030);
+	SBltROP3(
+		dword_1002A328,
+		dword_1002A320,
+		dword_1002A300,
+		dword_1002A304,
+		dword_1002A300,
+		dword_1002A310,
+		0,
+		13369376);
+	SBltROP3(
+		dword_1002A328,
+		dword_1002A324,
+		v6 * dword_1002A300 / 100,
+		dword_1002A304,
+		dword_1002A300,
+		dword_1002A308,
+		0,
+		13369376);
+	GetWindowRect(hWnda, &Rect);
+	ScreenToClient(v2, (LPPOINT)&Rect);
+	ScreenToClient(v2, (LPPOINT)&Rect.right);
+	return InvalidateRect(v2, &Rect, 0);
+} */
+// 100103F4: using guessed type int __stdcall SBltROP3(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A300: using guessed type int dword_1002A300;
+// 1002A304: using guessed type int dword_1002A304;
+// 1002A308: using guessed type int dword_1002A308;
+// 1002A310: using guessed type int dword_1002A310;
+// 1002A320: using guessed type int dword_1002A320;
+// 1002A324: using guessed type int dword_1002A324;
+// 1002A328: using guessed type int dword_1002A328;
+
+// ref: 0x100098B0
+void Progress_100098B0() { return; }
+/* {
+	dword_1002A2E8 = 2;
+	dword_1002A2F8 = 1;
+} */
+// 1002A2E8: using guessed type int dword_1002A2E8;
+// 1002A2F8: using guessed type int dword_1002A2F8;
+
+// ref: 0x100098C5
+void UNKCALL Progress_100098C5(HWND hWnd) { return; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	HWND v3; // edi
+	int v4; // edx
+
+	v1 = hWnd;
+	v2 = dword_1002A2F4();
+	if ( v2 >= 100 )
+	{
+		SDlgKillTimer(v1, 1);
+		v3 = GetParent(v1);
+		if ( (HWND)SDrawGetFrameWindow() == v3 )
+			Fade_100072BE(10);
+		Progress_100098B0();
+		dword_1002A2E8 &= v4;
+	}
+	else
+	{
+		Progress_10009805(v1, v2);
+	}
+} */
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 1002A2E8: using guessed type int dword_1002A2E8;
+// 1002A2F4: using guessed type int (*dword_1002A2F4)(void);
+
+// ref: 0x1000991C
+BOOL UNKCALL Progress_1000991C(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	BOOL result; // eax
+	struct tagMSG Msg; // [esp+Ch] [ebp-1Ch]
+
+	v1 = hWnd;
+	for ( result = IsWindow(hWnd); result; result = IsWindow(v1) )
+	{
+		if ( dword_1002A2F8 )
+			goto LABEL_12;
+		if ( PeekMessageA(&Msg, 0, 0, 0, 1u) )
+		{
+			if ( Msg.message == 18 )
+			{
+				PostQuitMessage(Msg.wParam);
+			}
+			else if ( !IsDialogMessageA(v1, &Msg) )
+			{
+				TranslateMessage(&Msg);
+				DispatchMessageA(&Msg);
+			}
+		}
+		else
+		{
+			SDlgCheckTimers();
+			SDlgUpdateCursor();
+		}
+	}
+	if ( !dword_1002A2F8 )
+		return result;
+LABEL_12:
+	result = DestroyWindow(v1);
+	dword_1002A2F8 = 0;
+	return result;
+} */
+// 10010460: using guessed type _DWORD __stdcall SDlgUpdateCursor();
+// 10010466: using guessed type _DWORD __stdcall SDlgCheckTimers();
+// 1002A2F8: using guessed type int dword_1002A2F8;

--- a/DiabloUI/sbar.cpp
+++ b/DiabloUI/sbar.cpp
@@ -1,0 +1,276 @@
+// ref: 0x100099B5
+signed int Sbar_100099B5() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A338 = 2139095040;
+	return result;
+} */
+// 1002A338: using guessed type int dword_1002A338;
+
+// ref: 0x100099C0
+int UNKCALL Sbar_100099C0(HWND hWnd) { return 0; }
+/* {
+	_DWORD *v1; // eax
+
+	v1 = (_DWORD *)GetWindowLongA(hWnd, -21);
+	if ( !v1 || !*v1 )
+		return 0;
+	*v1 = 0;
+	return 1;
+} */
+
+// ref: 0x100099DC
+int __fastcall Sbar_100099DC(HWND hWnd, LONG a2, int a3) { return 0; }
+/* {
+	HWND v3; // esi
+	_DWORD *v4; // eax
+	_DWORD *v5; // esi
+	int result; // eax
+	signed int v7; // ecx
+	LONG v8; // ebx
+	LONG v9; // edi
+	signed int v10; // [esp-4h] [ebp-1Ch]
+	struct tagPOINT Point; // [esp+Ch] [ebp-Ch]
+	HWND hWnda; // [esp+14h] [ebp-4h]
+
+	v3 = hWnd;
+	hWnda = hWnd;
+	Point.x = a2;
+	Point.y = a3;
+	if ( !hWnd )
+		return 0;
+	if ( !IsWindowVisible(hWnd) )
+		return 0;
+	v4 = (_DWORD *)GetWindowLongA(v3, -21);
+	v5 = v4;
+	if ( !v4 )
+		return 0;
+	v7 = v4[13];
+	if ( v7 <= 1 )
+		v8 = 22;
+	else
+		v8 = v4[14] * (v4[3] - v4[9] - 44) / (v7 - 1) + 22;
+	v9 = v8 + v4[9];
+	ScreenToClient(hWnda, &Point);
+	if ( Point.y >= 22 )
+	{
+		if ( Point.y >= v8 )
+		{
+			if ( Point.y >= v9 )
+			{
+				if ( Point.y >= v5[3] - 22 )
+				{
+					*v5 = 4;
+					v10 = 2;
+				}
+				else
+				{
+					*v5 = 8;
+					v10 = 4;
+				}
+			}
+			else
+			{
+				*v5 = 16;
+				v10 = 5;
+			}
+		}
+		else
+		{
+			*v5 = 2;
+			v10 = 3;
+		}
+		result = v10;
+	}
+	else
+	{
+		result = 1;
+		*v5 = 1;
+	}
+	return result;
+} */
+
+// ref: 0x10009A99
+HWND __fastcall Sbar_10009A99(HWND hDlg, int nIDDlgItem, int a3, int a4) { return 0; }
+/* {
+	HWND result; // eax
+	HWND v5; // esi
+	bool v6; // zf
+	int v7; // eax
+	int v8; // [esp+Ch] [ebp-24h]
+	int v9; // [esp+10h] [ebp-20h]
+	int v10; // [esp+14h] [ebp-1Ch]
+	int v11; // [esp+18h] [ebp-18h]
+	int v12; // [esp+1Ch] [ebp-14h]
+	int v13; // [esp+20h] [ebp-10h]
+	int v14; // [esp+24h] [ebp-Ch]
+	int v15; // [esp+28h] [ebp-8h]
+	HWND hWnd; // [esp+2Ch] [ebp-4h]
+
+	result = GetDlgItem(hDlg, nIDDlgItem);
+	hWnd = result;
+	if ( result )
+	{
+		result = (HWND)GetWindowLongA(result, -21);
+		v5 = result;
+		if ( result )
+		{
+			if ( *((_DWORD *)result + 1) )
+			{
+				v6 = *((_DWORD *)result + 4) == 0;
+				*((_DWORD *)result + 13) = a3;
+				result = (HWND)a4;
+				*((_DWORD *)v5 + 14) = a4;
+				if ( !v6 )
+				{
+					v12 = 0;
+					v8 = 0;
+					v13 = 0;
+					v9 = 0;
+					v10 = *((_DWORD *)v5 + 2) - 1;
+					v11 = *((_DWORD *)v5 + 3) - 1;
+					v14 = *((_DWORD *)v5 + 2) - 1;
+					v15 = *((_DWORD *)v5 + 6) - 1;
+					result = (HWND)SBltROP3Tiled(
+									   *((_DWORD *)v5 + 1),
+									   &v8,
+									   *((_DWORD *)v5 + 2),
+									   *((_DWORD *)v5 + 4),
+									   &v12,
+									   *((_DWORD *)v5 + 5),
+									   0,
+									   0,
+									   0,
+									   13369376);
+					if ( *((_DWORD *)v5 + 7) )
+					{
+						if ( a3 <= 1 )
+							v7 = 22;
+						else
+							v7 = a4 * (*((_DWORD *)v5 + 3) - *((_DWORD *)v5 + 9) - 44) / (a3 - 1) + 22;
+						SBltROP3(
+							v7 * *((_DWORD *)v5 + 2) + *((_DWORD *)v5 + 1) + 3,
+							*((_DWORD *)v5 + 7),
+							18,
+							*((_DWORD *)v5 + 9),
+							*((_DWORD *)v5 + 2),
+							*((_DWORD *)v5 + 8),
+							0,
+							13369376);
+						SBltROP3(
+							*((_DWORD *)v5 + 1),
+							*((_DWORD *)v5 + 10) + 22 * (~*(_BYTE *)v5 & 1) * *((_DWORD *)v5 + 11),
+							*((_DWORD *)v5 + 2),
+							22,
+							*((_DWORD *)v5 + 2),
+							*((_DWORD *)v5 + 11),
+							0,
+							13369376);
+						SBltROP3(
+							*((_DWORD *)v5 + 1) + *((_DWORD *)v5 + 2) * (*((_DWORD *)v5 + 3) - 22),
+							*((_DWORD *)v5 + 10) + 22 * ((~*(_BYTE *)v5 & 4 | 8u) >> 2) * *((_DWORD *)v5 + 11),
+							*((_DWORD *)v5 + 2),
+							22,
+							*((_DWORD *)v5 + 2),
+							*((_DWORD *)v5 + 11),
+							0,
+							13369376);
+						result = (HWND)InvalidateRect(hWnd, 0, 0);
+					}
+				}
+			}
+		}
+	}
+	return result;
+} */
+// 100103F4: using guessed type int __stdcall SBltROP3(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1001046C: using guessed type int __stdcall SBltROP3Tiled(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10009BF1
+HWND __fastcall Sbar_10009BF1(HWND hDlg, int nIDDlgItem) { return 0; }
+/* {
+	HWND result; // eax
+	HWND v3; // esi
+	struct tagRECT Rect; // [esp+Ch] [ebp-14h]
+	HWND hWnd; // [esp+1Ch] [ebp-4h]
+
+	result = GetDlgItem(hDlg, nIDDlgItem);
+	hWnd = result;
+	if ( result )
+	{
+		result = (HWND)SMemAlloc(60, "C:\\Src\\Diablo\\DiabloUI\\Sbar.cpp", 221, 0);
+		v3 = result;
+		if ( result )
+		{
+			SetWindowLongA(hWnd, -21, (LONG)result);
+			*(_DWORD *)v3 = 0;
+			GetClientRect(hWnd, &Rect);
+			*(_DWORD *)(v3 + 2) = Rect.right;
+			*(_DWORD *)(v3 + 3) = Rect.bottom;
+			result = (HWND)SMemAlloc(Rect.right * Rect.bottom, "C:\\Src\\Diablo\\DiabloUI\\Sbar.cpp", 230, 0);
+			*((_DWORD *)v3 + 1) = result;
+			if ( result )
+			{
+				SDlgSetBitmapI(hWnd, 0, &byte_10029448, -1, 1, result, 0, *((_DWORD *)v3 + 2), *((_DWORD *)v3 + 3), -1);
+				local_100078BE((int)"ui_art\\sb_bg.pcx", (int *)v3 + 4, (_DWORD *)v3 + 5);
+				local_100078BE((int)"ui_art\\sb_thumb.pcx", (int *)v3 + 7, (_DWORD *)v3 + 8);
+				result = (HWND)local_100078BE((int)"ui_art\\sb_arrow.pcx", (int *)v3 + 10, (_DWORD *)v3 + 11);
+			}
+		}
+	}
+	return result;
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10009CC7
+signed int Sbar_10009CC7() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A344 = 2139095040;
+	return result;
+} */
+// 1002A344: using guessed type int dword_1002A344;
+
+// ref: 0x10009CD2
+HWND __fastcall Sbar_10009CD2(HWND hDlg, int nIDDlgItem) { return 0; }
+/* {
+	HWND result; // eax
+	HWND v3; // ebp
+	HWND v4; // esi
+	int v5; // eax
+	int v6; // eax
+	int v7; // eax
+	int v8; // eax
+
+	result = GetDlgItem(hDlg, nIDDlgItem);
+	v3 = result;
+	if ( result )
+	{
+		result = (HWND)GetWindowLongA(result, -21);
+		v4 = result;
+		if ( result )
+		{
+			v5 = *((_DWORD *)result + 1);
+			if ( v5 )
+				SMemFree(v5, "C:\\Src\\Diablo\\DiabloUI\\Sbar.cpp", 267, 0);
+			v6 = *((_DWORD *)v4 + 4);
+			if ( v6 )
+				SMemFree(v6, "C:\\Src\\Diablo\\DiabloUI\\Sbar.cpp", 269, 0);
+			v7 = *((_DWORD *)v4 + 7);
+			if ( v7 )
+				SMemFree(v7, "C:\\Src\\Diablo\\DiabloUI\\Sbar.cpp", 271, 0);
+			v8 = *((_DWORD *)v4 + 10);
+			if ( v8 )
+				SMemFree(v8, "C:\\Src\\Diablo\\DiabloUI\\Sbar.cpp", 273, 0);
+			SMemFree(v4, "C:\\Src\\Diablo\\DiabloUI\\Sbar.cpp", 275, 0);
+			result = (HWND)SetWindowLongA(v3, -21, 0);
+		}
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);

--- a/DiabloUI/selclass.cpp
+++ b/DiabloUI/selclass.cpp
@@ -1,0 +1,193 @@
+// ref: 0x10009D66
+int __stdcall SelClass_10009D66(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	LONG v5; // edx
+	HWND v6; // eax
+	HWND v7; // eax
+	HWND v9; // eax
+
+	if ( Msg == 2 )
+	{
+		SelClass_10009EC0(hDlg);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v9 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v9, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	if ( Msg == 272 )
+	{
+		SelClass_10009EFD(hDlg);
+		return 0;
+	}
+	if ( Msg != 273 )
+	{
+		if ( Msg != 275 )
+		{
+			if ( Msg == 513 )
+			{
+				v4 = GetDlgItem(hDlg, 1056);
+				if ( local_10007C3B(hDlg, v4, (unsigned short)lParam, (unsigned int)lParam >> 16) )
+				{
+					v5 = 1;
+LABEL_19:
+					SelClass_1000A00D((int)hDlg, v5);
+					return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+				}
+				v6 = GetDlgItem(hDlg, 1054);
+				if ( local_10007C3B(hDlg, v6, (unsigned short)lParam, (unsigned int)lParam >> 16) )
+				{
+LABEL_21:
+					v5 = 2;
+					goto LABEL_19;
+				}
+			}
+			return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+		}
+		v7 = GetFocus();
+		Focus_100075DC(hDlg, v7);
+		return 0;
+	}
+	if ( HIWORD(wParam) == 7 )
+	{
+		Focus_100075B7(hDlg, (HWND)lParam);
+	}
+	else
+	{
+		if ( HIWORD(wParam) != 6 )
+		{
+			v5 = 1;
+			if ( wParam == 327681 )
+				goto LABEL_19;
+			if ( (_WORD)wParam != 2 )
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+			goto LABEL_21;
+		}
+		Focus_10007458((void *)lParam);
+		Focus_100075DC(hDlg, (HWND)lParam);
+		SelClass_10009FA2(hDlg, (unsigned short)wParam);
+	}
+	return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x10009EC0
+HWND UNKCALL SelClass_10009EC0(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // eax
+
+	v1 = hDlg;
+	Focus_100076C3();
+	Doom_10006C53(v1, (int *)&unk_10022EC8);
+	Doom_10006C53(v1, (int *)&unk_10022EBC);
+	Doom_10006C53(v1, (int *)&unk_10022EB4);
+	v2 = GetParent(v1);
+	return SelHero_1000BA7B(v2, 0);
+} */
+
+// ref: 0x10009EFD
+int UNKCALL SelClass_10009EFD(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // esi
+	LONG v3; // eax
+	CHAR Buffer; // [esp+8h] [ebp-20h]
+
+	v1 = hWnd;
+	v2 = GetParent(hWnd);
+	if ( SelHero_1000B7CA() == 1 )
+		LoadStringA(hInstance, 0x20u, &Buffer, 31);
+	else
+		LoadStringA(hInstance, 0x1Fu, &Buffer, 31);
+	SelHero_1000BA7B(v2, &Buffer);
+	v3 = GetWindowLongA(v2, -21);
+	SetWindowLongA(v1, -21, v3);
+	local_10007CB5(v1, (int *)&unk_10022EC8);
+	Doom_100068AB(v1, (int *)&unk_10022EB4, 5);
+	Doom_1000658C(v1, (int *)&unk_10022EBC, 4, 0);
+	Doom_1000658C(v1, (int *)&unk_10022EC8, 2, 1);
+	Focus_10007719("ui_art\\focus.pcx");
+	return SDlgSetTimer(v1, 1, 55, 0);
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x10009FA2
+int __fastcall SelClass_10009FA2(HWND hWnd, int a2) { return 0; }
+/* {
+	char v2; // bl
+	HWND v3; // esi
+	HWND v4; // eax
+	char v6; // [esp+8h] [ebp-34h]
+	short v7; // [esp+1Ch] [ebp-20h]
+	char v8; // [esp+1Eh] [ebp-1Eh]
+	short v9; // [esp+20h] [ebp-1Ch]
+	short v10; // [esp+22h] [ebp-1Ah]
+	short v11; // [esp+24h] [ebp-18h]
+	short v12; // [esp+26h] [ebp-16h]
+	short v13; // [esp+34h] [ebp-8h]
+	short v14; // [esp+36h] [ebp-6h]
+	short v15; // [esp+38h] [ebp-4h]
+	short v16; // [esp+3Ah] [ebp-2h]
+
+	v2 = a2;
+	v3 = hWnd;
+	SelHero_1000B7D0(a2 - 1062, (int)&v13);
+	memset(&v6, 0, 0x2Cu);
+	v9 = v13;
+	v10 = v14;
+	v11 = v15;
+	v7 = 1;
+	v8 = v2 - 38;
+	v12 = v16;
+	v4 = GetParent(v3);
+	return SelHero_1000B905(v4, (int)&v6);
+} */
+
+// ref: 0x1000A00D
+int __fastcall SelClass_1000A00D(int a1, LONG a2) { return 0; }
+/* {
+	LONG v2; // esi
+	int v3; // ebp
+	HWND v4; // eax
+	HWND v6; // eax
+
+	v2 = a2;
+	v3 = a1;
+	if ( DiabloUI_10005C2A() )
+	{
+		if ( v2 == 1 )
+		{
+			v4 = GetFocus();
+			if ( GetWindowLongA(v4, -12) != 1062 )
+				return SelYesNo_1000FD77(v3, 0x45u, 0);
+		}
+	}
+	TitleSnd_1001031F();
+	SDlgKillTimer(v3, 1);
+	if ( v2 == 1 )
+	{
+		v6 = GetFocus();
+		v2 = GetWindowLongA(v6, -12);
+	}
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x1000A077
+signed int SelClass_1000A077() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A348 = 2139095040;
+	return result;
+} */
+// 1002A348: using guessed type int dword_1002A348;

--- a/DiabloUI/selconn.cpp
+++ b/DiabloUI/selconn.cpp
@@ -1,0 +1,1146 @@
+// ref: 0x1000A082
+int SelConn_1000A082() { return 0; }
+/* {
+	return SMemAlloc(272, "C:\\Src\\Diablo\\DiabloUI\\SelConn.cpp", 124, 0);
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000A09B
+signed int SelConn_1000A09B() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A350 = 2139095040;
+	return result;
+} */
+// 1002A350: using guessed type int dword_1002A350;
+
+// ref: 0x1000A0A6
+int __stdcall SelConn_1000A0A6(HWND hWnd, UINT Msg, WPARAM wParam, unsigned int lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	HWND v6; // eax
+	char *v7; // [esp+0h] [ebp-Ch]
+	int v8; // [esp+4h] [ebp-8h]
+
+	if ( Msg > 0x201 )
+	{
+		if ( Msg == 514 )
+		{
+			v6 = GetDlgItem(hWnd, 1105);
+			if ( !Sbar_100099C0(v6) )
+				return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+			goto LABEL_27;
+		}
+		if ( Msg != 515 )
+		{
+			if ( Msg != 2024 )
+				return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+			if ( !Fade_1000739F() )
+				Fade_100073FD(hWnd, (int)v7);
+			return 0;
+		}
+LABEL_25:
+		SelConn_1000AE59(hWnd, (unsigned short)lParam, lParam >> 16);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg == 513 )
+		goto LABEL_25;
+	if ( Msg == 2 )
+	{
+		SelConn_1000A43A(hWnd);
+		BNetGW_10002A07(&unk_10029480);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v4 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v4, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg == 272 )
+	{
+		BNetGW_100028C2(&unk_10029480);
+		SelConn_1000A4E4(hWnd, v7, v8);
+		PostMessageA(hWnd, 0x7E8u, 0, 0);
+		return 0;
+	}
+	if ( Msg == 273 )
+	{
+		if ( HIWORD(wParam) == 7 )
+		{
+			Focus_100075B7(hWnd, (HWND)lParam);
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		if ( HIWORD(wParam) != 6 )
+		{
+			if ( wParam == 327681 )
+			{
+				SelConn_1000AC30(hWnd);
+			}
+			else if ( (_WORD)wParam == 2 )
+			{
+				SelConn_1000AC07((int)hWnd, 2);
+			}
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		Focus_10007458((void *)lParam);
+		Focus_100075DC(hWnd, (HWND)lParam);
+		SelConn_1000A226(hWnd, (unsigned short)wParam);
+LABEL_27:
+		SelConn_1000A3E2(hWnd);
+	}
+	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x1000A226
+HWND __fastcall SelConn_1000A226(HWND hDlg, int nIDDlgItem) { return 0; }
+/* {
+	HWND v2; // edi
+	HWND result; // eax
+	int v4; // ebx
+	int v5; // eax
+	HWND v6; // ebp
+	unsigned int v7; // eax
+	int v8; // eax
+	const char *v9; // ebx
+	int v10; // eax
+	HWND v11; // eax
+	HWND v12; // eax
+	HWND v13; // eax
+	HWND v14; // eax
+	HWND v15; // eax
+	HWND v16; // eax
+	HWND v17; // eax
+	HWND v18; // eax
+	HWND hWnd; // [esp+10h] [ebp-8Ch]
+	CHAR Buffer; // [esp+14h] [ebp-88h]
+	CHAR v21; // [esp+54h] [ebp-48h]
+
+	v2 = hDlg;
+	result = GetDlgItem(hDlg, nIDDlgItem);
+	if ( result )
+	{
+		result = (HWND)GetWindowLongA(result, -21);
+		if ( result )
+		{
+			v4 = *((_DWORD *)result + 3);
+			if ( v4 )
+			{
+				result = GetDlgItem(v2, 1081);
+				if ( result )
+				{
+					v5 = GetWindowLongA(result, -21);
+					local_10007FA4(v5, (const char *)(v4 + 144));
+					result = GetDlgItem(v2, 1076);
+					v6 = result;
+					if ( result )
+					{
+						LoadStringA(hInstance, 0x21u, &Buffer, 63);
+						if ( dword_1002A370 )
+						{
+							v7 = *(_DWORD *)(dword_1002A370 + 24);
+							if ( v7 >= *(_DWORD *)(v4 + 12) )
+								v7 = *(_DWORD *)(v4 + 12);
+							wsprintfA(&v21, &Buffer, v7);
+						}
+						else
+						{
+							wsprintfA(&v21, &Buffer, *(_DWORD *)(v4 + 12));
+						}
+						v8 = GetWindowLongA(v6, -21);
+						local_10007FA4(v8, &v21);
+						if ( *(_DWORD *)(v4 + 8) == 1112425812 )
+						{
+							hWnd = GetDlgItem(v2, 1144);
+							v9 = BNetGW_10002B21(&unk_10029480, dword_1002948C);
+							if ( !v9 )
+								v9 = &byte_10029448;
+							if ( hWnd )
+							{
+								v10 = GetWindowLongA(hWnd, -21);
+								local_10007FA4(v10, v9);
+							}
+							v11 = GetDlgItem(v2, 1143);
+							ShowWindow(v11, 5);
+							v12 = GetDlgItem(v2, 1147);
+							ShowWindow(v12, 0);
+							v13 = GetDlgItem(v2, 1144);
+							ShowWindow(v13, 5);
+							v14 = GetDlgItem(v2, 1145);
+							ShowWindow(v14, 5);
+							dword_1002A354 = 1;
+						}
+						else
+						{
+							v15 = GetDlgItem(v2, 1143);
+							ShowWindow(v15, 0);
+							v16 = GetDlgItem(v2, 1147);
+							ShowWindow(v16, 5);
+							v17 = GetDlgItem(v2, 1144);
+							ShowWindow(v17, 0);
+							v18 = GetDlgItem(v2, 1145);
+							ShowWindow(v18, 0);
+							dword_1002A354 = 0;
+						}
+						result = (HWND)Doom_10006A13(v2, (int *)&unk_10022EF0, 1);
+					}
+				}
+			}
+		}
+	}
+	return result;
+} */
+// 1002948C: using guessed type int dword_1002948C;
+// 1002A354: using guessed type int dword_1002A354;
+// 1002A370: using guessed type int dword_1002A370;
+
+// ref: 0x1000A3E2
+HWND UNKCALL SelConn_1000A3E2(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+
+	v1 = hDlg;
+	v2 = SelConn_1000A3FF();
+	return Sbar_10009A99(v1, 1105, dword_1002A360, v2);
+} */
+
+// ref: 0x1000A3FF
+int SelConn_1000A3FF() { return 0; }
+/* {
+	HWND v0; // eax
+	LONG v1; // eax
+	_DWORD *v2; // ecx
+	_DWORD *v3; // eax
+	int v5; // edx
+
+	v0 = GetFocus();
+	if ( !v0 )
+		return 0;
+	v1 = GetWindowLongA(v0, -21);
+	if ( !v1 )
+		return 0;
+	v2 = (_DWORD *)dword_1002A35C;
+	if ( !dword_1002A35C )
+		return 0;
+	v3 = *(_DWORD **)(v1 + 12);
+	if ( !v3 )
+		return 0;
+	v5 = 0;
+	do
+	{
+		if ( v2 == v3 )
+			break;
+		v2 = (_DWORD *)*v2;
+		++v5;
+	}
+	while ( v2 );
+	return v5;
+} */
+// 1002A35C: using guessed type int dword_1002A35C;
+
+// ref: 0x1000A43A
+void UNKCALL SelConn_1000A43A(HWND hDlg) { return; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	Title_100100E7(hDlg);
+	Focus_10007818(v1);
+	Sbar_10009CD2(v1, 1105);
+	SelConn_1000A4B9((_DWORD *)dword_1002A35C);
+	Doom_10006C53(v1, &dword_10022F18);
+	Doom_10006C53(v1, (int *)&unk_10022F08);
+	Doom_10006C53(v1, (int *)&unk_10022ED8);
+	Doom_10006C53(v1, (int *)&unk_10022EE4);
+	Doom_10006C53(v1, (int *)&unk_10022F00);
+	Doom_10006C53(v1, (int *)&unk_10022EF0);
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+} */
+// 10022F18: using guessed type int dword_10022F18;
+// 1002A35C: using guessed type int dword_1002A35C;
+
+// ref: 0x1000A4B9
+int __fastcall SelConn_1000A4B9(_DWORD *a1) { return 0; }
+/* {
+	_DWORD *v1; // esi
+	int result; // eax
+
+	if ( a1 )
+	{
+		do
+		{
+			v1 = (_DWORD *)*a1;
+			result = SelConn_1000A4CD(a1);
+			a1 = v1;
+		}
+		while ( v1 );
+	}
+	return result;
+} */
+
+// ref: 0x1000A4CD
+int UNKCALL SelConn_1000A4CD(void *arg) { return 0; }
+/* {
+	int result; // eax
+
+	if ( arg )
+		result = SMemFree(arg, "C:\\Src\\Diablo\\DiabloUI\\SelConn.cpp", 130, 0);
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000A4E4
+HWND UNKCALL SelConn_1000A4E4(HWND hWnd, char *a2, int a3) { return 0; }
+/* {
+	HWND v3; // esi
+	HWND v4; // ST1C_4
+	int v5; // eax
+	int *v6; // edi
+	HWND result; // eax
+	HWND v8; // eax
+	HWND v9; // [esp+0h] [ebp-Ch]
+
+	v3 = hWnd;
+	SelConn_1000A6EC(hWnd);
+	Focus_100077E9((int)v3, "ui_art\\focus16.pcx", v9);
+	Title_1001009E(v3, (int)"ui_art\\smlogo.pcx", v4);
+	v5 = local_10007F46();
+	v6 = (int *)v5;
+	if ( v5 )
+	{
+		SetWindowLongA(v3, -21, v5);
+		local_10007944((int)v3, 0, &byte_10029448, -1, 1, (int)"ui_art\\selconn.pcx", v6, v6 + 1, 0);
+		Fade_100073C5(v3, 1);
+	}
+	Doom_100068AB(v3, (int *)&unk_10022EF0, 1);
+	Doom_100068AB(v3, (int *)&unk_10022F00, 1);
+	Doom_100068AB(v3, (int *)&unk_10022ED8, 5);
+	Doom_100068AB(v3, (int *)&unk_10022EE4, 3);
+	Doom_1000658C(v3, (int *)&unk_10022F08, 4, 0);
+	Doom_1000658C(v3, &dword_10022F18, 0, 1);
+	dword_1002A360 = 0;
+	dword_1002A368 = dword_10029488;
+	dword_1002A35C = 0;
+	SNetEnumProviders(0, SelConn_1000A5F3);
+	SelConn_1000A670(v3, (const char *)dword_1002A35C);
+	result = Sbar_10009BF1(v3, 1105);
+	if ( dword_1002A360 <= 6 )
+	{
+		v8 = GetDlgItem(v3, 1105);
+		result = (HWND)ShowWindow(v8, 0);
+	}
+	return result;
+} */
+// 10010472: using guessed type int __stdcall SNetEnumProviders(_DWORD, _DWORD);
+// 10022F18: using guessed type int dword_10022F18;
+// 10029488: using guessed type int dword_10029488;
+// 1002A35C: using guessed type int dword_1002A35C;
+// 1002A368: using guessed type int dword_1002A368;
+
+// ref: 0x1000A5F3
+signed int __stdcall SelConn_1000A5F3(int a1, char *a2, char *a3, int a4) { return 0; }
+/* {
+	int v4; // esi
+	int v6; // edx
+	_DWORD *v7; // eax
+
+	v4 = SelConn_1000A082();
+	if ( !v4 || a1 == 1112425812 && !dword_1002A368 )
+		return 0;
+	*(_DWORD *)v4 = 0;
+	v6 = *(_DWORD *)(a4 + 4);
+	*(_DWORD *)(v4 + 8) = a1;
+	*(_DWORD *)(v4 + 4) = v6 & 2;
+	*(_DWORD *)(v4 + 12) = *(_DWORD *)(a4 + 16);
+	strcpy((char *)(v4 + 16), a2);
+	strcpy((char *)(v4 + 144), a3);
+	v7 = SelRegn_1000EF56(dword_1002A35C, (_DWORD *)v4);
+	++dword_1002A360;
+	dword_1002A35C = (int)v7;
+	return 1;
+} */
+// 1002A35C: using guessed type int dword_1002A35C;
+// 1002A368: using guessed type int dword_1002A368;
+
+// ref: 0x1000A670
+int __fastcall SelConn_1000A670(HWND a1, const char *a2) { return 0; }
+/* {
+	const char *v2; // edi
+	int *v3; // ebx
+	HWND v4; // eax
+	HWND v5; // esi
+	int v6; // eax
+	HWND hDlg; // [esp+8h] [ebp-4h]
+
+	v2 = a2;
+	hDlg = a1;
+	v3 = &dword_10022F18;
+	if ( dword_10022F18 )
+	{
+		do
+		{
+			v4 = GetDlgItem(hDlg, *v3);
+			v5 = v4;
+			if ( v4 )
+			{
+				if ( v2 )
+				{
+					EnableWindow(v4, 1);
+					v6 = GetWindowLongA(v5, -21);
+					if ( v6 )
+					{
+						*(_DWORD *)(v6 + 12) = v2;
+						local_10007FA4(v6, v2 + 16);
+						v2 = *(const char **)v2;
+					}
+				}
+				else
+				{
+					EnableWindow(v4, 0);
+				}
+			}
+			++v3;
+		}
+		while ( *v3 );
+	}
+	return Doom_1000680A(hDlg, &dword_10022F18, 0, 1);
+} */
+// 10022F18: using guessed type int dword_10022F18;
+
+// ref: 0x1000A6EC
+void UNKCALL SelConn_1000A6EC(HWND hDlg) { return; }
+/* {
+	HWND v1; // ebx
+	int *v2; // edi
+	HWND v3; // eax
+	HWND v4; // esi
+	void *v5; // eax
+
+	v1 = hDlg;
+	v2 = &dword_10022F18;
+	if ( dword_10022F18 )
+	{
+		do
+		{
+			v3 = GetDlgItem(v1, *v2);
+			v4 = v3;
+			if ( v3 )
+			{
+				v5 = (void *)GetWindowLongA(v3, -4);
+				SetPropA(v4, "UIOLDPROC", v5);
+				SetWindowLongA(v4, -4, (LONG)SelConn_1000A73E);
+			}
+			++v2;
+		}
+		while ( *v2 );
+	}
+} */
+// 10022F18: using guessed type int dword_10022F18;
+
+// ref: 0x1000A73E
+LRESULT __stdcall SelConn_1000A73E(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	LRESULT (__stdcall *v4)(HWND, UINT, WPARAM, LPARAM); // edi
+	HWND v5; // eax
+	WPARAM v7; // [esp-8h] [ebp-14h]
+
+	v4 = (LRESULT (__stdcall *)(HWND, UINT, WPARAM, LPARAM))GetPropA(hWnd, "UIOLDPROC");
+	switch ( Msg )
+	{
+		case 2u:
+			RemovePropA(hWnd, "UIOLDPROC");
+			if ( !v4 )
+				return DefWindowProcA(hWnd, Msg, wParam, lParam);
+			SetWindowLongA(hWnd, -4, (LONG)v4);
+			break;
+		case 0xFu:
+			local_10007C95(hWnd);
+			return 0;
+		case 0x87u:
+			return 4;
+		case 0x100u:
+			if ( wParam > 0x21 )
+			{
+				if ( wParam == 34 )
+				{
+					SelConn_1000A948(hWnd);
+				}
+				else if ( wParam > 0x24 )
+				{
+					if ( wParam <= 0x26 )
+					{
+						SelConn_1000AB83(hWnd);
+					}
+					else if ( wParam <= 0x28 )
+					{
+						SelConn_1000AAEB(hWnd);
+					}
+				}
+				return 0;
+			}
+			if ( wParam == 33 )
+			{
+				SelConn_1000AA3B(hWnd);
+				return 0;
+			}
+			if ( wParam == 9 )
+			{
+				if ( GetKeyState(16) >= 0 )
+					SelConn_1000A866(hWnd);
+				else
+					SelConn_1000A8D7(hWnd);
+				return 0;
+			}
+			if ( wParam != 13 )
+			{
+				if ( wParam == 27 )
+				{
+					v7 = 2;
+					goto LABEL_13;
+				}
+				if ( wParam != 32 )
+					return 0;
+			}
+			v7 = 1;
+LABEL_13:
+			v5 = GetParent(hWnd);
+			SendMessageA(v5, 0x111u, v7, 0);
+			return 0;
+	}
+	if ( v4 )
+		return CallWindowProcA(v4, hWnd, Msg, wParam, lParam);
+	return DefWindowProcA(hWnd, Msg, wParam, lParam);
+} */
+
+// ref: 0x1000A866
+HWND UNKCALL SelConn_1000A866(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // ebx
+	int nIDDlgItem[1066]; // [esp+0h] [ebp-10CCh]
+	int v5; // [esp+10A8h] [ebp-24h]
+	int v6; // [esp+10B4h] [ebp-18h]
+	int v7; // [esp+10B8h] [ebp-14h]
+	int v8; // [esp+10BCh] [ebp-10h]
+	int v9; // [esp+10C0h] [ebp-Ch]
+	int v10; // [esp+10C4h] [ebp-8h]
+	int v11; // [esp+10C8h] [ebp-4h]
+
+	v1 = hWnd;
+	v6 = 1070;
+	v7 = 1071;
+	v8 = 1072;
+	v9 = 1073;
+	v10 = 1074;
+	v11 = 1069;
+	v2 = GetParent(hWnd);
+	do
+	{
+		v5 = nIDDlgItem[GetWindowLongA(v1, -12)];
+		v1 = GetDlgItem(v2, v5);
+	}
+	while ( !IsWindowEnabled(v1) );
+	return SetFocus(v1);
+} */
+// 1000A866: using guessed type int nIDDlgItem[1066];
+
+// ref: 0x1000A8D7
+HWND UNKCALL SelConn_1000A8D7(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // ebx
+	int nIDDlgItem[1066]; // [esp+0h] [ebp-10CCh]
+	int v5; // [esp+10A8h] [ebp-24h]
+	int v6; // [esp+10B4h] [ebp-18h]
+	int v7; // [esp+10B8h] [ebp-14h]
+	int v8; // [esp+10BCh] [ebp-10h]
+	int v9; // [esp+10C0h] [ebp-Ch]
+	int v10; // [esp+10C4h] [ebp-8h]
+	int v11; // [esp+10C8h] [ebp-4h]
+
+	v1 = hWnd;
+	v6 = 1074;
+	v7 = 1069;
+	v8 = 1070;
+	v9 = 1071;
+	v10 = 1072;
+	v11 = 1073;
+	v2 = GetParent(hWnd);
+	do
+	{
+		v5 = nIDDlgItem[GetWindowLongA(v1, -12)];
+		v1 = GetDlgItem(v2, v5);
+	}
+	while ( !IsWindowEnabled(v1) );
+	return SetFocus(v1);
+} */
+// 1000A8D7: using guessed type int nIDDlgItem[1066];
+
+// ref: 0x1000A948
+HWND UNKCALL SelConn_1000A948(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // ebp
+	HWND result; // eax
+	HWND v3; // esi
+	HWND v4; // ebx
+	HWND v5; // eax
+	_DWORD *v6; // eax
+	int v7; // eax
+	const char *v8; // ebx
+	int v9; // eax
+
+	v1 = hWnd;
+	result = GetParent(hWnd);
+	v3 = result;
+	if ( result )
+	{
+		result = GetDlgItem(result, 1069);
+		v4 = result;
+		if ( result )
+		{
+			v5 = GetDlgItem(v3, 1074);
+			result = (HWND)GetWindowLongA(v5, -21);
+			if ( result )
+			{
+				v6 = (_DWORD *)*((_DWORD *)result + 3);
+				if ( v6 && *v6 )
+				{
+					v7 = SelConn_1000A9F3(v4) + 6;
+					if ( v7 > dword_1002A360 - 6 )
+						v7 = dword_1002A360 - 6;
+					result = (HWND)SelConn_1000AA28(v7);
+					v8 = (const char *)result;
+					if ( result )
+					{
+						TitleSnd_10010315();
+						SelConn_1000A670(v3, v8);
+						v9 = GetWindowLongA(v1, -12);
+						SelConn_1000A226(v3, v9);
+						result = SelConn_1000A3E2(v3);
+					}
+				}
+				else
+				{
+					result = SelConn_1000A8D7(v4);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000A9F3
+int UNKCALL SelConn_1000A9F3(HWND hWnd) { return 0; }
+/* {
+	LONG v1; // eax
+	_DWORD *v2; // ecx
+	_DWORD *v3; // eax
+	int v5; // edx
+
+	if ( !hWnd )
+		return 0;
+	v1 = GetWindowLongA(hWnd, -21);
+	if ( !v1 )
+		return 0;
+	v2 = (_DWORD *)dword_1002A35C;
+	if ( !dword_1002A35C )
+		return 0;
+	v3 = *(_DWORD **)(v1 + 12);
+	if ( !v3 )
+		return 0;
+	v5 = 0;
+	do
+	{
+		if ( v2 == v3 )
+			break;
+		v2 = (_DWORD *)*v2;
+		++v5;
+	}
+	while ( v2 );
+	return v5;
+} */
+// 1002A35C: using guessed type int dword_1002A35C;
+
+// ref: 0x1000AA28
+_DWORD *__fastcall SelConn_1000AA28(int a1) { return 0; }
+/* {
+	_DWORD *result; // eax
+
+	result = (_DWORD *)dword_1002A35C;
+	while ( result && a1 )
+	{
+		result = (_DWORD *)*result;
+		--a1;
+	}
+	return result;
+} */
+// 1002A35C: using guessed type int dword_1002A35C;
+
+// ref: 0x1000AA3B
+HWND UNKCALL SelConn_1000AA3B(HWND hWnd) { return 0; }
+/* {
+	HWND result; // eax
+	HWND v2; // esi
+	HWND v3; // edi
+	HWND v4; // eax
+	int v5; // eax
+	const char *v6; // edi
+	int v7; // eax
+	HWND hWnda; // [esp+10h] [ebp-4h]
+
+	hWnda = hWnd;
+	result = GetParent(hWnd);
+	v2 = result;
+	if ( result )
+	{
+		result = GetDlgItem(result, 1069);
+		v3 = result;
+		if ( result )
+		{
+			result = (HWND)GetWindowLongA(result, -21);
+			if ( result )
+			{
+				result = (HWND)*((_DWORD *)result + 3);
+				if ( result )
+				{
+					if ( result == (HWND)dword_1002A35C )
+					{
+						v4 = GetDlgItem(v2, 1074);
+						result = SelConn_1000A866(v4);
+					}
+					else
+					{
+						v5 = SelConn_1000A9F3(v3) - 6;
+						if ( v5 < 0 )
+							v5 = 0;
+						result = (HWND)SelConn_1000AA28(v5);
+						v6 = (const char *)result;
+						if ( result )
+						{
+							TitleSnd_10010315();
+							SelConn_1000A670(v2, v6);
+							v7 = GetWindowLongA(hWnda, -12);
+							SelConn_1000A226(v2, v7);
+							result = SelConn_1000A3E2(v2);
+						}
+					}
+				}
+			}
+		}
+	}
+	return result;
+} */
+// 1002A35C: using guessed type int dword_1002A35C;
+
+// ref: 0x1000AAEB
+HWND UNKCALL SelConn_1000AAEB(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND result; // eax
+	HWND v3; // eax
+	const char *v4; // ebp
+	HWND v5; // eax
+	int v6; // ebx
+	HWND v7; // eax
+	HWND v8; // eax
+
+	v1 = hWnd;
+	result = (HWND)GetWindowLongA(hWnd, -21);
+	if ( result )
+	{
+		result = (HWND)*((_DWORD *)result + 3);
+		if ( result )
+		{
+			if ( *(_DWORD *)result )
+			{
+				if ( GetWindowLongA(v1, -12) >= 1074 )
+				{
+					v3 = GetParent(v1);
+					result = GetDlgItem(v3, 1070);
+					if ( result )
+					{
+						result = (HWND)GetWindowLongA(result, -21);
+						if ( result )
+						{
+							v4 = (const char *)*((_DWORD *)result + 3);
+							if ( v4 )
+							{
+								TitleSnd_10010315();
+								v5 = GetParent(v1);
+								SelConn_1000A670(v5, v4);
+								v6 = GetWindowLongA(v1, -12);
+								v7 = GetParent(v1);
+								SelConn_1000A226(v7, v6);
+								v8 = GetParent(v1);
+								result = SelConn_1000A3E2(v8);
+							}
+						}
+					}
+				}
+				else
+				{
+					result = SelConn_1000A866(v1);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000AB83
+HWND UNKCALL SelConn_1000AB83(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND result; // eax
+	const char *v3; // ebx
+	HWND v4; // eax
+	int v5; // ebx
+	HWND v6; // eax
+	HWND v7; // eax
+
+	v1 = hWnd;
+	if ( GetWindowLongA(hWnd, -12) > 1069 )
+		return SelConn_1000A8D7(v1);
+	result = (HWND)GetWindowLongA(v1, -21);
+	if ( result )
+	{
+		result = (HWND)*((_DWORD *)result + 3);
+		if ( result )
+		{
+			v3 = (const char *)dword_1002A35C;
+			if ( result != (HWND)dword_1002A35C )
+			{
+				while ( v3 && *(HWND *)v3 != result )
+					v3 = *(const char **)v3;
+				TitleSnd_10010315();
+				v4 = GetParent(v1);
+				SelConn_1000A670(v4, v3);
+				v5 = GetWindowLongA(v1, -12);
+				v6 = GetParent(v1);
+				SelConn_1000A226(v6, v5);
+				v7 = GetParent(v1);
+				result = SelConn_1000A3E2(v7);
+			}
+		}
+	}
+	return result;
+} */
+// 1002A35C: using guessed type int dword_1002A35C;
+
+// ref: 0x1000AC07
+int __fastcall SelConn_1000AC07(int a1, int a2) { return 0; }
+/* {
+	int v2; // esi
+	int v3; // edi
+
+	v2 = a2;
+	v3 = a1;
+	if ( a2 == 2 )
+		TitleSnd_1001031F();
+	Fade_100073B4();
+	Fade_100072BE(10);
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+
+// ref: 0x1000AC30
+int UNKCALL SelConn_1000AC30(HWND arg) { return 0; }
+/* {
+	int v1; // esi
+	int v2; // edx
+	int result; // eax
+	int v4; // eax
+	int v5; // ecx
+	UINT v6; // [esp-4h] [ebp-8h]
+
+	v1 = (int)arg;
+	if ( SelConn_1000AC9E(arg) )
+	{
+		v2 = 1;
+		return SelConn_1000AC07(v1, v2);
+	}
+	if ( SErrGetLastError() == -2062548873 )
+	{
+		dword_1002A374 = 1;
+		v2 = 0;
+		return SelConn_1000AC07(v1, v2);
+	}
+	result = SelGame_1000B67E();
+	switch ( result )
+	{
+		case 1230002254:
+			goto LABEL_17;
+		case 1297040461:
+			v4 = SErrGetLastError();
+			v5 = v1;
+			if ( v4 == 1222 )
+				v6 = 46;
+			else
+				v6 = 53;
+			goto LABEL_14;
+		case 1396916812:
+LABEL_17:
+			v6 = 44;
+			v5 = v1;
+LABEL_14:
+			result = SelConn_1000AE19(v5, v6);
+			break;
+	}
+	return result;
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 1002A374: using guessed type int dword_1002A374;
+
+// ref: 0x1000AC9E
+int UNKCALL SelConn_1000AC9E(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // ebx
+	HWND v2; // eax
+	LONG v3; // eax
+	int v4; // esi
+	char *v6; // ST10_4
+	int v7; // ST08_4
+	int v8; // eax
+	int v9; // esi
+	char *v10; // ST14_4
+	int v11; // ST0C_4
+	void *v12; // eax
+	char v13; // [esp+8h] [ebp-8Ch]
+	HWND v14; // [esp+10h] [ebp-84h]
+	char v15; // [esp+58h] [ebp-3Ch]
+
+	v1 = hWnd;
+	TitleSnd_1001031F();
+	SelGame_1000B677(0);
+	SelGame_1000B66A(0);
+	v2 = GetFocus();
+	v3 = GetWindowLongA(v2, -21);
+	if ( !v3 )
+		return 0;
+	v4 = *(_DWORD *)(v3 + 12);
+	if ( !v4 )
+		return 0;
+	SelGame_1000B677(*(void **)(v4 + 8));
+	SelGame_1000B66A(*(void **)(v4 + 4));
+	if ( SelGame_1000B67E() == 1112425812 )
+	{
+		BNetGW_10002A07(&unk_10029480);
+		BNetGW_100028C2(&unk_10029480);
+	}
+	if ( dword_1002A364 )
+		qmemcpy(&v13, (const void *)dword_1002A364, 0x50u);
+	v14 = v1;
+	if ( dword_1002A370 )
+		qmemcpy(&v15, (const void *)dword_1002A370, 0x3Cu);
+	SelConn_1000ADA8(v1);
+	v6 = dword_1002A358;
+	v7 = dword_1002A34C;
+	v8 = SelGame_1000B67E();
+	v9 = SNetInitializeProvider(v8, &v15, v7, &v13, v6);
+	if ( v9 )
+	{
+		v10 = dword_1002A358;
+		v11 = dword_1002A34C;
+		v12 = (void *)SelGame_1000B67E();
+		v9 = SelModem_1000E435(v12, (int)&v15, v11, &v13, v10);
+	}
+	else
+	{
+		SNetDestroy();
+	}
+	if ( !v9 )
+		SelConn_1000ADD0(v1);
+	return v9;
+} */
+// 10010478: using guessed type _DWORD __stdcall SNetDestroy();
+// 1001047E: using guessed type int __stdcall SNetInitializeProvider(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A364: using guessed type int dword_1002A364;
+// 1002A370: using guessed type int dword_1002A370;
+
+// ref: 0x1000ADA8
+int UNKCALL SelConn_1000ADA8(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+
+	v1 = hWnd;
+	Fade_100072BE(10);
+	local_1000811B();
+	ShowWindow(v1, 0);
+	Title_100100E7(v1);
+	return Focus_10007818(v1);
+} */
+
+// ref: 0x1000ADD0
+BOOL UNKCALL SelConn_1000ADD0(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // ST10_4
+	HWND v4; // [esp+0h] [ebp-4h]
+
+	v1 = hWnd;
+	Focus_100077E9((int)hWnd, "ui_art\\focus16.pcx", v4);
+	Title_1001009E(v1, (int)"ui_art\\smlogo.pcx", v2);
+	local_100080F1();
+	Fade_100073C5(v1, 0);
+	PostMessageA(v1, 0x7E8u, 0, 0);
+	ShowWindow(v1, 5);
+	return UpdateWindow(v1);
+} */
+
+// ref: 0x1000AE19
+int __fastcall SelConn_1000AE19(int a1, UINT a2) { return 0; }
+/* {
+	UINT v2; // esi
+	int v3; // edi
+	int result; // eax
+	CHAR Buffer; // [esp+8h] [ebp-80h]
+
+	v2 = a2;
+	v3 = a1;
+	result = SErrGetLastError();
+	if ( result != 1223 )
+	{
+		LoadStringA(hInstance, v2, &Buffer, 127);
+		result = SelYesNo_1000FD39(v3, &Buffer, 0, 0);
+	}
+	return result;
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+
+// ref: 0x1000AE59
+HWND __fastcall SelConn_1000AE59(HWND hWnd, int a2, int a3) { return 0; }
+/* {
+	int v3; // ebp
+	int v4; // ebx
+	int v5; // ST0C_4
+	HWND v6; // esi
+	int v7; // ST08_4
+	HWND v8; // eax
+	HWND result; // eax
+	HWND v10; // eax
+	HWND v11; // eax
+	HWND v12; // eax
+	HWND v13; // eax
+	int v14; // eax
+	int v15; // eax
+	int v16; // eax
+	HWND v17; // eax
+	HWND v18; // eax
+	HWND v19; // eax
+	HWND v20; // eax
+
+	v3 = a3;
+	v4 = a2;
+	v5 = a3;
+	v6 = hWnd;
+	v7 = a2;
+	v8 = GetDlgItem(hWnd, 1056);
+	if ( local_10007C3B(v6, v8, v7, v5) )
+		return (HWND)SelConn_1000AC30(v6);
+	v10 = GetDlgItem(v6, 1054);
+	if ( local_10007C3B(v6, v10, v4, v3) )
+		return (HWND)SelConn_1000AC07((int)v6, 2);
+	if ( dword_1002A354 && (v11 = GetDlgItem(v6, 1145), local_10007C3B(v6, v11, v4, v3)) )
+	{
+		SelConn_1000ADA8(v6);
+		TitleSnd_1001031F();
+		UiSelectRegion(&a3);
+		result = (HWND)SelConn_1000ADD0(v6);
+	}
+	else
+	{
+		v12 = GetDlgItem(v6, 1105);
+		result = (HWND)local_10007C3B(v6, v12, v4, v3);
+		if ( result )
+		{
+			v13 = GetDlgItem(v6, 1105);
+			v14 = Sbar_100099DC(v13, v4, v3) - 1;
+			if ( v14 )
+			{
+				v15 = v14 - 1;
+				if ( v15 )
+				{
+					v16 = v15 - 1;
+					if ( v16 )
+					{
+						result = (HWND)(v16 - 1);
+						if ( !result )
+						{
+							v17 = GetFocus();
+							result = SelConn_1000A948(v17);
+						}
+					}
+					else
+					{
+						v18 = GetFocus();
+						result = SelConn_1000AA3B(v18);
+					}
+				}
+				else
+				{
+					v19 = GetFocus();
+					result = SelConn_1000AAEB(v19);
+				}
+			}
+			else
+			{
+				v20 = GetFocus();
+				result = SelConn_1000AB83(v20);
+			}
+		}
+	}
+	return result;
+} */
+// 1002A354: using guessed type int dword_1002A354;
+
+// ref: 0x1000AF69
+int __stdcall UiSelectProvider(int a1, _SNETPROGRAMDATA *client_info, _SNETPLAYERDATA *user_info, _SNETUIDATA *ui_info, _SNETVERSIONDATA *file_info, int *type) { return 0; }
+/* {
+	int v6; // eax
+	int v7; // ebx
+
+	dword_1002A374 = 0;
+	dword_1002A36C = a1;
+	dword_1002A370 = a2;
+	dword_1002A34C = a3;
+	dword_1002A364 = a4;
+	dword_1002A358 = a5;
+	artfont_10001159();
+	v6 = SDrawGetFrameWindow();
+	v7 = SDlgDialogBoxParam(hInstance, "SELCONNECT_DIALOG", v6, SelConn_1000A0A6, 0);
+	if ( a6 )
+		*a6 = SelGame_1000B67E();
+	if ( dword_1002A374 )
+	{
+		artfont_100010C8();
+		local_100078B6();
+		SErrSetLastError(-2062548873);
+	}
+	else
+	{
+		if ( v7 == 1 )
+		{
+			artfont_100010C8();
+			local_100078B6();
+			return 1;
+		}
+		SErrSetLastError(1223);
+	}
+	return 0;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 1002A364: using guessed type int dword_1002A364;
+// 1002A36C: using guessed type int dword_1002A36C;
+// 1002A370: using guessed type int dword_1002A370;
+// 1002A374: using guessed type int dword_1002A374;

--- a/DiabloUI/seldial.cpp
+++ b/DiabloUI/seldial.cpp
@@ -1,0 +1,426 @@
+// ref: 0x1000B011
+int UNKCALL SelDial_1000B011(char *arg) { return 0; }
+/* {
+	signed int v1; // edi
+	int i; // edi
+	char v4; // [esp+8h] [ebp-24h]
+	char v5; // [esp+27h] [ebp-5h]
+	char *v6; // [esp+28h] [ebp-4h]
+
+	v6 = arg;
+	v1 = 0;
+	do
+	{
+		if ( SRegLoadString("Diablo\\Phone Book", off_10022F8C[v1], 1u, &v4, 0x20u) )
+		{
+			v5 = 0;
+			if ( !strcmp(&v4, v6) )
+				break;
+		}
+		++v1;
+	}
+	while ( v1 < 4 );
+	if ( v1 == 4 )
+		v1 = 3;
+	for ( i = v1 - 1; i >= 0; --i )
+	{
+		v4 = 0;
+		if ( SRegLoadString("Diablo\\Phone Book", off_10022F8C[i], 1u, &v4, 0x20u) )
+		{
+			v5 = 0;
+			if ( strlen(&v4) )
+				SRegSaveString("Diablo\\Phone Book", off_10022F90[i], 1u, &v4);
+		}
+	}
+	return SRegSaveString("Diablo\\Phone Book", off_10022F8C[0], 1u, v6);
+} */
+// 10010484: using guessed type int __stdcall SRegSaveString(const char *, const char *, unsigned int, const char *);
+// 1001048A: using guessed type int __stdcall SRegLoadString(const char *, const char *, unsigned int, char *, unsigned int);
+// 10022F8C: using guessed type char *off_10022F8C[4];
+// 10022F90: using guessed type char *off_10022F90[3];
+
+// ref: 0x1000B0C4
+signed int SelDial_1000B0C4() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A37C = 2139095040;
+	return result;
+} */
+// 1002A37C: using guessed type int dword_1002A37C;
+
+// ref: 0x1000B0CF
+int __stdcall SelDial_1000B0CF(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	int v6; // edx
+	HWND v7; // eax
+	int savedregs; // [esp+Ch] [ebp+0h]
+
+	if ( Msg == 2 )
+	{
+		SelDial_1000B29A(hWnd);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg > 0x103 )
+	{
+		if ( Msg <= 0x105 )
+		{
+			v7 = (HWND)SDrawGetFrameWindow();
+			SendMessageA(v7, Msg, wParam, lParam);
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		if ( Msg == 272 )
+		{
+			dword_1002A378 = (char *)lParam;
+			SelDial_1000B483(hWnd, (int)&savedregs);
+			return 0;
+		}
+		if ( Msg != 273 )
+		{
+			if ( Msg != 275 )
+			{
+				if ( Msg == 513 )
+					SelDial_1000B614(hWnd, (unsigned short)lParam, (unsigned int)lParam >> 16);
+				return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+			}
+			if ( wParam == 1 )
+			{
+				v4 = GetFocus();
+				Focus_100075DC(hWnd, v4);
+			}
+			else if ( wParam == 2 )
+			{
+				SelDial_1000B354(hWnd);
+			}
+			return 0;
+		}
+		if ( HIWORD(wParam) == 7 )
+		{
+			Focus_100075B7(hWnd, (HWND)lParam);
+		}
+		else if ( HIWORD(wParam) == 6 )
+		{
+			Focus_10007458((void *)lParam);
+			Focus_100075DC(hWnd, (HWND)lParam);
+			SelDial_1000B1FB(hWnd, (unsigned short)wParam);
+		}
+		else
+		{
+			v6 = 1;
+			if ( wParam != 327681 )
+			{
+				if ( (_WORD)wParam != 2 )
+					return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+				v6 = 2;
+			}
+			SelDial_1000B2D8((int)hWnd, v6);
+		}
+	}
+	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x1000B1FB
+HWND __fastcall SelDial_1000B1FB(HWND hWnd, int a2) { return 0; }
+/* {
+	int v2; // edi
+	HWND v3; // ebx
+	HWND v4; // eax
+	CHAR v6; // [esp+Ch] [ebp-140h]
+	CHAR Buffer; // [esp+10Ch] [ebp-40h]
+
+	v2 = a2;
+	v3 = hWnd;
+	LoadStringA(hInstance, 0x39u, &Buffer, 63);
+	if ( v2 == 1117 )
+	{
+		if ( Modem_1000855D() )
+			LoadStringA(hInstance, 0x43u, &v6, 255);
+		else
+			LoadStringA(hInstance, 0x36u, &v6, 255);
+	}
+	else if ( v2 == 1118 )
+	{
+		if ( Modem_1000855D() )
+			LoadStringA(hInstance, 0x44u, &v6, 255);
+		else
+			LoadStringA(hInstance, 0x37u, &v6, 255);
+	}
+	else
+	{
+		LoadStringA(hInstance, 0x38u, &v6, 255);
+	}
+	v4 = GetParent(v3);
+	return Modem_10008563(v4, &Buffer, (int)&v6);
+} */
+
+// ref: 0x1000B29A
+HWND UNKCALL SelDial_1000B29A(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // eax
+
+	v1 = hDlg;
+	Doom_10006C53(hDlg, (int *)&unk_10022FB0);
+	Doom_10006C53(v1, (int *)&unk_10022FA4);
+	Doom_10006C53(v1, (int *)&unk_10022F9C);
+	Focus_100076C3();
+	v2 = GetParent(v1);
+	return Modem_10008563(v2, 0, 0);
+} */
+
+// ref: 0x1000B2D8
+int __fastcall SelDial_1000B2D8(int a1, int a2) { return 0; }
+/* {
+	int v2; // esi
+	int v3; // edi
+	HWND v4; // eax
+	LONG v5; // eax
+
+	v2 = a2;
+	v3 = a1;
+	if ( a2 == 1 || a2 == 2 )
+		TitleSnd_1001031F();
+	SDlgKillTimer(v3, 1);
+	SDlgKillTimer(v3, 2);
+	if ( v2 != 1 )
+		return SDlgEndDialog(v3, v2);
+	v4 = GetFocus();
+	v5 = GetWindowLongA(v4, -12);
+	if ( v5 == 1117 )
+		return SDlgEndDialog(v3, 3);
+	if ( v5 == 1118 )
+		return SDlgEndDialog(v3, 5);
+	if ( dword_1002A378 )
+		strcpy(dword_1002A378, &byte_1002A380[32 * (v5 - 1119)]);
+	return SDlgEndDialog(v3, 4);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x1000B354
+HWND UNKCALL SelDial_1000B354(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND result; // eax
+	HWND v3; // esi
+	HWND v4; // eax
+
+	v1 = hDlg;
+	result = GetDlgItem(hDlg, 1118);
+	v3 = result;
+	if ( result )
+	{
+		if ( Modem_10008606() )
+		{
+			SelDial_1000B3D8(v1);
+			EnableWindow(v3, 1);
+			result = (HWND)ShowWindow(v3, 1);
+		}
+		else if ( SErrGetLastError() == 1222 )
+		{
+			result = (HWND)SelDial_1000B2D8((int)v1, 1222);
+		}
+		else
+		{
+			if ( GetFocus() == v3 )
+			{
+				v4 = GetDlgItem(v1, 1117);
+				SetFocus(v4);
+			}
+			SelDial_1000B44C(v1);
+			EnableWindow(v3, 0);
+			result = (HWND)ShowWindow(v3, 0);
+		}
+	}
+	return result;
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+
+// ref: 0x1000B3D8
+HWND UNKCALL SelDial_1000B3D8(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND result; // eax
+	HWND v3; // edi
+	char *v4; // eax
+	int v5; // ebx
+	int v6; // eax
+	CHAR Buffer; // [esp+8h] [ebp-40h]
+
+	v1 = hDlg;
+	result = GetDlgItem(hDlg, 1118);
+	v3 = result;
+	if ( result )
+	{
+		v4 = Modem_1000863D();
+		v5 = Modem_1000865F(v4);
+		if ( v5 <= Modem_10008659() )
+			LoadStringA(hInstance, 0x4Au, &Buffer, 63);
+		else
+			LoadStringA(hInstance, 0x4Bu, &Buffer, 63);
+		v6 = GetWindowLongA(v3, -21);
+		local_10007FA4(v6, &Buffer);
+		result = (HWND)Doom_1000680A(v1, (int *)&unk_10022FB0, 0, 1);
+	}
+	return result;
+} */
+
+// ref: 0x1000B44C
+HWND UNKCALL SelDial_1000B44C(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND result; // eax
+	int v3; // eax
+
+	v1 = hDlg;
+	result = GetDlgItem(hDlg, 1118);
+	if ( result )
+	{
+		v3 = GetWindowLongA(result, -21);
+		local_10007FA4(v3, 0);
+		result = (HWND)Doom_1000680A(v1, (int *)&unk_10022FB0, 0, 1);
+	}
+	return result;
+} */
+
+// ref: 0x1000B483
+HWND USERCALL SelDial_1000B483(HWND hWnd, int a2) { return 0; }
+/* {
+	HWND v2; // esi
+	HWND v3; // eax
+	LONG v4; // eax
+	HWND result; // eax
+	char *v6; // eax
+	int v7; // ebx
+	HWND v8; // eax
+	HWND v9; // edi
+	int v10; // esi
+	const char *v11; // edx
+	int v12; // [esp-64h] [ebp-6Ch]
+	int v13; // [esp-24h] [ebp-2Ch]
+	HWND v14; // [esp-4h] [ebp-Ch]
+	const char *v15; // [esp+0h] [ebp-8h]
+	int v16; // [esp+4h] [ebp-4h]
+
+	v2 = hWnd;
+	v3 = GetParent(hWnd);
+	v4 = GetWindowLongA(v3, -21);
+	SetWindowLongA(v2, -21, v4);
+	Focus_10007719("ui_art\\focus16.pcx");
+	SDlgSetTimer(v2, 1, 55, 0);
+	local_10007CB5(v2, (int *)&unk_10022FB0);
+	Doom_100068AB(v2, (int *)&unk_10022F9C, 5);
+	Doom_1000658C(v2, (int *)&unk_10022FA4, 4, 0);
+	Doom_1000658C(v2, (int *)&unk_10022FB0, 0, 1);
+	if ( Modem_1000855D() )
+	{
+		SDlgSetTimer(v2, 2, 2000, 0);
+		result = SelDial_1000B354(v2);
+	}
+	else
+	{
+		v16 = a2;
+		v14 = v2;
+		v6 = byte_1002A380;
+		do
+		{
+			*v6 = 0;
+			v6 += 32;
+		}
+		while ( (signed int)v6 < (signed int)&dword_1002A400 );
+		SelDial_1000B5D9();
+		LoadStringA(hInstance, 0x34u, (LPSTR)&v13, 31);
+		v7 = 0;
+		v15 = byte_1002A380;
+		do
+		{
+			v8 = GetDlgItem(v14, v7 + 1119);
+			v9 = v8;
+			if ( v8 )
+			{
+				v10 = GetWindowLongA(v8, -21);
+				if ( v10 )
+				{
+					if ( strlen(v15) )
+					{
+						wsprintfA((LPSTR)&v12, (LPCSTR)&v13, v15);
+						v11 = (const char *)&v12;
+					}
+					else
+					{
+						EnableWindow(v9, 0);
+						v11 = 0;
+					}
+					local_10007FA4(v10, v11);
+				}
+			}
+			v15 += 32;
+			++v7;
+		}
+		while ( (signed int)v15 < (signed int)&dword_1002A400 );
+		result = (HWND)Doom_1000680A(v14, (int *)&unk_10022FB0, 0, 1);
+	}
+	return result;
+} */
+// 1000B483: could not find valid save-restore pair for ebp
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A400: using guessed type int dword_1002A400;
+
+// ref: 0x1000B5D9
+int SelDial_1000B5D9() { return 0; }
+/* {
+	char *v0; // esi
+	const char **v1; // edi
+	int result; // eax
+
+	v0 = byte_1002A380;
+	v1 = (const char **)off_10022F8C;
+	do
+	{
+		result = SRegLoadString("Diablo\\Phone Book", *v1, 1u, v0, 0x20u);
+		if ( result )
+			v0[31] = 0;
+		else
+			*v0 = 0;
+		++v1;
+		v0 += 32;
+	}
+	while ( (signed int)v1 < (signed int)&unk_10022F9C );
+	return result;
+} */
+// 1001048A: using guessed type int __stdcall SRegLoadString(const char *, const char *, unsigned int, char *, unsigned int);
+// 10022F8C: using guessed type char *off_10022F8C[4];
+
+// ref: 0x1000B614
+int __fastcall SelDial_1000B614(HWND hWnd, int a2, int a3) { return 0; }
+/* {
+	int v3; // ebx
+	HWND v4; // esi
+	int v5; // ST08_4
+	HWND v6; // eax
+	int v7; // edx
+	HWND v8; // eax
+	int result; // eax
+
+	v3 = a2;
+	v4 = hWnd;
+	v5 = a2;
+	v6 = GetDlgItem(hWnd, 1056);
+	if ( local_10007C3B(v4, v6, v5, a3) )
+	{
+		v7 = 1;
+	}
+	else
+	{
+		v8 = GetDlgItem(v4, 1054);
+		result = local_10007C3B(v4, v8, v3, a3);
+		if ( !result )
+			return result;
+		v7 = 2;
+	}
+	return SelDial_1000B2D8((int)v4, v7);
+} */

--- a/DiabloUI/selgame.cpp
+++ b/DiabloUI/selgame.cpp
@@ -1,0 +1,85 @@
+// ref: 0x1000B66A
+void UNKCALL SelGame_1000B66A(void *arg) { return; }
+/* {
+	dword_1002A408 = (int)arg;
+} */
+// 1002A408: using guessed type int dword_1002A408;
+
+// ref: 0x1000B671
+int SelGame_1000B671() { return 0; }
+/* {
+	return dword_1002A408;
+} */
+// 1002A408: using guessed type int dword_1002A408;
+
+// ref: 0x1000B677
+void UNKCALL SelGame_1000B677(void *arg) { return; }
+/* {
+	dword_1002A404 = (int)arg;
+} */
+// 1002A404: using guessed type int dword_1002A404;
+
+// ref: 0x1000B67E
+int SelGame_1000B67E() { return 0; }
+/* {
+	return dword_1002A404;
+} */
+// 1002A404: using guessed type int dword_1002A404;
+
+// ref: 0x1000B684
+int __stdcall UiSelectGame(int a1, _SNETPROGRAMDATA *client_info, _SNETPLAYERDATA *user_info, _SNETUIDATA *ui_info, _SNETVERSIONDATA *file_info, int *a6) { return 0; }
+/* {
+	int v6; // eax
+	CHAR v8; // [esp+4h] [ebp-110h]
+	char v9; // [esp+5h] [ebp-10Fh]
+	short v10; // [esp+81h] [ebp-93h]
+	char v11; // [esp+83h] [ebp-91h]
+	CHAR v12; // [esp+84h] [ebp-90h]
+	char v13; // [esp+85h] [ebp-8Fh]
+	short v14; // [esp+101h] [ebp-13h]
+	char v15; // [esp+103h] [ebp-11h]
+	int v16; // [esp+104h] [ebp-10h]
+	CHAR *v17; // [esp+108h] [ebp-Ch]
+	CHAR *v18; // [esp+10Ch] [ebp-8h]
+
+	v12 = byte_10029448;
+	memset(&v13, 0, 0x7Cu);
+	v14 = 0;
+	v15 = 0;
+	v8 = byte_10029448;
+	memset(&v9, 0, 0x7Cu);
+	v10 = 0;
+	v11 = 0;
+	Connect_10004028((int)&v12, 128, (int)&v8, 128);
+	memset(&v16, 0, 0x10u);
+	if ( a3 )
+		memcpy(&v16, a3, 0x10u);
+	v16 = 16;
+	v17 = &v12;
+	v18 = &v8;
+	if ( SelGame_1000B671() )
+		return SelIPX_1000C634(a1, a2, (int)&v16, (_DWORD *)a4, a5, a6);
+	v6 = SelGame_1000B67E();
+	switch ( v6 )
+	{
+		case 1230002254:
+			return SelIPX_1000C634(a1, a2, (int)&v16, (_DWORD *)a4, a5, a6);
+		case 1297040461:
+			return Modem_10008680(a1, a2, (int)&v16, (_DWORD *)a4, a5, a6);
+		case 1396916812:
+			return DirLink_10005D05(a1, a2, (int)&v16, (_DWORD *)a4, a5, a6);
+	}
+	return SNetSelectGame(a1, a2, &v16, a4, a5, a6);
+} */
+// 10010490: using guessed type int __stdcall SNetSelectGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000B795
+signed int SelGame_1000B795() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A400 = 2139095040;
+	return result;
+} */
+// 1002A400: using guessed type int dword_1002A400;

--- a/DiabloUI/selhero.cpp
+++ b/DiabloUI/selhero.cpp
@@ -1,0 +1,893 @@
+// ref: 0x1000B7A0
+int SelHero_1000B7A0() { return 0; }
+/* {
+	return dword_1002A458;
+} */
+// 1002A458: using guessed type int dword_1002A458;
+
+// ref: 0x1000B7A6
+int SelHero_1000B7A6() { return 0; }
+/* {
+	return dword_1002A428;
+} */
+// 1002A428: using guessed type int dword_1002A428;
+
+// ref: 0x1000B7AC
+void UNKCALL SelHero_1000B7AC(void *arg) { return; }
+/* {
+	dword_1002A420 = (int)arg;
+} */
+// 1002A420: using guessed type int dword_1002A420;
+
+// ref: 0x1000B7B3
+char *SelHero_1000B7B3() { return 0; }
+/* {
+	return &byte_1002A440;
+} */
+
+// ref: 0x1000B7B9
+int SelHero_1000B7B9() { return 0; }
+/* {
+	return SMemAlloc(44, "C:\\Src\\Diablo\\DiabloUI\\SelHero.cpp", 123, 0);
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000B7CA
+int SelHero_1000B7CA() { return 0; }
+/* {
+	return dword_1002A48C;
+} */
+// 1002A48C: using guessed type int dword_1002A48C;
+
+// ref: 0x1000B7D0
+int __fastcall SelHero_1000B7D0(int a1, int a2) { return 0; }
+/* {
+	return dword_1002A410(a1, a2);
+} */
+// 1002A410: using guessed type int (__stdcall *dword_1002A410)(_DWORD, _DWORD);
+
+// ref: 0x1000B7DE
+signed int SelHero_1000B7DE() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A414 = 2139095040;
+	return result;
+} */
+// 1002A414: using guessed type int dword_1002A414;
+
+// ref: 0x1000B899
+int __fastcall SelHero_1000B899(HWND hDlg, int a2) { return 0; }
+/* {
+	int v2; // ebx
+	HWND v3; // esi
+	struct tagRECT Rect; // [esp+8h] [ebp-10h]
+
+	v2 = a2;
+	v3 = GetDlgItem(hDlg, 1040);
+	InvalidateRect(v3, 0, 0);
+	GetClientRect(v3, &Rect);
+	local_10007A68(&Rect, 0, v2 * Rect.bottom);
+	return SDlgSetBitmapI(v3, 0, "Static", -1, 1, dword_1002A498, &Rect, dword_1002A418, dword_1002A41C, -1);
+} */
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A418: using guessed type int dword_1002A418;
+// 1002A41C: using guessed type int dword_1002A41C;
+// 1002A498: using guessed type int dword_1002A498;
+
+// ref: 0x1000B905
+int __fastcall SelHero_1000B905(HWND hDlg, int a2) { return 0; }
+/* {
+	HWND v2; // ebp
+	HWND v3; // eax
+	int v4; // eax
+	HWND v5; // eax
+	int v6; // eax
+	HWND v7; // eax
+	int v8; // eax
+	HWND v9; // eax
+	int v10; // eax
+	HWND v11; // eax
+	int v12; // eax
+	int result; // eax
+	int v14; // esi
+	HWND v15; // edi
+	HWND v16; // ebp
+	int v17; // eax
+	HWND hWnd; // ST1C_4
+	int v19; // eax
+	HWND v20; // ST1C_4
+	int v21; // eax
+	HWND v22; // ST1C_4
+	int v23; // eax
+	HWND v24; // ST1C_4
+	int v25; // eax
+	HWND hDlga; // [esp+Ch] [ebp-4h]
+
+	v14 = a2;
+	v15 = hDlg;
+	hDlga = hDlg;
+	if ( *(_WORD *)(a2 + 20) )
+	{
+		dword_1002A424 = *(_DWORD *)(a2 + 36);
+		strcpy(&byte_1002A440, (const char *)(a2 + 4));
+		v16 = GetDlgItem(v15, 1014);
+		wsprintfA(byte_1002A42C, "%d", *(unsigned short *)(v14 + 20));
+		v17 = GetWindowLongA(v16, -21);
+		local_10007FA4(v17, byte_1002A42C);
+		hWnd = GetDlgItem(hDlga, 1018);
+		wsprintfA(byte_1002A490, "%d", *(unsigned short *)(v14 + 24));
+		v19 = GetWindowLongA(hWnd, -21);
+		local_10007FA4(v19, byte_1002A490);
+		v20 = GetDlgItem(hDlga, 1017);
+		wsprintfA(byte_1002A43C, "%d", *(unsigned short *)(v14 + 26));
+		v21 = GetWindowLongA(v20, -21);
+		local_10007FA4(v21, byte_1002A43C);
+		v22 = GetDlgItem(hDlga, 1016);
+		wsprintfA(byte_1002A454, "%d", *(unsigned short *)(v14 + 28));
+		v23 = GetWindowLongA(v22, -21);
+		local_10007FA4(v23, byte_1002A454);
+		v24 = GetDlgItem(hDlga, 1015);
+		wsprintfA(byte_1002A494, "%d", *(unsigned short *)(v14 + 30));
+		v25 = GetWindowLongA(v24, -21);
+		local_10007FA4(v25, byte_1002A494);
+		SelHero_1000B899(hDlga, *(unsigned char *)(v14 + 22));
+		result = Doom_10006A13(hDlga, (int *)&unk_10023020, 1);
+	}
+	else
+	{
+		dword_1002A424 = 0;
+		byte_1002A440 = 0;
+		v2 = hDlg;
+		v3 = GetDlgItem(hDlg, 1014);
+		v4 = GetWindowLongA(v3, -21);
+		local_10007FA4(v4, "--");
+		v5 = GetDlgItem(v2, 1018);
+		v6 = GetWindowLongA(v5, -21);
+		local_10007FA4(v6, "--");
+		v7 = GetDlgItem(v2, 1017);
+		v8 = GetWindowLongA(v7, -21);
+		local_10007FA4(v8, "--");
+		v9 = GetDlgItem(v2, 1016);
+		v10 = GetWindowLongA(v9, -21);
+		local_10007FA4(v10, "--");
+		v11 = GetDlgItem(v2, 1015);
+		v12 = GetWindowLongA(v11, -21);
+		local_10007FA4(v12, "--");
+		SelHero_1000B899(v2, 3);
+		result = Doom_10006A13(v2, (int *)&unk_10023020, 1);
+	}
+	return result;
+} */
+// 1002A424: using guessed type int dword_1002A424;
+
+// ref: 0x1000BA7B
+HWND __fastcall SelHero_1000BA7B(HWND hDlg, const char *a2) { return 0; }
+/* {
+	HWND v2; // esi
+	const char *v3; // edi
+	HWND result; // eax
+	int v5; // eax
+
+	v2 = hDlg;
+	v3 = a2;
+	result = GetDlgItem(hDlg, 1038);
+	if ( result )
+	{
+		v5 = GetWindowLongA(result, -21);
+		local_10007FA4(v5, v3);
+		result = (HWND)Doom_10006A13(v2, (int *)&unk_10023000, 5);
+	}
+	return result;
+} */
+
+// ref: 0x1000BAB4
+char *UNKCALL SelHero_1000BAB4(char *arg) { return 0; }
+/* {
+	UINT v1; // esi
+	char *result; // eax
+	CHAR SrcStr; // [esp+4h] [ebp-90h]
+	CHAR Buffer; // [esp+84h] [ebp-10h]
+
+	strcpy(&SrcStr, arg);
+	_strlwr(&SrcStr);
+	v1 = 19;
+	while ( 1 )
+	{
+		LoadStringA(hInstance, v1, &Buffer, 15);
+		SelHero_1000BB26(&Buffer);
+		_strlwr(&Buffer);
+		result = strstr(&SrcStr, &Buffer);
+		if ( result )
+			break;
+		if ( (signed int)++v1 > 26 )
+			return result;
+	}
+	return (char *)1;
+} */
+
+// ref: 0x1000BB26
+char __fastcall SelHero_1000BB26(char *a1) { return 0; }
+/* {
+	char result; // al
+
+	while ( 1 )
+	{
+		result = *a1;
+		if ( !*a1 )
+			break;
+		*a1++ = result - 1;
+	}
+	return result;
+} */
+
+// ref: 0x1000BB34
+int __fastcall SelHero_1000BB34(char *a1, char *a2) { return 0; }
+/* {
+	char *v2; // esi
+	char *v3; // edi
+	char v5; // al
+
+	v2 = a1;
+	v3 = a2;
+	if ( strpbrk(a1, ",<>%&\\\"?*#/:") || strpbrk(v2, v3) )
+		return 1;
+	while ( 1 )
+	{
+		v5 = *v2;
+		if ( !*v2 )
+			break;
+		if ( (unsigned char)v5 < 0x20u || (unsigned char)v5 > 0x7Eu && (unsigned char)v5 < 0xC0u )
+			return 1;
+		++v2;
+	}
+	return 0;
+} */
+
+// ref: 0x1000BB75
+int __stdcall UiValidPlayerName(char *arg) { return 0; }
+/* {
+	char *v1; // esi
+	signed int v2; // edi
+
+	v1 = arg;
+	v2 = 1;
+	if ( !strlen(arg) )
+		v2 = 0;
+	if ( dword_1002A48C == 1 && (SelHero_1000BAB4(v1) || SelHero_1000BB34(v1, " ")) )
+		v2 = 0;
+	return v2;
+} */
+// 1002A48C: using guessed type int dword_1002A48C;
+
+// ref: 0x1000BBB4
+int __stdcall UiSelHeroMultDialog(void *fninfo, void *fncreate, void *fnremove, void *fnstats, int *a5, int *a6, char *name) { return 0; }
+/* {
+	int v7; // eax
+	int v8; // eax
+
+	artfont_10001159();
+	dword_1002A438 = (int (__stdcall *)(_DWORD))a1;
+	dword_1002A450 = (int (UNKCALL *)(_DWORD, _DWORD))a2;
+	dword_1002A434 = (int (__stdcall *)(_DWORD))a3;
+	dword_1002A410 = (int (__stdcall *)(_DWORD, _DWORD))a4;
+	dword_1002A458 = 0;
+	dword_1002A48C = 1;
+	dword_1002A45C = 0;
+	v7 = SDrawGetFrameWindow();
+	v8 = SDlgDialogBoxParam(hInstance, "SELHERO_DIALOG", v7, SelHero_1000BC46, 0);
+	if ( a5 )
+		*(_DWORD *)a5 = v8;
+	if ( a7 )
+		strcpy(a7, &byte_1002A440);
+	if ( a6 )
+		*(_DWORD *)a6 = dword_1002A45C;
+	return 1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1002A410: using guessed type int (__stdcall *dword_1002A410)(_DWORD, _DWORD);
+// 1002A434: using guessed type int (__stdcall *dword_1002A434)(_DWORD);
+// 1002A438: using guessed type int (__stdcall *dword_1002A438)(_DWORD);
+// 1002A450: using guessed type int (UNKCALL *dword_1002A450)(_DWORD, _DWORD);
+// 1002A458: using guessed type int dword_1002A458;
+// 1002A45C: using guessed type int dword_1002A45C;
+// 1002A48C: using guessed type int dword_1002A48C;
+
+// ref: 0x1000BC46
+int __stdcall SelHero_1000BC46(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	int v6; // edx
+	HWND v7; // ecx
+	signed int v8; // [esp-4h] [ebp-8h]
+	int v9; // [esp+0h] [ebp-4h]
+
+	if ( Msg > 0xBD2 )
+	{
+		switch ( Msg )
+		{
+			case 0xBD3u:
+				SelHero_1000C21A(hWnd);
+				return 0;
+			case 0xBD4u:
+				SelHero_1000C269(hWnd);
+				return 0;
+			case 0xBD5u:
+				v7 = hWnd;
+				if ( dword_1002A48C != 1 )
+				{
+					v8 = 2;
+					goto LABEL_30;
+				}
+				break;
+			case 0xBD6u:
+				strcpy(&byte_1002A440, byte_1002A464);
+				v6 = 1;
+				v7 = hWnd;
+				if ( dword_1002A48C != 1 )
+				{
+					dword_1002A420 = 0;
+LABEL_31:
+					SelHero_1000C3E2((int)v7, v6);
+					return 0;
+				}
+				break;
+			case 0xBD7u:
+				SelHero_1000BDAD(hWnd);
+				return 0;
+			default:
+				return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		v8 = 3;
+LABEL_30:
+		v6 = v8;
+		goto LABEL_31;
+	}
+	if ( Msg == 3026 )
+	{
+		SelHero_1000C09B(hWnd);
+		return 0;
+	}
+	if ( Msg == 2 )
+	{
+		SelHero_1000C364(hWnd);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v4 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v4, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	switch ( Msg )
+	{
+		case 0x110u:
+			SelHero_1000C3FF(hWnd);
+			PostMessageA(hWnd, 0x7E8u, 0, 0);
+			return 0;
+		case 0x7E8u:
+			if ( !Fade_1000739F() )
+				Fade_100073FD(hWnd, v9);
+			return 0;
+		case 0xBD0u:
+			SelHero_1000BF6D(hWnd);
+			return 0;
+	}
+	if ( Msg != 3025 )
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	SelHero_1000BFF9(hWnd);
+	return 0;
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1002A420: using guessed type int dword_1002A420;
+// 1002A48C: using guessed type int dword_1002A48C;
+
+// ref: 0x1000BDAD
+BOOL UNKCALL SelHero_1000BDAD(HWND arg) { return 0; }
+/* {
+	const char *v1; // eax
+	CHAR v3; // [esp+Ch] [ebp-B4h]
+	CHAR v4; // [esp+5Ch] [ebp-64h]
+	CHAR Buffer; // [esp+9Ch] [ebp-24h]
+	HWND hWnd; // [esp+BCh] [ebp-4h]
+
+	hWnd = arg;
+	if ( SelHero_1000B7CA() == 1 )
+		LoadStringA(hInstance, 0x23u, &Buffer, 31);
+	else
+		LoadStringA(hInstance, 0x22u, &Buffer, 31);
+	LoadStringA(hInstance, 7u, &v4, 63);
+	wsprintfA(&v3, &v4, &byte_1002A440);
+	if ( SelYesNo_1000FA49((int)hWnd, &v3, (int)&Buffer, 1) != 2 )
+	{
+		v1 = SelHero_1000BF4A((const char *)dword_1002A458, &byte_1002A440);
+		if ( v1 )
+		{
+			if ( dword_1002A434(v1) )
+			{
+				dword_1002A458 = (int)SelHero_1000BEDB((int *)dword_1002A458, &byte_1002A440);
+				--dword_1002A428;
+				LoadStringA(hInstance, 0x1Eu, &v4, 15);
+				if ( !strcmp(&v4, (const char *)(dword_1002A458 + 4)) )
+					return PostMessageA(hWnd, 0xBD1u, 0, 0);
+				SelHero_1000B905(hWnd, dword_1002A458);
+			}
+			else
+			{
+				LoadStringA(hInstance, 0x11u, &v4, 63);
+				SelYesNo_1000FD39((int)hWnd, &v4, (int)&Buffer, 1);
+			}
+		}
+	}
+	return PostMessageA(hWnd, 0xBD0u, 0, 0);
+} */
+// 1002A428: using guessed type int dword_1002A428;
+// 1002A434: using guessed type int (__stdcall *dword_1002A434)(_DWORD);
+// 1002A458: using guessed type int dword_1002A458;
+
+// ref: 0x1000BEDB
+int *__fastcall SelHero_1000BEDB(int *a1, char *a2) { return 0; }
+/* {
+	int *v2; // ebx
+	_DWORD *v3; // ebp
+	_DWORD *v4; // edi
+	int *v5; // esi
+	char *v7; // [esp+10h] [ebp-4h]
+
+	v2 = a1;
+	v3 = 0;
+	v4 = 0;
+	v7 = a2;
+	v5 = a1;
+	if ( a1 )
+	{
+		while ( !v4 )
+		{
+			if ( !strcmp((const char *)v5 + 4, v7) )
+			{
+				v4 = v5;
+			}
+			else
+			{
+				v3 = v5;
+				v5 = (int *)*v5;
+			}
+			if ( !v5 )
+			{
+				if ( !v4 )
+					return v2;
+				break;
+			}
+		}
+		if ( v3 )
+			*v3 = *v4;
+		else
+			v2 = (int *)*v4;
+		SelHero_1000BF33(v4);
+	}
+	return v2;
+} */
+
+// ref: 0x1000BF33
+int UNKCALL SelHero_1000BF33(void *arg) { return 0; }
+/* {
+	int result; // eax
+
+	if ( arg )
+		result = SMemFree(arg, "C:\\Src\\Diablo\\DiabloUI\\SelHero.cpp", 131, 0);
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000BF4A
+const char *__fastcall SelHero_1000BF4A(const char *a1, const char *a2) { return 0; }
+/* {
+	const char *v2; // edi
+	const char *i; // esi
+
+	v2 = a2;
+	for ( i = a1; i && _strcmpi(i + 4, v2); i = *(const char **)i )
+		;
+	return i;
+} */
+
+// ref: 0x1000BF6D
+int UNKCALL SelHero_1000BF6D(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	int v4; // edx
+
+	v1 = hWnd;
+	v2 = SDlgDialogBoxParam(hInstance, "SELLIST_DIALOG", hWnd, SelList_1000D774, 0);
+	if ( v2 == 1 )
+	{
+		if ( !strlen(&byte_1002A440) )
+			return PostMessageA(v1, 0xBD1u, 0, 0);
+		if ( dword_1002A48C == 1 )
+			return PostMessageA(v1, 0xBD5u, 0, 0);
+		if ( dword_1002A424 )
+			return PostMessageA(v1, 0xBD3u, 0, 0);
+		dword_1002A420 = 0;
+		v4 = 1;
+		return SelHero_1000C3E2((int)v1, v4);
+	}
+	if ( v2 != 1006 )
+	{
+		v4 = 4;
+		return SelHero_1000C3E2((int)v1, v4);
+	}
+	return PostMessageA(v1, 0xBD7u, 0, 0);
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A420: using guessed type int dword_1002A420;
+// 1002A424: using guessed type int dword_1002A424;
+// 1002A48C: using guessed type int dword_1002A48C;
+
+// ref: 0x1000BFF9
+int UNKCALL SelHero_1000BFF9(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	int v3; // eax
+	int result; // eax
+	CHAR Buffer; // [esp+8h] [ebp-20h]
+
+	v1 = hWnd;
+	v2 = SDlgDialogBoxParam(hInstance, "SELCLASS_DIALOG", hWnd, SelClass_10009D66, 0);
+	if ( v2 == -1 || v2 == 2 )
+	{
+		LoadStringA(hInstance, 0x1Eu, &Buffer, 31);
+		if ( !strcmp(&Buffer, (const char *)(dword_1002A458 + 4)) )
+			result = SelHero_1000C3E2((int)v1, 4);
+		else
+			result = PostMessageA(v1, 0xBD0u, 0, 0);
+	}
+	else
+	{
+		v3 = v2 - 1063;
+		if ( v3 )
+		{
+			if ( v3 == 1 )
+				byte_1002A476 = 2;
+			else
+				byte_1002A476 = 0;
+		}
+		else
+		{
+			byte_1002A476 = 1;
+		}
+		result = PostMessageA(v1, 0xBD2u, 0, 0);
+	}
+	return result;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A458: using guessed type int dword_1002A458;
+// 1002A476: using guessed type char byte_1002A476;
+
+// ref: 0x1000C09B
+int UNKCALL SelHero_1000C09B(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int result; // eax
+	char v3; // [esp+8h] [ebp-10h]
+	char v4; // [esp+17h] [ebp-1h]
+
+	v1 = hWnd;
+	if ( SDlgDialogBoxParam(hInstance, "ENTERNAME_DIALOG", hWnd, EntName_10006F7C, &v3) != 1 )
+		return PostMessageA(v1, 0xBD1u, 0, 0);
+	v4 = 0;
+	if ( SelHero_1000C0F9((int)v1, &v3) )
+		result = PostMessageA(v1, 0xBD6u, 0, 0);
+	else
+		result = PostMessageA(v1, 0xBD2u, 0, 0);
+	return result;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000C0F9
+signed int __fastcall SelHero_1000C0F9(int a1, char *a2) { return 0; }
+/* {
+	const char *v2; // edi
+	int v3; // ST0C_4
+	CHAR v5; // [esp+Ch] [ebp-138h]
+	CHAR v6; // [esp+9Ch] [ebp-A8h]
+	CHAR Buffer; // [esp+11Ch] [ebp-28h]
+	int v8; // [esp+13Ch] [ebp-8h]
+	char *v9; // [esp+140h] [ebp-4h]
+
+	v9 = a2;
+	v8 = a1;
+	if ( SelHero_1000B7CA() == 1 )
+		LoadStringA(hInstance, 0x20u, &Buffer, 31);
+	else
+		LoadStringA(hInstance, 0x1Fu, &Buffer, 31);
+	if ( !UiValidPlayerName(v9) )
+	{
+		LoadStringA(hInstance, 0xFu, &v6, 127);
+		SelYesNo_1000FD39(v8, &v6, (int)&Buffer, 1);
+		return 0;
+	}
+	v2 = SelHero_1000BF4A((const char *)dword_1002A458, v9);
+	if ( v2 )
+	{
+		LoadStringA(hInstance, 8u, &v6, 127);
+		wsprintfA(&v5, &v6, v2 + 4);
+		if ( SelYesNo_1000FA49(v8, &v5, (int)&Buffer, 1) == 2 )
+			return 0;
+	}
+	strcpy(byte_1002A464, v9);
+	dword_1002A484 = 0;
+	if ( !dword_1002A450(v3, &unk_1002A460) )
+	{
+		LoadStringA(hInstance, 0x10u, &v6, 127);
+		OkCancel_1000930A(v8, (int)&v6, 1);
+		return 0;
+	}
+	dword_1002A45C = 1;
+	return 1;
+} */
+// 1002A450: using guessed type int (UNKCALL *dword_1002A450)(_DWORD, _DWORD);
+// 1002A458: using guessed type int dword_1002A458;
+// 1002A45C: using guessed type int dword_1002A45C;
+// 1002A484: using guessed type int dword_1002A484;
+
+// ref: 0x1000C21A
+BOOL UNKCALL SelHero_1000C21A(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+
+	v1 = hWnd;
+	v2 = SDlgDialogBoxParam(hInstance, "SELLOAD_DIALOG", hWnd, SelLoad_1000E1C2, 0);
+	if ( v2 == -1 || v2 == 2 )
+		return PostMessageA(v1, 0xBD0u, 0, 0);
+	if ( v2 == 1106 )
+		return PostMessageA(v1, 0xBD5u, 0, 0);
+	return PostMessageA(v1, 0xBD4u, 0, 0);
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000C269
+int UNKCALL SelHero_1000C269(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // ebx
+	int v2; // ecx
+	const char *v4; // eax
+	int v5; // eax
+	CHAR Buffer; // [esp+4h] [ebp-208h]
+	char v7; // [esp+104h] [ebp-108h]
+	char v8; // [esp+184h] [ebp-88h]
+	char v9; // [esp+204h] [ebp-8h]
+	char v10; // [esp+208h] [ebp-4h]
+
+	v1 = hWnd;
+	if ( !SelHero_1000B7CA() )
+	{
+		SelHero_1000B7AC(0);
+		v2 = (int)v1;
+		return SelHero_1000C3E2(v2, 1);
+	}
+	CreaDung_10004C33((void *)1);
+	if ( SDlgDialogBoxParam(hInstance, "SELDIFF_DIALOG", v1, CreaDung_10004C4A, dword_1002A48C) != 1 )
+		return PostMessageA(v1, 0xBD3u, 0, 0);
+	v4 = SelHero_1000BF4A((const char *)dword_1002A458, &byte_1002A440);
+	UiCreatePlayerDescription((int)v4, 1145195599, (int)&v8);
+	v10 = dword_1002A420;
+	Connect_10003E0C((int)&v9, &byte_1002A440, &v8, &v7, 128);
+	v5 = UiAuthCallback(2, (int)&byte_1002A440, &v8, 0, &v7, &Buffer, 256);
+	v2 = (int)v1;
+	if ( v5 )
+		return SelHero_1000C3E2(v2, 1);
+	SelYesNo_1000FD39((int)v1, &Buffer, 0, 1);
+	return PostMessageA(v1, 0xBD4u, 0, 0);
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A420: using guessed type int dword_1002A420;
+// 1002A458: using guessed type int dword_1002A458;
+// 1002A48C: using guessed type int dword_1002A48C;
+
+// ref: 0x1000C364
+void UNKCALL SelHero_1000C364(HWND hDlg) { return; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	Doom_10006C53(hDlg, (int *)&unk_10023020);
+	Doom_10006C53(v1, (int *)&unk_10023008);
+	Doom_10006C53(v1, (int *)&unk_10023000);
+	Title_100100E7(v1);
+	SelHero_1000C3CE((_DWORD *)dword_1002A458);
+	if ( dword_1002A498 )
+	{
+		SMemFree(dword_1002A498, "C:\\Src\\Diablo\\DiabloUI\\SelHero.cpp", 744, 0);
+		dword_1002A498 = 0;
+	}
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A458: using guessed type int dword_1002A458;
+// 1002A498: using guessed type int dword_1002A498;
+
+// ref: 0x1000C3CE
+int __fastcall SelHero_1000C3CE(_DWORD *a1) { return 0; }
+/* {
+	_DWORD *v1; // esi
+	int result; // eax
+
+	if ( a1 )
+	{
+		do
+		{
+			v1 = (_DWORD *)*a1;
+			result = SelHero_1000BF33(a1);
+			a1 = v1;
+		}
+		while ( v1 );
+	}
+	return result;
+} */
+
+// ref: 0x1000C3E2
+int __fastcall SelHero_1000C3E2(int a1, int a2) { return 0; }
+/* {
+	int v2; // edi
+	int v3; // esi
+
+	v2 = a2;
+	v3 = a1;
+	Fade_100073B4();
+	Fade_100072BE(10);
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+
+// ref: 0x1000C3FF
+int UNKCALL SelHero_1000C3FF(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // eax
+	int v2; // eax
+	HWND v3; // eax
+	int v4; // eax
+	HWND v5; // eax
+	int v6; // eax
+	HWND v7; // eax
+	int v8; // eax
+	HWND v9; // eax
+	int v10; // eax
+	HWND v12; // esi
+	int v13; // eax
+	int *v14; // edi
+	void *v15; // [esp+0h] [ebp-8h]
+	HWND v16; // [esp+0h] [ebp-8h]
+
+	v12 = hWnd;
+	SelHero_1000C49F(hWnd, v15);
+	v13 = local_10007F46();
+	v14 = (int *)v13;
+	if ( v13 )
+	{
+		SetWindowLongA(v12, -21, v13);
+		local_10007944((int)v12, 0, &byte_10029448, -1, 1, (int)"ui_art\\selhero.pcx", v14, v14 + 1, 0);
+		Fade_100073C5(v12, 1);
+	}
+	local_100078BE((int)"ui_art\\heros.pcx", &dword_1002A498, &dword_1002A418);
+	SetActiveWindow(v12);
+	Title_1001009E(v12, (int)"ui_art\\smlogo.pcx", v16);
+	Doom_100068AB(v12, (int *)&unk_10023000, 5);
+	Doom_100068AB(v12, (int *)&unk_10023008, 1);
+	Doom_100068AB(v12, (int *)&unk_10023020, 1);
+	dword_1002A424 = 0;
+	byte_1002A440 = 0;
+	v1 = GetDlgItem(v12, 1014);
+	v2 = GetWindowLongA(v1, -21);
+	local_10007FA4(v2, "--");
+	v3 = GetDlgItem(v12, 1018);
+	v4 = GetWindowLongA(v3, -21);
+	local_10007FA4(v4, "--");
+	v5 = GetDlgItem(v12, 1017);
+	v6 = GetWindowLongA(v5, -21);
+	local_10007FA4(v6, "--");
+	v7 = GetDlgItem(v12, 1016);
+	v8 = GetWindowLongA(v7, -21);
+	local_10007FA4(v8, "--");
+	v9 = GetDlgItem(v12, 1015);
+	v10 = GetWindowLongA(v9, -21);
+	local_10007FA4(v10, "--");
+	SelHero_1000B899(v12, 3);
+	return Doom_10006A13(v12, (int *)&unk_10023020, 1);
+} */
+// 1002A418: using guessed type int dword_1002A418;
+// 1002A424: using guessed type int dword_1002A424;
+// 1002A498: using guessed type int dword_1002A498;
+
+// ref: 0x1000C49F
+BOOL UNKCALL SelHero_1000C49F(HWND hWnd, void *a2) { return 0; }
+/* {
+	HWND v2; // ebx
+	int v3; // esi
+	BOOL result; // eax
+	int v5; // [esp+10h] [ebp-44h]
+	CHAR Buffer; // [esp+14h] [ebp-40h]
+
+	v2 = hWnd;
+	v3 = SelHero_1000B7B9();
+	*(_DWORD *)v3 = 0;
+	LoadStringA(hInstance, 0x1Eu, (LPSTR)(v3 + 4), 15);
+	*(_WORD *)(v3 + 20) = 0;
+	dword_1002A458 = (int)SelRegn_1000EF56(dword_1002A458, (_DWORD *)v3);
+	v5 = dword_1002A458;
+	dword_1002A428 = 1;
+	if ( !dword_1002A438(SelHero_1000C541) )
+	{
+		LoadStringA(hInstance, 0x12u, &Buffer, 64);
+		OkCancel_1000930A((int)v2, (int)&Buffer, 1);
+	}
+	if ( v5 == dword_1002A458 )
+		result = PostMessageA(v2, 0xBD1u, 0, 0);
+	else
+		result = PostMessageA(v2, 0xBD0u, 0, 0);
+	return result;
+} */
+// 1002A428: using guessed type int dword_1002A428;
+// 1002A438: using guessed type int (__stdcall *dword_1002A438)(_DWORD);
+// 1002A458: using guessed type int dword_1002A458;
+
+// ref: 0x1000C541
+signed int __stdcall SelHero_1000C541(void *a1) { return 0; }
+/* {
+	_DWORD *v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = (_DWORD *)SelHero_1000B7B9();
+	memcpy(v1, a1, 0x2Cu);
+	*v1 = 0;
+	v2 = SelRegn_1000EF56(dword_1002A458, v1);
+	++dword_1002A428;
+	dword_1002A458 = (int)v2;
+	return 1;
+} */
+// 1002A428: using guessed type int dword_1002A428;
+// 1002A458: using guessed type int dword_1002A458;
+
+// ref: 0x1000C57A
+int __stdcall UiSelHeroSingDialog(void *fninfo, void *fncreate, void *fnremove, void *fnstats, int *a5, char *name, int *difficulty) { return 0; }
+/* {
+	int v7; // eax
+	int v8; // edi
+
+	artfont_10001159();
+	dword_1002A438 = (int (__stdcall *)(_DWORD))a1;
+	dword_1002A450 = (int (UNKCALL *)(_DWORD, _DWORD))a2;
+	dword_1002A434 = (int (__stdcall *)(_DWORD))a3;
+	dword_1002A410 = (int (__stdcall *)(_DWORD, _DWORD))a4;
+	dword_1002A458 = 0;
+	dword_1002A48C = 0;
+	v7 = SDrawGetFrameWindow();
+	v8 = SDlgDialogBoxParam(hInstance, "SELHERO_DIALOG", v7, SelHero_1000BC46, 0);
+	if ( a5 )
+		*(_DWORD *)a5 = v8;
+	if ( a6 )
+		strcpy(a6, &byte_1002A440);
+	if ( a7 )
+		*(_DWORD *)a7 = dword_1002A420;
+	if ( v8 != 4 )
+		artfont_100010C8();
+	return 1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1002A410: using guessed type int (__stdcall *dword_1002A410)(_DWORD, _DWORD);
+// 1002A420: using guessed type int dword_1002A420;
+// 1002A434: using guessed type int (__stdcall *dword_1002A434)(_DWORD);
+// 1002A438: using guessed type int (__stdcall *dword_1002A438)(_DWORD);
+// 1002A450: using guessed type int (UNKCALL *dword_1002A450)(_DWORD, _DWORD);
+// 1002A458: using guessed type int dword_1002A458;
+// 1002A48C: using guessed type int dword_1002A48C;

--- a/DiabloUI/selipx.cpp
+++ b/DiabloUI/selipx.cpp
@@ -1,0 +1,1258 @@
+// ref: 0x1000C610
+int SelIPX_1000C610() { return 0; }
+/* {
+	return SMemAlloc(268, "C:\\Src\\Diablo\\DiabloUI\\SelIPX.cpp", 105, 0);
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000C629
+signed int SelIPX_1000C629() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A4A4 = 2139095040;
+	return result;
+} */
+// 1002A4A4: using guessed type int dword_1002A4A4;
+
+// ref: 0x1000C634
+BOOL __fastcall SelIPX_1000C634(int a1, int a2, int a3, _DWORD *a4, int a5, int a6) { return 0; }
+/* {
+	int v6; // esi
+
+	dword_1002A49C = a3;
+	dword_1002A4AC = a2;
+	dword_1002A4BC = a5;
+	dword_1002A4A0 = a4;
+	dword_1002A4A8 = a6;
+	artfont_10001159();
+	v6 = SDlgDialogBoxParam(hInstance, "SELIPXGAME_DIALOG", a4[2], SelIPX_1000C692, 0);
+	artfont_100010C8();
+	return v6 == 1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A49C: using guessed type int dword_1002A49C;
+// 1002A4A8: using guessed type int dword_1002A4A8;
+// 1002A4AC: using guessed type int dword_1002A4AC;
+// 1002A4BC: using guessed type int dword_1002A4BC;
+
+// ref: 0x1000C692
+int __stdcall SelIPX_1000C692(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	HWND v6; // eax
+	int v7; // [esp+0h] [ebp-Ch]
+	int savedregs; // [esp+Ch] [ebp+0h]
+
+	if ( Msg > 0x113 )
+	{
+		switch ( Msg )
+		{
+			case 0x201u:
+				goto LABEL_35;
+			case 0x202u:
+				v6 = GetDlgItem(hWnd, 1105);
+				if ( !Sbar_100099C0(v6) )
+					return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+				goto LABEL_12;
+			case 0x203u:
+LABEL_35:
+				SelIPX_1000D696(hWnd, (unsigned short)lParam, (unsigned int)lParam >> 16);
+				return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		if ( Msg != 2024 )
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		if ( !Fade_1000739F() )
+			Fade_100073FD(hWnd, v7);
+		return 0;
+	}
+	if ( Msg == 275 )
+	{
+		if ( wParam == 3 )
+			SelIPX_1000C9DA(hWnd);
+		return 0;
+	}
+	if ( Msg == 2 )
+	{
+		SelIPX_1000CC41(hWnd);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v4 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v4, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg == 272 )
+	{
+		SelIPX_1000CD4A(hWnd);
+		PostMessageA(hWnd, 0x7E8u, 0, 0);
+		return 0;
+	}
+	if ( Msg == 273 )
+	{
+		if ( HIWORD(wParam) == 7 )
+		{
+			Focus_100075B7(hWnd, (HWND)lParam);
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		if ( HIWORD(wParam) != 6 )
+		{
+			if ( wParam == 327681 )
+			{
+				SelIPX_1000D3C5(hWnd, (int)&savedregs);
+			}
+			else if ( (_WORD)wParam == 2 )
+			{
+				SelIPX_1000D3A0((int)hWnd, 2);
+			}
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		Focus_10007458((void *)lParam);
+		Focus_100075DC(hWnd, (HWND)lParam);
+		SelIPX_1000C818(hWnd, (unsigned short)wParam);
+LABEL_12:
+		SelIPX_1000C982(hWnd);
+	}
+	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x1000C818
+LONG __fastcall SelIPX_1000C818(HWND hDlg, int nIDDlgItem) { return 0; }
+/* {
+	HWND v2; // ebx
+	HWND v3; // edi
+	LONG result; // eax
+	const char *v5; // edi
+	int v6; // eax
+	CHAR *v7; // edx
+	CHAR v8; // [esp+Ch] [ebp-280h]
+	CHAR v9; // [esp+10Ch] [ebp-180h]
+	char v10; // [esp+18Ch] [ebp-100h]
+	CHAR Buffer; // [esp+20Ch] [ebp-80h]
+	CHAR v12; // [esp+22Ch] [ebp-60h]
+	char v13; // [esp+24Ch] [ebp-40h]
+	unsigned short v14; // [esp+260h] [ebp-2Ch]
+	unsigned char v15; // [esp+262h] [ebp-2Ah]
+	char v16; // [esp+278h] [ebp-14h]
+	unsigned char v17; // [esp+27Ch] [ebp-10h]
+	int v18; // [esp+280h] [ebp-Ch]
+	int v19; // [esp+284h] [ebp-8h]
+	HWND hWnd; // [esp+288h] [ebp-4h]
+
+	v2 = hDlg;
+	v3 = GetDlgItem(hDlg, nIDDlgItem);
+	hWnd = GetDlgItem(v2, 1098);
+	result = GetWindowLongA(v3, -21);
+	if ( result )
+	{
+		result = *(_DWORD *)(result + 12);
+		if ( result )
+		{
+			v5 = (const char *)(result + 140);
+			if ( *(_DWORD *)(result + 4) )
+			{
+				if ( result == -140 || strlen((const char *)(result + 140)) < 0x10 )
+				{
+					v6 = GetWindowLongA(hWnd, -21);
+					v7 = (CHAR *)&byte_10029448;
+				}
+				else
+				{
+					v19 = (int)&byte_10029448;
+					v18 = (int)&byte_10029448;
+					strcpy(&v10, v5);
+					if ( Connect_10003DAF(&v10, (int)&v16, (int)&v19, (int)&v18)
+					  && Connect_10003E61((const char *)v18, &v13) )
+					{
+						LoadStringA(hInstance, v17 + 1003, &Buffer, 31);
+						LoadStringA(hInstance, v15 + 4, &v12, 31);
+						LoadStringA(hInstance, 0x31u, &v9, 127);
+						wsprintfA(&v8, &v9, &Buffer, v19, v14, &v12);
+						v6 = GetWindowLongA(hWnd, -21);
+						v7 = &v8;
+					}
+					else
+					{
+						v6 = GetWindowLongA(hWnd, -21);
+						v7 = 0;
+					}
+				}
+			}
+			else
+			{
+				v6 = GetWindowLongA(hWnd, -21);
+				v7 = (CHAR *)v5;
+			}
+			local_10007FA4(v6, v7);
+			result = Doom_10006A13(v2, (int *)&unk_10023104, 1);
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000C982
+HWND UNKCALL SelIPX_1000C982(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+
+	v1 = hDlg;
+	v2 = SelIPX_1000C99F();
+	return Sbar_10009A99(v1, 1105, dword_1002A4B8, v2);
+} */
+
+// ref: 0x1000C99F
+int SelIPX_1000C99F() { return 0; }
+/* {
+	HWND v0; // eax
+	LONG v1; // eax
+	_DWORD *v2; // ecx
+	_DWORD *v3; // eax
+	int v5; // edx
+
+	v0 = GetFocus();
+	if ( !v0 )
+		return 0;
+	v1 = GetWindowLongA(v0, -21);
+	if ( !v1 )
+		return 0;
+	v2 = (_DWORD *)dword_1002A4B4;
+	if ( !dword_1002A4B4 )
+		return 0;
+	v3 = *(_DWORD **)(v1 + 12);
+	if ( !v3 )
+		return 0;
+	v5 = 0;
+	do
+	{
+		if ( v2 == v3 )
+			break;
+		v2 = (_DWORD *)*v2;
+		++v5;
+	}
+	while ( v2 );
+	return v5;
+} */
+// 1002A4B4: using guessed type int dword_1002A4B4;
+
+// ref: 0x1000C9DA
+const char *UNKCALL SelIPX_1000C9DA(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	const char *result; // eax
+	int v3; // ST0C_4
+	HWND v4; // eax
+	HWND v5; // eax
+	int v6; // eax
+
+	v1 = hDlg;
+	dword_1002A4B0 = 0;
+	SelIPX_1000CA64((_DWORD *)dword_1002A4B4);
+	SNetEnumGames(0, 0, SelIPX_1000CAD5, 0);
+	result = (const char *)SelIPX_1000CA71((_DWORD *)dword_1002A4B4);
+	dword_1002A4B4 = (int)result;
+	if ( dword_1002A4B0 )
+	{
+		SelIPX_1000CB83(v1, result);
+		v3 = dword_1002A4B8 > 6;
+		v4 = GetDlgItem(v1, 1105);
+		ShowWindow(v4, v3);
+		v5 = GetFocus();
+		v6 = GetWindowLongA(v5, -12);
+		SelIPX_1000C818(v1, v6);
+		result = (const char *)SelIPX_1000C982(v1);
+	}
+	return result;
+} */
+// 10010436: using guessed type int __stdcall SNetEnumGames(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A4B0: using guessed type int dword_1002A4B0;
+// 1002A4B4: using guessed type int dword_1002A4B4;
+
+// ref: 0x1000CA64
+void __fastcall SelIPX_1000CA64(_DWORD *a1) { return; }
+/* {
+	while ( a1 )
+	{
+		a1[2] = 0;
+		a1 = (_DWORD *)*a1;
+	}
+} */
+
+// ref: 0x1000CA71
+_DWORD **__fastcall SelIPX_1000CA71(_DWORD *a1) { return 0; }
+/* {
+	_DWORD **v1; // edi
+	_DWORD *v2; // esi
+
+	v1 = (_DWORD **)a1;
+	v2 = 0;
+	while ( a1 )
+	{
+		if ( a1[2] || !a1[1] )
+		{
+			v2 = a1;
+			a1 = (_DWORD *)*a1;
+		}
+		else
+		{
+			if ( v2 )
+				*v2 = *a1;
+			else
+				v1 = (_DWORD **)*a1;
+			SelIPX_1000CAC1(a1);
+			--dword_1002A4B8;
+			dword_1002A4B0 = 1;
+			if ( v2 )
+				a1 = (_DWORD *)*v2;
+			else
+				a1 = *v1;
+		}
+	}
+	return v1;
+} */
+// 1002A4B0: using guessed type int dword_1002A4B0;
+
+// ref: 0x1000CAC1
+int UNKCALL SelIPX_1000CAC1(void *arg) { return 0; }
+/* {
+	int result; // eax
+
+	if ( arg )
+		result = SMemFree(arg, "C:\\Src\\Diablo\\DiabloUI\\SelIPX.cpp", 110, 0);
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000CAD5
+int __stdcall SelIPX_1000CAD5(int a1, char *a2, char *a3) { return 0; }
+/* {
+	_DWORD *v3; // eax
+	int result; // eax
+	int v5; // esi
+	_DWORD *v6; // eax
+
+	v3 = SelIPX_1000CB73((_DWORD *)dword_1002A4B4, a1);
+	if ( v3 )
+	{
+		v3[2] = 1;
+	}
+	else
+	{
+		result = SelIPX_1000C610();
+		v5 = result;
+		if ( !result )
+			return result;
+		*(_DWORD *)result = 0;
+		*(_DWORD *)(result + 4) = a1;
+		*(_DWORD *)(result + 8) = 1;
+		strcpy((char *)(result + 12), a2);
+		strcpy((char *)(v5 + 140), a3);
+		v6 = SelIPX_1000CB50((_DWORD *)dword_1002A4B4, (_DWORD *)v5);
+		++dword_1002A4B8;
+		dword_1002A4B4 = (int)v6;
+		dword_1002A4B0 = 1;
+	}
+	return 1;
+} */
+// 1002A4B0: using guessed type int dword_1002A4B0;
+// 1002A4B4: using guessed type int dword_1002A4B4;
+
+// ref: 0x1000CB50
+_DWORD *__fastcall SelIPX_1000CB50(_DWORD *a1, _DWORD *a2) { return 0; }
+/* {
+	_DWORD *result; // eax
+	_DWORD *v3; // edi
+	_DWORD *i; // esi
+
+	result = a1;
+	v3 = 0;
+	for ( i = a1; i; i = (_DWORD *)*i )
+		v3 = i;
+	*a2 = i;
+	if ( !v3 )
+		return a2;
+	*v3 = a2;
+	return result;
+} */
+
+// ref: 0x1000CB73
+_DWORD *__fastcall SelIPX_1000CB73(_DWORD *a1, int a2) { return 0; }
+/* {
+	_DWORD *result; // eax
+
+	for ( result = a1; result && result[1] != a2; result = (_DWORD *)*result )
+		;
+	return result;
+} */
+
+// ref: 0x1000CB83
+int __fastcall SelIPX_1000CB83(HWND a1, const char *a2) { return 0; }
+/* {
+	int *v2; // ebp
+	HWND v3; // eax
+	HWND v4; // esi
+	int v5; // eax
+	int v6; // eax
+	const char *v8; // [esp+4h] [ebp-8h]
+	HWND hDlg; // [esp+8h] [ebp-4h]
+
+	v8 = a2;
+	hDlg = a1;
+	v2 = &dword_10023118;
+	if ( dword_10023118 )
+	{
+		do
+		{
+			v3 = GetDlgItem(hDlg, *v2);
+			v4 = v3;
+			if ( v3 )
+			{
+				if ( v8 )
+				{
+					EnableWindow(v3, 1);
+					v6 = GetWindowLongA(v4, -21);
+					if ( v6 )
+					{
+						*(_DWORD *)(v6 + 12) = v8;
+						local_10007FA4(v6, v8 + 12);
+					}
+					v8 = *(const char **)v8;
+				}
+				else
+				{
+					if ( v3 == GetFocus() )
+						SelIPX_1000CCD9(v4);
+					EnableWindow(v4, 0);
+					v5 = GetWindowLongA(v4, -21);
+					if ( v5 )
+					{
+						*(_DWORD *)(v5 + 12) = 0;
+						local_10007FA4(v5, &byte_10029448);
+					}
+				}
+			}
+			++v2;
+		}
+		while ( *v2 );
+	}
+	return Doom_1000680A(hDlg, &dword_10023118, 2, 1);
+} */
+// 10023118: using guessed type int dword_10023118;
+
+// ref: 0x1000CC41
+int UNKCALL SelIPX_1000CC41(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	SelIPX_1000CCC5((_DWORD *)dword_1002A4B4);
+	dword_1002A4B4 = 0;
+	Sbar_10009CD2(v1, 1105);
+	Doom_10006C53(v1, &dword_10023118);
+	Doom_10006C53(v1, (int *)&unk_1002310C);
+	Doom_10006C53(v1, (int *)&unk_10023104);
+	Doom_10006C53(v1, (int *)&unk_100230FC);
+	Doom_10006C53(v1, (int *)&unk_100230F0);
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+	Title_100100E7(v1);
+	Focus_10007818(v1);
+	return SDrawClearSurface();
+} */
+// 1001043C: using guessed type _DWORD __stdcall SDrawClearSurface();
+// 10023118: using guessed type int dword_10023118;
+// 1002A4B4: using guessed type int dword_1002A4B4;
+
+// ref: 0x1000CCC5
+int __fastcall SelIPX_1000CCC5(_DWORD *a1) { return 0; }
+/* {
+	_DWORD *v1; // esi
+	int result; // eax
+
+	if ( a1 )
+	{
+		do
+		{
+			v1 = (_DWORD *)*a1;
+			result = SelIPX_1000CAC1(a1);
+			a1 = v1;
+		}
+		while ( v1 );
+	}
+	return result;
+} */
+
+// ref: 0x1000CCD9
+HWND UNKCALL SelIPX_1000CCD9(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // ebx
+	int nIDDlgItem[1085]; // [esp+0h] [ebp-1118h]
+	int v5; // [esp+10F4h] [ebp-24h]
+	int v6; // [esp+1100h] [ebp-18h]
+	int v7; // [esp+1104h] [ebp-14h]
+	int v8; // [esp+1108h] [ebp-10h]
+	int v9; // [esp+110Ch] [ebp-Ch]
+	int v10; // [esp+1110h] [ebp-8h]
+	int v11; // [esp+1114h] [ebp-4h]
+
+	v1 = hWnd;
+	v6 = 1093;
+	v7 = 1088;
+	v8 = 1089;
+	v9 = 1090;
+	v10 = 1091;
+	v11 = 1092;
+	v2 = GetParent(hWnd);
+	do
+	{
+		v5 = nIDDlgItem[GetWindowLongA(v1, -12)];
+		v1 = GetDlgItem(v2, v5);
+	}
+	while ( !IsWindowEnabled(v1) );
+	return SetFocus(v1);
+} */
+// 1000CCD9: using guessed type int nIDDlgItem[1085];
+
+// ref: 0x1000CD4A
+HWND UNKCALL SelIPX_1000CD4A(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // ST1C_4
+	int v3; // eax
+	int *v4; // edi
+	HWND v5; // ebp
+	int v6; // eax
+	HWND result; // eax
+	HWND v8; // eax
+	HWND v9; // [esp+0h] [ebp-4Ch]
+	CHAR Buffer; // [esp+Ch] [ebp-40h]
+
+	v1 = hWnd;
+	SelIPX_1000CEE6(hWnd);
+	Focus_100077E9((int)v1, "ui_art\\focus16.pcx", v9);
+	Title_1001009E(v1, (int)"ui_art\\smlogo.pcx", v2);
+	v3 = local_10007F46();
+	v4 = (int *)v3;
+	if ( v3 )
+	{
+		SetWindowLongA(v1, -21, v3);
+		local_10007944((int)v1, 0, &byte_10029448, -1, 1, (int)"ui_art\\selgame.pcx", v4, v4 + 1, 0);
+		Fade_100073C5(v1, 1);
+	}
+	if ( SelGame_1000B67E() != 1230002254 )
+	{
+		v5 = GetDlgItem(v1, 1038);
+		LoadStringA(hInstance, 0x4Du, &Buffer, 63);
+		SetWindowTextA(v5, &Buffer);
+	}
+	Doom_100068AB(v1, (int *)&unk_100230F0, 5);
+	Doom_100068AB(v1, (int *)&unk_100230FC, 3);
+	Doom_100068AB(v1, (int *)&unk_10023104, 1);
+	Doom_1000658C(v1, (int *)&unk_1002310C, 4, 0);
+	Doom_1000658C(v1, &dword_10023118, 2, 1);
+	dword_1002A4B8 = 0;
+	v6 = SelIPX_1000C610();
+	dword_1002A4B4 = v6;
+	if ( v6 )
+	{
+		++dword_1002A4B8;
+		*(_DWORD *)(v6 + 4) = 0;
+		*(_BYTE *)(dword_1002A4B4 + 140) = 0;
+		*(_DWORD *)dword_1002A4B4 = 0;
+		LoadStringA(hInstance, 0x24u, (LPSTR)(dword_1002A4B4 + 12), 127);
+		LoadStringA(hInstance, 0x2Au, (LPSTR)(dword_1002A4B4 + 140), 127);
+	}
+	SNetEnumGames(0, 0, SelIPX_1000CAD5, 0);
+	SelIPX_1000CB83(v1, (const char *)dword_1002A4B4);
+	SDlgSetTimer(v1, 3, 1000, 0);
+	result = Sbar_10009BF1(v1, 1105);
+	if ( dword_1002A4B8 <= 6 )
+	{
+		v8 = GetDlgItem(v1, 1105);
+		result = (HWND)ShowWindow(v8, 0);
+	}
+	return result;
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010436: using guessed type int __stdcall SNetEnumGames(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10023118: using guessed type int dword_10023118;
+// 1002A4B4: using guessed type int dword_1002A4B4;
+
+// ref: 0x1000CEE6
+void UNKCALL SelIPX_1000CEE6(HWND hDlg) { return; }
+/* {
+	HWND v1; // ebx
+	int *v2; // edi
+	HWND v3; // eax
+	HWND v4; // esi
+	void *v5; // eax
+
+	v1 = hDlg;
+	v2 = &dword_10023118;
+	if ( dword_10023118 )
+	{
+		do
+		{
+			v3 = GetDlgItem(v1, *v2);
+			v4 = v3;
+			if ( v3 )
+			{
+				v5 = (void *)GetWindowLongA(v3, -4);
+				SetPropA(v4, "UIOLDPROC", v5);
+				SetWindowLongA(v4, -4, (LONG)SelIPX_1000CF38);
+			}
+			++v2;
+		}
+		while ( *v2 );
+	}
+} */
+// 10023118: using guessed type int dword_10023118;
+
+// ref: 0x1000CF38
+LRESULT __stdcall SelIPX_1000CF38(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	LRESULT (__stdcall *v4)(HWND, UINT, WPARAM, LPARAM); // edi
+	HWND v5; // eax
+	UINT v7; // [esp-Ch] [ebp-18h]
+	WPARAM v8; // [esp-8h] [ebp-14h]
+	LPARAM v9; // [esp-4h] [ebp-10h]
+
+	v4 = (LRESULT (__stdcall *)(HWND, UINT, WPARAM, LPARAM))GetPropA(hWnd, "UIOLDPROC");
+	switch ( Msg )
+	{
+		case 2u:
+			RemovePropA(hWnd, "UIOLDPROC");
+			if ( !v4 )
+				return DefWindowProcA(hWnd, Msg, wParam, lParam);
+			SetWindowLongA(hWnd, -4, (LONG)v4);
+			break;
+		case 0xFu:
+			local_10007C95(hWnd);
+			return 0;
+		case 0x87u:
+			return 4;
+		case 0x100u:
+			if ( wParam > 0x21 )
+			{
+				if ( wParam == 34 )
+				{
+					SelIPX_1000D0E1(hWnd);
+					return 0;
+				}
+				if ( wParam > 0x24 )
+				{
+					if ( wParam <= 0x26 )
+					{
+						SelIPX_1000D31C(hWnd);
+						return 0;
+					}
+					if ( wParam <= 0x28 )
+					{
+						SelIPX_1000D284(hWnd);
+						return 0;
+					}
+					if ( wParam == 46 )
+					{
+						v9 = lParam;
+						v8 = 46;
+						v7 = 256;
+						goto LABEL_24;
+					}
+				}
+			}
+			else
+			{
+				switch ( wParam )
+				{
+					case 0x21u:
+						SelIPX_1000D1D4(hWnd);
+						break;
+					case 9u:
+						if ( GetKeyState(16) >= 0 )
+							SelIPX_1000D070(hWnd);
+						else
+							SelIPX_1000CCD9(hWnd);
+						return 0;
+					case 0xDu:
+						goto LABEL_38;
+					case 0x1Bu:
+						v9 = 0;
+						v8 = 2;
+						goto LABEL_12;
+					case 0x20u:
+LABEL_38:
+						v9 = 0;
+						v8 = 1;
+LABEL_12:
+						v7 = 273;
+LABEL_24:
+						v5 = GetParent(hWnd);
+						SendMessageA(v5, v7, v8, v9);
+						return 0;
+				}
+			}
+			return 0;
+	}
+	if ( v4 )
+		return CallWindowProcA(v4, hWnd, Msg, wParam, lParam);
+	return DefWindowProcA(hWnd, Msg, wParam, lParam);
+} */
+
+// ref: 0x1000D070
+HWND UNKCALL SelIPX_1000D070(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // ebx
+	int nIDDlgItem[1085]; // [esp+0h] [ebp-1118h]
+	int v5; // [esp+10F4h] [ebp-24h]
+	int v6; // [esp+1100h] [ebp-18h]
+	int v7; // [esp+1104h] [ebp-14h]
+	int v8; // [esp+1108h] [ebp-10h]
+	int v9; // [esp+110Ch] [ebp-Ch]
+	int v10; // [esp+1110h] [ebp-8h]
+	int v11; // [esp+1114h] [ebp-4h]
+
+	v1 = hWnd;
+	v6 = 1089;
+	v7 = 1090;
+	v8 = 1091;
+	v9 = 1092;
+	v10 = 1093;
+	v11 = 1088;
+	v2 = GetParent(hWnd);
+	do
+	{
+		v5 = nIDDlgItem[GetWindowLongA(v1, -12)];
+		v1 = GetDlgItem(v2, v5);
+	}
+	while ( !IsWindowEnabled(v1) );
+	return SetFocus(v1);
+} */
+// 1000D070: using guessed type int nIDDlgItem[1085];
+
+// ref: 0x1000D0E1
+HWND UNKCALL SelIPX_1000D0E1(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // ebp
+	HWND result; // eax
+	HWND v3; // esi
+	HWND v4; // ebx
+	HWND v5; // eax
+	_DWORD *v6; // eax
+	int v7; // eax
+	const char *v8; // ebx
+	int v9; // eax
+
+	v1 = hWnd;
+	result = GetParent(hWnd);
+	v3 = result;
+	if ( result )
+	{
+		result = GetDlgItem(result, 1088);
+		v4 = result;
+		if ( result )
+		{
+			v5 = GetDlgItem(v3, 1093);
+			result = (HWND)GetWindowLongA(v5, -21);
+			if ( result )
+			{
+				v6 = (_DWORD *)*((_DWORD *)result + 3);
+				if ( v6 && *v6 )
+				{
+					v7 = SelIPX_1000D18C(v4) + 6;
+					if ( v7 > dword_1002A4B8 - 6 )
+						v7 = dword_1002A4B8 - 6;
+					result = (HWND)SelIPX_1000D1C1(v7);
+					v8 = (const char *)result;
+					if ( result )
+					{
+						TitleSnd_10010315();
+						SelIPX_1000CB83(v3, v8);
+						v9 = GetWindowLongA(v1, -12);
+						SelIPX_1000C818(v3, v9);
+						result = SelIPX_1000C982(v3);
+					}
+				}
+				else
+				{
+					result = SelIPX_1000CCD9(v4);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000D18C
+int UNKCALL SelIPX_1000D18C(HWND hWnd) { return 0; }
+/* {
+	LONG v1; // eax
+	_DWORD *v2; // ecx
+	_DWORD *v3; // eax
+	int v5; // edx
+
+	if ( !hWnd )
+		return 0;
+	v1 = GetWindowLongA(hWnd, -21);
+	if ( !v1 )
+		return 0;
+	v2 = (_DWORD *)dword_1002A4B4;
+	if ( !dword_1002A4B4 )
+		return 0;
+	v3 = *(_DWORD **)(v1 + 12);
+	if ( !v3 )
+		return 0;
+	v5 = 0;
+	do
+	{
+		if ( v2 == v3 )
+			break;
+		v2 = (_DWORD *)*v2;
+		++v5;
+	}
+	while ( v2 );
+	return v5;
+} */
+// 1002A4B4: using guessed type int dword_1002A4B4;
+
+// ref: 0x1000D1C1
+_DWORD *__fastcall SelIPX_1000D1C1(int a1) { return 0; }
+/* {
+	_DWORD *result; // eax
+
+	result = (_DWORD *)dword_1002A4B4;
+	while ( result && a1 )
+	{
+		result = (_DWORD *)*result;
+		--a1;
+	}
+	return result;
+} */
+// 1002A4B4: using guessed type int dword_1002A4B4;
+
+// ref: 0x1000D1D4
+HWND UNKCALL SelIPX_1000D1D4(HWND hWnd) { return 0; }
+/* {
+	HWND result; // eax
+	HWND v2; // esi
+	HWND v3; // edi
+	HWND v4; // eax
+	int v5; // eax
+	const char *v6; // edi
+	int v7; // eax
+	HWND hWnda; // [esp+10h] [ebp-4h]
+
+	hWnda = hWnd;
+	result = GetParent(hWnd);
+	v2 = result;
+	if ( result )
+	{
+		result = GetDlgItem(result, 1088);
+		v3 = result;
+		if ( result )
+		{
+			result = (HWND)GetWindowLongA(result, -21);
+			if ( result )
+			{
+				result = (HWND)*((_DWORD *)result + 3);
+				if ( result )
+				{
+					if ( result == (HWND)dword_1002A4B4 )
+					{
+						v4 = GetDlgItem(v2, 1093);
+						result = SelIPX_1000D070(v4);
+					}
+					else
+					{
+						v5 = SelIPX_1000D18C(v3) - 6;
+						if ( v5 < 0 )
+							v5 = 0;
+						result = (HWND)SelIPX_1000D1C1(v5);
+						v6 = (const char *)result;
+						if ( result )
+						{
+							TitleSnd_10010315();
+							SelIPX_1000CB83(v2, v6);
+							v7 = GetWindowLongA(hWnda, -12);
+							SelIPX_1000C818(v2, v7);
+							result = SelIPX_1000C982(v2);
+						}
+					}
+				}
+			}
+		}
+	}
+	return result;
+} */
+// 1002A4B4: using guessed type int dword_1002A4B4;
+
+// ref: 0x1000D284
+HWND UNKCALL SelIPX_1000D284(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND result; // eax
+	HWND v3; // eax
+	const char *v4; // ebp
+	HWND v5; // eax
+	int v6; // ebx
+	HWND v7; // eax
+	HWND v8; // eax
+
+	v1 = hWnd;
+	result = (HWND)GetWindowLongA(hWnd, -21);
+	if ( result )
+	{
+		result = (HWND)*((_DWORD *)result + 3);
+		if ( result )
+		{
+			if ( *(_DWORD *)result )
+			{
+				if ( GetWindowLongA(v1, -12) >= 1093 )
+				{
+					v3 = GetParent(v1);
+					result = GetDlgItem(v3, 1089);
+					if ( result )
+					{
+						result = (HWND)GetWindowLongA(result, -21);
+						if ( result )
+						{
+							v4 = (const char *)*((_DWORD *)result + 3);
+							if ( v4 )
+							{
+								TitleSnd_10010315();
+								v5 = GetParent(v1);
+								SelIPX_1000CB83(v5, v4);
+								v6 = GetWindowLongA(v1, -12);
+								v7 = GetParent(v1);
+								SelIPX_1000C818(v7, v6);
+								v8 = GetParent(v1);
+								result = SelIPX_1000C982(v8);
+							}
+						}
+					}
+				}
+				else
+				{
+					result = SelIPX_1000D070(v1);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000D31C
+HWND UNKCALL SelIPX_1000D31C(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND result; // eax
+	const char *v3; // ebx
+	HWND v4; // eax
+	int v5; // ebx
+	HWND v6; // eax
+	HWND v7; // eax
+
+	v1 = hWnd;
+	if ( GetWindowLongA(hWnd, -12) > 1088 )
+		return SelIPX_1000CCD9(v1);
+	result = (HWND)GetWindowLongA(v1, -21);
+	if ( result )
+	{
+		result = (HWND)*((_DWORD *)result + 3);
+		if ( result )
+		{
+			v3 = (const char *)dword_1002A4B4;
+			if ( result != (HWND)dword_1002A4B4 )
+			{
+				while ( v3 && *(HWND *)v3 != result )
+					v3 = *(const char **)v3;
+				TitleSnd_10010315();
+				v4 = GetParent(v1);
+				SelIPX_1000CB83(v4, v3);
+				v5 = GetWindowLongA(v1, -12);
+				v6 = GetParent(v1);
+				SelIPX_1000C818(v6, v5);
+				v7 = GetParent(v1);
+				result = SelIPX_1000C982(v7);
+			}
+		}
+	}
+	return result;
+} */
+// 1002A4B4: using guessed type int dword_1002A4B4;
+
+// ref: 0x1000D3A0
+int __fastcall SelIPX_1000D3A0(int a1, int a2) { return 0; }
+/* {
+	int v2; // edi
+	int v3; // esi
+
+	v2 = a2;
+	v3 = a1;
+	Fade_100073B4();
+	SDlgKillTimer(v3, 3);
+	Fade_100072BE(10);
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x1000D3C5
+HWND USERCALL SelIPX_1000D3C5(HWND hDlg, int a2) { return 0; }
+/* {
+	HWND v2; // edi
+	HWND v3; // eax
+	HWND v4; // esi
+	HWND result; // eax
+	int v6; // esi
+	HWND v7; // esi
+	int v8; // eax
+	HWND v9; // edi
+	int v10; // [esp-DCh] [ebp-E4h]
+	signed int v11; // [esp-5Ch] [ebp-64h]
+	HWND v12; // [esp-54h] [ebp-5Ch]
+	signed int v13; // [esp-Ch] [ebp-14h]
+	signed int v14; // [esp-8h] [ebp-10h]
+	int v15; // [esp-4h] [ebp-Ch]
+	int v16; // [esp+0h] [ebp-8h]
+	int v17; // [esp+4h] [ebp-4h]
+
+	v2 = hDlg;
+	v3 = GetFocus();
+	v4 = v3;
+	result = GetParent(v3);
+	if ( v2 == result )
+	{
+		result = (HWND)GetWindowLongA(v4, -21);
+		if ( result )
+		{
+			v6 = *((_DWORD *)result + 3);
+			TitleSnd_1001031F();
+			if ( *(_DWORD *)(v6 + 4) )
+			{
+				result = (HWND)SelIPX_1000D5B0((int)v2, v6);
+			}
+			else
+			{
+				v17 = a2;
+				v7 = v2;
+				SelIPX_1000C9DA(v2);
+				memcpy(&v11, dword_1002A4A0, 0x50u);
+				v11 = 80;
+				v12 = v2;
+				memset(&v13, 0, 0x10u);
+				v13 = 16;
+				v14 = 1230002254;
+				v8 = *(_DWORD *)(dword_1002A4AC + 24);
+				v16 = 0;
+				v15 = v8;
+				v9 = GetFocus();
+				SelIPX_1000D4CA(v7, 0);
+				SelIPX_1000D520((char *)&v10);
+				if ( CreaDung_100051D8(
+						 (int)&v13,
+						 dword_1002A4AC,
+						 dword_1002A49C,
+						 (int)&v11,
+						 dword_1002A4BC,
+						 dword_1002A4A8,
+						 0,
+						 (int)&v10) )
+				{
+					result = (HWND)SelIPX_1000D3A0((int)v7, 1);
+				}
+				else
+				{
+					SelIPX_1000D4CA(v7, 1);
+					result = SetFocus(v9);
+				}
+			}
+		}
+	}
+	return result;
+} */
+// 1000D3C5: could not find valid save-restore pair for ebp
+// 1002A49C: using guessed type int dword_1002A49C;
+// 1002A4A8: using guessed type int dword_1002A4A8;
+// 1002A4AC: using guessed type int dword_1002A4AC;
+// 1002A4BC: using guessed type int dword_1002A4BC;
+
+// ref: 0x1000D4CA
+BOOL __fastcall SelIPX_1000D4CA(HWND hDlg, int a2) { return 0; }
+/* {
+	HWND v2; // ebx
+	int v3; // ebp
+	HWND v4; // eax
+	HWND v5; // eax
+	BOOL result; // eax
+	int nCmdShow; // [esp+10h] [ebp-4h]
+
+	nCmdShow = a2;
+	v2 = hDlg;
+	v3 = 1088;
+	do
+	{
+		v4 = GetDlgItem(v2, v3);
+		if ( v4 )
+			ShowWindow(v4, nCmdShow);
+		++v3;
+	}
+	while ( v3 <= 1093 );
+	v5 = GetDlgItem(v2, 1105);
+	if ( dword_1002A4B8 > 6 )
+		result = ShowWindow(v5, nCmdShow);
+	else
+		result = ShowWindow(v5, 0);
+	return result;
+} */
+
+// ref: 0x1000D520
+char *UNKCALL SelIPX_1000D520(char *arg) { return 0; }
+/* {
+	char *v1; // esi
+	char *result; // eax
+	signed int v3; // edi
+	signed int v4; // eax
+	char v5; // [esp+4h] [ebp-80h]
+
+	v1 = arg;
+	Connect_10004028((int)&v5, 128, 0, 0);
+	if ( !SelIPX_1000D58D((const char *)dword_1002A4B4, &v5) )
+		return strcpy(v1, &v5);
+	v3 = 2;
+	do
+	{
+		v4 = v3++;
+		wsprintfA(v1, "%s %d", &v5, v4);
+		result = (char *)SelIPX_1000D58D((const char *)dword_1002A4B4, v1);
+	}
+	while ( result );
+	return result;
+} */
+// 1002A4B4: using guessed type int dword_1002A4B4;
+
+// ref: 0x1000D58D
+const char *__fastcall SelIPX_1000D58D(const char *a1, const char *a2) { return 0; }
+/* {
+	const char *v2; // edi
+	const char *i; // esi
+
+	v2 = a2;
+	for ( i = a1; i && _strcmpi(i + 12, v2); i = *(const char **)i )
+		;
+	return i;
+} */
+
+// ref: 0x1000D5B0
+int __fastcall SelIPX_1000D5B0(int a1, int a2) { return 0; }
+/* {
+	int v2; // esi
+	CHAR *v3; // edx
+	CHAR v5; // [esp+Ch] [ebp-384h]
+	CHAR v6; // [esp+10Ch] [ebp-284h]
+	char v7; // [esp+20Ch] [ebp-184h]
+	CHAR Buffer; // [esp+28Ch] [ebp-104h]
+	int v9; // [esp+30Ch] [ebp-84h]
+	int v10; // [esp+38Ch] [ebp-4h]
+
+	v2 = a2;
+	v10 = a1;
+	Connect_10004028((int)&v9, 128, (int)&v7, 128);
+	if ( UiAuthCallback(2, (int)&v9, &v7, 0, (char *)(v2 + 140), &v6, 256) )
+	{
+		if ( SNetJoinGame(*(_DWORD *)(v2 + 4), v2 + 12, 0, &v9, &v7, dword_1002A4A8) )
+			return SelIPX_1000D3A0(v10, 1);
+		if ( SErrGetLastError() == -2062548871 )
+			LoadStringA(hInstance, 0x32u, &Buffer, 127);
+		else
+			LoadStringA(hInstance, 0x25u, &Buffer, 127);
+		wsprintfA(&v5, &Buffer, v2 + 12);
+		v3 = &v5;
+	}
+	else
+	{
+		v3 = &v6;
+	}
+	return SelYesNo_1000FD39(v10, v3, 0, 0);
+} */
+// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010430: using guessed type int __stdcall SNetJoinGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A4A8: using guessed type int dword_1002A4A8;
+
+// ref: 0x1000D696
+HWND __fastcall SelIPX_1000D696(HWND hDlg, int a2, int a3) { return 0; }
+/* {
+	int v3; // ebx
+	HWND v4; // esi
+	int v5; // ST08_4
+	HWND v6; // eax
+	HWND result; // eax
+	HWND v8; // eax
+	HWND v9; // eax
+	HWND v10; // eax
+	int v11; // eax
+	int v12; // eax
+	int v13; // eax
+	HWND v14; // eax
+	HWND v15; // eax
+	HWND v16; // eax
+	HWND v17; // eax
+
+	v3 = a2;
+	v4 = hDlg;
+	v5 = a2;
+	v6 = GetDlgItem(hDlg, 1056);
+	if ( local_10007C3B(v4, v6, v5, a3) )
+		return SelIPX_1000D3C5(v4, a3);
+	v8 = GetDlgItem(v4, 1054);
+	if ( local_10007C3B(v4, v8, v3, a3) )
+		return (HWND)SelIPX_1000D3A0((int)v4, 2);
+	v9 = GetDlgItem(v4, 1105);
+	result = (HWND)local_10007C3B(v4, v9, v3, a3);
+	if ( result )
+	{
+		v10 = GetDlgItem(v4, 1105);
+		v11 = Sbar_100099DC(v10, v3, a3) - 1;
+		if ( v11 )
+		{
+			v12 = v11 - 1;
+			if ( v12 )
+			{
+				v13 = v12 - 1;
+				if ( v13 )
+				{
+					result = (HWND)(v13 - 1);
+					if ( !result )
+					{
+						v14 = GetFocus();
+						result = SelIPX_1000D0E1(v14);
+					}
+				}
+				else
+				{
+					v15 = GetFocus();
+					result = SelIPX_1000D1D4(v15);
+				}
+			}
+			else
+			{
+				v16 = GetFocus();
+				result = SelIPX_1000D284(v16);
+			}
+		}
+		else
+		{
+			v17 = GetFocus();
+			result = SelIPX_1000D31C(v17);
+		}
+	}
+	return result;
+} */

--- a/DiabloUI/sellist.cpp
+++ b/DiabloUI/sellist.cpp
@@ -1,0 +1,832 @@
+// ref: 0x1000D769
+signed int SelList_1000D769() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A4C0 = 2139095040;
+	return result;
+} */
+// 1002A4C0: using guessed type int dword_1002A4C0;
+
+// ref: 0x1000D774
+int __stdcall SelList_1000D774(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	char *v5; // eax
+	int v6; // edx
+	HWND v8; // eax
+	HWND v9; // eax
+
+	if ( Msg > 0x111 )
+	{
+		if ( Msg == 275 )
+		{
+			v9 = GetFocus();
+			Focus_100075DC(hDlg, v9);
+			return 0;
+		}
+		if ( Msg != 513 )
+		{
+			if ( Msg == 514 )
+			{
+				v8 = GetDlgItem(hDlg, 1105);
+				if ( !Sbar_100099C0(v8) )
+					return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+				goto LABEL_23;
+			}
+			if ( Msg != 515 )
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+		}
+		SelList_1000E0CA(hDlg, (unsigned short)lParam, (unsigned int)lParam >> 16);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	switch ( Msg )
+	{
+		case 0x111u:
+			if ( HIWORD(wParam) == 7 )
+			{
+				Focus_100075B7(hDlg, (HWND)lParam);
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+			}
+			if ( HIWORD(wParam) != 6 )
+			{
+				v6 = 1;
+				if ( wParam != 327681 )
+				{
+					v6 = 2;
+					if ( (_WORD)wParam != 2 )
+						return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+				}
+LABEL_25:
+				OkCancel_100092F5((int)hDlg, v6);
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+			}
+			Focus_10007458((void *)lParam);
+			Focus_100075DC(hDlg, (HWND)lParam);
+			SelList_1000D964(hDlg, (unsigned short)wParam);
+LABEL_23:
+			SelList_1000D9CF(hDlg);
+			return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+		case 2u:
+			SelList_1000D916(hDlg);
+			return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+		case 6u:
+			if ( (_WORD)wParam == 1 || (_WORD)wParam == 2 )
+				SelList_1000DA2D(hDlg);
+			else
+				SelList_1000DA48(hDlg);
+			return 0;
+		case 0x100u:
+			if ( wParam != 46 )
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+			v5 = SelHero_1000B7B3();
+			if ( !strlen(v5) )
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+			v6 = 1006;
+			goto LABEL_25;
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v4 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v4, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	if ( Msg != 272 )
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	SelList_1000DA55(hDlg);
+	return 0;
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x1000D916
+HWND UNKCALL SelList_1000D916(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // eax
+
+	v1 = hDlg;
+	Sbar_10009CD2(hDlg, 1105);
+	Doom_10006C53(v1, &dword_10023190);
+	Doom_10006C53(v1, (int *)&unk_10023188);
+	Doom_10006C53(v1, (int *)&unk_1002317C);
+	Doom_10006C53(v1, (int *)&unk_10023174);
+	v2 = GetParent(v1);
+	return SelHero_1000BA7B(v2, 0);
+} */
+// 10023190: using guessed type int dword_10023190;
+
+// ref: 0x1000D964
+HWND __fastcall SelList_1000D964(HWND hDlg, int nIDDlgItem) { return 0; }
+/* {
+	HWND v2; // ebp
+	HWND v3; // eax
+	int v4; // eax
+	HWND v5; // eax
+	int v6; // eax
+	HWND v7; // eax
+	int v8; // eax
+	HWND v9; // eax
+	int v10; // eax
+	HWND v11; // eax
+	int v12; // eax
+	HWND v13; // esi
+	HWND result; // eax
+	int v15; // edi
+	HWND v16; // eax
+	HWND v17; // eax
+
+	v13 = hDlg;
+	result = GetDlgItem(hDlg, nIDDlgItem);
+	if ( result )
+	{
+		result = (HWND)GetWindowLongA(result, -21);
+		if ( result )
+		{
+			v15 = *((_DWORD *)result + 3);
+			if ( v15 )
+			{
+				if ( *(_WORD *)(v15 + 20) )
+					Doom_1000680A(v13, (int *)&unk_10023188, 4, 0);
+				else
+					Doom_1000680A(v13, (int *)&unk_10023188, 5, 0);
+				v16 = GetParent(v13);
+				result = (HWND)SelHero_1000B905(v16, v15);
+			}
+			else
+			{
+				Doom_1000680A(v13, (int *)&unk_10023188, 5, 0);
+				v17 = GetParent(v13);
+				dword_1002A424 = 0;
+				byte_1002A440 = 0;
+				v2 = v17;
+				v3 = GetDlgItem(v17, 1014);
+				v4 = GetWindowLongA(v3, -21);
+				local_10007FA4(v4, "--");
+				v5 = GetDlgItem(v2, 1018);
+				v6 = GetWindowLongA(v5, -21);
+				local_10007FA4(v6, "--");
+				v7 = GetDlgItem(v2, 1017);
+				v8 = GetWindowLongA(v7, -21);
+				local_10007FA4(v8, "--");
+				v9 = GetDlgItem(v2, 1016);
+				v10 = GetWindowLongA(v9, -21);
+				local_10007FA4(v10, "--");
+				v11 = GetDlgItem(v2, 1015);
+				v12 = GetWindowLongA(v11, -21);
+				local_10007FA4(v12, "--");
+				SelHero_1000B899(v2, 3);
+				result = (HWND)Doom_10006A13(v2, (int *)&unk_10023020, 1);
+			}
+		}
+	}
+	return result;
+} */
+// 1002A424: using guessed type int dword_1002A424;
+
+// ref: 0x1000D9CF
+HWND UNKCALL SelList_1000D9CF(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // eax
+	int v3; // ST04_4
+	int v4; // eax
+
+	v1 = hDlg;
+	v2 = GetFocus();
+	v3 = SelList_1000D9F4(v2);
+	v4 = SelHero_1000B7A6();
+	return Sbar_10009A99(v1, 1105, v4, v3);
+} */
+
+// ref: 0x1000D9F4
+int UNKCALL SelList_1000D9F4(HWND hWnd) { return 0; }
+/* {
+	LONG v1; // esi
+	_DWORD *v2; // eax
+	_DWORD *v3; // esi
+	int v5; // ecx
+
+	if ( !hWnd )
+		return 0;
+	v1 = GetWindowLongA(hWnd, -21);
+	if ( !v1 )
+		return 0;
+	v2 = (_DWORD *)SelHero_1000B7A0();
+	if ( !v2 )
+		return 0;
+	v3 = *(_DWORD **)(v1 + 12);
+	if ( !v3 )
+		return 0;
+	v5 = 0;
+	do
+	{
+		if ( v2 == v3 )
+			break;
+		v2 = (_DWORD *)*v2;
+		++v5;
+	}
+	while ( v2 );
+	return v5;
+} */
+
+// ref: 0x1000DA2D
+int UNKCALL SelList_1000DA2D(void *arg) { return 0; }
+/* {
+	void *v1; // esi
+
+	v1 = arg;
+	Focus_10007719("ui_art\\focus16.pcx");
+	return SDlgSetTimer(v1, 1, 55, 0);
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000DA48
+int UNKCALL SelList_1000DA48(void *arg) { return 0; }
+/* {
+	SDlgKillTimer(arg, 1);
+	return Focus_100076C3();
+} */
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x1000DA55
+int UNKCALL SelList_1000DA55(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // edi
+	LONG v3; // eax
+	int result; // eax
+	HWND v5; // eax
+	CHAR Buffer; // [esp+8h] [ebp-20h]
+
+	v1 = hWnd;
+	v2 = GetParent(hWnd);
+	SelList_1000DBAC(v1);
+	if ( SelHero_1000B7CA() == 1 )
+		LoadStringA(hInstance, 0x1Cu, &Buffer, 31);
+	else
+		LoadStringA(hInstance, 0x1Du, &Buffer, 31);
+	SelHero_1000BA7B(v2, &Buffer);
+	v3 = GetWindowLongA(v2, -21);
+	SetWindowLongA(v1, -21, v3);
+	Doom_100068AB(v1, (int *)&unk_10023174, 5);
+	Doom_1000658C(v1, (int *)&unk_1002317C, 4, 0);
+	Doom_1000658C(v1, (int *)&unk_10023188, 4, 0);
+	Doom_1000658C(v1, &dword_10023190, 2, 1);
+	dword_1002A4C4 = SelHero_1000B7A0();
+	SelList_1000DB2C(v1, (const char *)dword_1002A4C4);
+	Sbar_10009BF1(v1, 1105);
+	result = SelHero_1000B7A6();
+	if ( result <= 6 )
+	{
+		v5 = GetDlgItem(v1, 1105);
+		result = ShowWindow(v5, 0);
+	}
+	return result;
+} */
+// 10023190: using guessed type int dword_10023190;
+// 1002A4C4: using guessed type int dword_1002A4C4;
+
+// ref: 0x1000DB2C
+int __fastcall SelList_1000DB2C(HWND a1, const char *a2) { return 0; }
+/* {
+	const char *v2; // edi
+	int *v3; // ebp
+	HWND v4; // eax
+	HWND v5; // esi
+	int v6; // esi
+	HWND hDlg; // [esp+8h] [ebp-4h]
+
+	v2 = a2;
+	hDlg = a1;
+	v3 = &dword_10023190;
+	if ( dword_10023190 )
+	{
+		do
+		{
+			v4 = GetDlgItem(hDlg, *v3);
+			v5 = v4;
+			if ( v4 )
+			{
+				if ( v2 )
+				{
+					EnableWindow(v4, 1);
+					v6 = GetWindowLongA(v5, -21);
+					local_10007FA4(v6, v2 + 4);
+					if ( v6 )
+						*(_DWORD *)(v6 + 12) = v2;
+					v2 = *(const char **)v2;
+				}
+				else
+				{
+					EnableWindow(v4, 0);
+				}
+			}
+			++v3;
+		}
+		while ( *v3 );
+	}
+	return Doom_1000680A(hDlg, &dword_10023190, 2, 1);
+} */
+// 10023190: using guessed type int dword_10023190;
+
+// ref: 0x1000DBAC
+void UNKCALL SelList_1000DBAC(HWND hDlg) { return; }
+/* {
+	HWND v1; // ebx
+	int *v2; // edi
+	HWND v3; // eax
+	HWND v4; // esi
+	void *v5; // eax
+
+	v1 = hDlg;
+	v2 = &dword_10023190;
+	if ( dword_10023190 )
+	{
+		do
+		{
+			v3 = GetDlgItem(v1, *v2);
+			v4 = v3;
+			if ( v3 )
+			{
+				v5 = (void *)GetWindowLongA(v3, -4);
+				SetPropA(v4, "UIOLDPROC", v5);
+				SetWindowLongA(v4, -4, (LONG)SelList_1000DBFE);
+			}
+			++v2;
+		}
+		while ( *v2 );
+	}
+} */
+// 10023190: using guessed type int dword_10023190;
+
+// ref: 0x1000DBFE
+LRESULT __stdcall SelList_1000DBFE(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	LRESULT (__stdcall *v4)(HWND, UINT, WPARAM, LPARAM); // edi
+	HWND v5; // eax
+	UINT v7; // [esp-Ch] [ebp-18h]
+	WPARAM v8; // [esp-8h] [ebp-14h]
+	LPARAM v9; // [esp-4h] [ebp-10h]
+
+	v4 = (LRESULT (__stdcall *)(HWND, UINT, WPARAM, LPARAM))GetPropA(hWnd, "UIOLDPROC");
+	switch ( Msg )
+	{
+		case 2u:
+			RemovePropA(hWnd, "UIOLDPROC");
+			if ( !v4 )
+				return DefWindowProcA(hWnd, Msg, wParam, lParam);
+			SetWindowLongA(hWnd, -4, (LONG)v4);
+			break;
+		case 0xFu:
+			local_10007C95(hWnd);
+			return 0;
+		case 0x87u:
+			return 4;
+		case 0x100u:
+			if ( wParam > 0x21 )
+			{
+				if ( wParam == 34 )
+				{
+					SelList_1000DE18(hWnd);
+					return 0;
+				}
+				if ( wParam > 0x24 )
+				{
+					if ( wParam <= 0x26 )
+					{
+						SelList_1000E043(hWnd);
+						return 0;
+					}
+					if ( wParam <= 0x28 )
+					{
+						SelList_1000DFAB(hWnd);
+						return 0;
+					}
+					if ( wParam == 46 )
+					{
+						v9 = lParam;
+						v8 = 46;
+						v7 = 256;
+						goto LABEL_24;
+					}
+				}
+			}
+			else
+			{
+				switch ( wParam )
+				{
+					case 0x21u:
+						SelList_1000DEF4(hWnd);
+						break;
+					case 9u:
+						if ( GetKeyState(16) >= 0 )
+							SelList_1000DD36(hWnd);
+						else
+							SelList_1000DDA7(hWnd);
+						return 0;
+					case 0xDu:
+						goto LABEL_38;
+					case 0x1Bu:
+						v9 = 0;
+						v8 = 2;
+						goto LABEL_12;
+					case 0x20u:
+LABEL_38:
+						v9 = 0;
+						v8 = 1;
+LABEL_12:
+						v7 = 273;
+LABEL_24:
+						v5 = GetParent(hWnd);
+						SendMessageA(v5, v7, v8, v9);
+						return 0;
+				}
+			}
+			return 0;
+	}
+	if ( v4 )
+		return CallWindowProcA(v4, hWnd, Msg, wParam, lParam);
+	return DefWindowProcA(hWnd, Msg, wParam, lParam);
+} */
+
+// ref: 0x1000DD36
+HWND UNKCALL SelList_1000DD36(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // ebx
+	int nIDDlgItem[1044]; // [esp+0h] [ebp-1074h]
+	int v5; // [esp+1050h] [ebp-24h]
+	int v6; // [esp+105Ch] [ebp-18h]
+	int v7; // [esp+1060h] [ebp-14h]
+	int v8; // [esp+1064h] [ebp-10h]
+	int v9; // [esp+1068h] [ebp-Ch]
+	int v10; // [esp+106Ch] [ebp-8h]
+	int v11; // [esp+1070h] [ebp-4h]
+
+	v1 = hWnd;
+	v6 = 1048;
+	v7 = 1049;
+	v8 = 1050;
+	v9 = 1051;
+	v10 = 1052;
+	v11 = 1047;
+	v2 = GetParent(hWnd);
+	do
+	{
+		v5 = nIDDlgItem[GetWindowLongA(v1, -12)];
+		v1 = GetDlgItem(v2, v5);
+	}
+	while ( !IsWindowEnabled(v1) );
+	return SetFocus(v1);
+} */
+// 1000DD36: using guessed type int nIDDlgItem[1044];
+
+// ref: 0x1000DDA7
+HWND UNKCALL SelList_1000DDA7(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // ebx
+	int nIDDlgItem[1044]; // [esp+0h] [ebp-1074h]
+	int v5; // [esp+1050h] [ebp-24h]
+	int v6; // [esp+105Ch] [ebp-18h]
+	int v7; // [esp+1060h] [ebp-14h]
+	int v8; // [esp+1064h] [ebp-10h]
+	int v9; // [esp+1068h] [ebp-Ch]
+	int v10; // [esp+106Ch] [ebp-8h]
+	int v11; // [esp+1070h] [ebp-4h]
+
+	v1 = hWnd;
+	v6 = 1052;
+	v7 = 1047;
+	v8 = 1048;
+	v9 = 1049;
+	v10 = 1050;
+	v11 = 1051;
+	v2 = GetParent(hWnd);
+	do
+	{
+		v5 = nIDDlgItem[GetWindowLongA(v1, -12)];
+		v1 = GetDlgItem(v2, v5);
+	}
+	while ( !IsWindowEnabled(v1) );
+	return SetFocus(v1);
+} */
+// 1000DDA7: using guessed type int nIDDlgItem[1044];
+
+// ref: 0x1000DE18
+HWND UNKCALL SelList_1000DE18(HWND hWnd) { return 0; }
+/* {
+	HWND result; // eax
+	HWND v2; // edi
+	HWND v3; // ebp
+	HWND v4; // eax
+	_DWORD *v5; // eax
+	char *v6; // esi
+	const char *v7; // esi
+	int v8; // eax
+	HWND hWnda; // [esp+10h] [ebp-4h]
+
+	hWnda = hWnd;
+	result = GetParent(hWnd);
+	v2 = result;
+	if ( result )
+	{
+		result = GetDlgItem(result, 1047);
+		v3 = result;
+		if ( result )
+		{
+			v4 = GetDlgItem(v2, 1052);
+			result = (HWND)GetWindowLongA(v4, -21);
+			if ( result )
+			{
+				v5 = (_DWORD *)*((_DWORD *)result + 3);
+				if ( v5 && *v5 )
+				{
+					v6 = (char *)(SelList_1000D9F4(v3) + 6);
+					if ( (signed int)v6 > SelHero_1000B7A6() - 6 )
+						v6 = (char *)(SelHero_1000B7A6() - 6);
+					result = (HWND)SelList_1000DEDD(v6);
+					v7 = (const char *)result;
+					if ( result )
+					{
+						TitleSnd_10010315();
+						SelList_1000DB2C(v2, v7);
+						v8 = GetWindowLongA(hWnda, -12);
+						SelList_1000D964(v2, v8);
+						result = SelList_1000D9CF(v2);
+					}
+				}
+				else
+				{
+					result = SelList_1000DDA7(v3);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000DEDD
+_DWORD *UNKCALL SelList_1000DEDD(char *arg) { return 0; }
+/* {
+	char *v1; // esi
+	_DWORD *result; // eax
+
+	v1 = arg;
+	result = (_DWORD *)SelHero_1000B7A0();
+	while ( result && v1 )
+	{
+		result = (_DWORD *)*result;
+		--v1;
+	}
+	return result;
+} */
+
+// ref: 0x1000DEF4
+HWND UNKCALL SelList_1000DEF4(HWND hWnd) { return 0; }
+/* {
+	HWND result; // eax
+	HWND v2; // esi
+	HWND v3; // edi
+	int v4; // ebp
+	HWND v5; // eax
+	char *v6; // eax
+	const char *v7; // edi
+	int v8; // eax
+	HWND hWnda; // [esp+10h] [ebp-4h]
+
+	hWnda = hWnd;
+	result = GetParent(hWnd);
+	v2 = result;
+	if ( result )
+	{
+		result = GetDlgItem(result, 1047);
+		v3 = result;
+		if ( result )
+		{
+			result = (HWND)GetWindowLongA(result, -21);
+			if ( result )
+			{
+				v4 = *((_DWORD *)result + 3);
+				if ( v4 )
+				{
+					if ( v4 == SelHero_1000B7A0() )
+					{
+						v5 = GetDlgItem(v2, 1052);
+						result = SelList_1000DD36(v5);
+					}
+					else
+					{
+						v6 = (char *)(SelList_1000D9F4(v3) - 6);
+						if ( (signed int)v6 < 0 )
+							v6 = 0;
+						result = (HWND)SelList_1000DEDD(v6);
+						v7 = (const char *)result;
+						if ( result )
+						{
+							TitleSnd_10010315();
+							SelList_1000DB2C(v2, v7);
+							v8 = GetWindowLongA(hWnda, -12);
+							SelList_1000D964(v2, v8);
+							result = SelList_1000D9CF(v2);
+						}
+					}
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000DFAB
+HWND UNKCALL SelList_1000DFAB(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND result; // eax
+	HWND v3; // eax
+	const char *v4; // ebp
+	HWND v5; // eax
+	int v6; // ebx
+	HWND v7; // eax
+	HWND v8; // eax
+
+	v1 = hWnd;
+	result = (HWND)GetWindowLongA(hWnd, -21);
+	if ( result )
+	{
+		result = (HWND)*((_DWORD *)result + 3);
+		if ( result )
+		{
+			if ( *(_DWORD *)result )
+			{
+				if ( GetWindowLongA(v1, -12) >= 1052 )
+				{
+					v3 = GetParent(v1);
+					result = GetDlgItem(v3, 1048);
+					if ( result )
+					{
+						result = (HWND)GetWindowLongA(result, -21);
+						if ( result )
+						{
+							v4 = (const char *)*((_DWORD *)result + 3);
+							if ( v4 )
+							{
+								TitleSnd_10010315();
+								v5 = GetParent(v1);
+								SelList_1000DB2C(v5, v4);
+								v6 = GetWindowLongA(v1, -12);
+								v7 = GetParent(v1);
+								SelList_1000D964(v7, v6);
+								v8 = GetParent(v1);
+								result = SelList_1000D9CF(v8);
+							}
+						}
+					}
+				}
+				else
+				{
+					result = SelList_1000DD36(v1);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000E043
+HWND UNKCALL SelList_1000E043(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND result; // eax
+	HWND v3; // esi
+	const char *v4; // ebx
+	HWND v5; // eax
+	int v6; // ebx
+	HWND v7; // eax
+	HWND v8; // eax
+
+	v1 = hWnd;
+	if ( GetWindowLongA(hWnd, -12) > 1047 )
+		return SelList_1000DDA7(v1);
+	result = (HWND)GetWindowLongA(v1, -21);
+	if ( result )
+	{
+		v3 = (HWND)*((_DWORD *)result + 3);
+		if ( v3 )
+		{
+			result = (HWND)SelHero_1000B7A0();
+			v4 = (const char *)result;
+			if ( v3 != result )
+			{
+				while ( v4 && *(HWND *)v4 != v3 )
+					v4 = *(const char **)v4;
+				TitleSnd_10010315();
+				v5 = GetParent(v1);
+				SelList_1000DB2C(v5, v4);
+				v6 = GetWindowLongA(v1, -12);
+				v7 = GetParent(v1);
+				SelList_1000D964(v7, v6);
+				v8 = GetParent(v1);
+				result = SelList_1000D9CF(v8);
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000E0CA
+int __fastcall SelList_1000E0CA(HWND hWnd, int a2, int a3) { return 0; }
+/* {
+	int v3; // ebx
+	HWND v4; // esi
+	int v5; // ST08_4
+	HWND v6; // eax
+	int v7; // edx
+	int result; // eax
+	HWND v9; // eax
+	HWND v10; // eax
+	char *v11; // eax
+	HWND v12; // eax
+	HWND v13; // eax
+	int v14; // eax
+	int v15; // eax
+	int v16; // eax
+	HWND v17; // eax
+	HWND v18; // eax
+	HWND v19; // eax
+	HWND v20; // eax
+
+	v3 = a2;
+	v4 = hWnd;
+	v5 = a2;
+	v6 = GetDlgItem(hWnd, 1056);
+	if ( local_10007C3B(v4, v6, v5, a3) )
+	{
+		v7 = 1;
+		return OkCancel_100092F5((int)v4, v7);
+	}
+	v9 = GetDlgItem(v4, 1054);
+	if ( local_10007C3B(v4, v9, v3, a3) )
+	{
+		v7 = 2;
+		return OkCancel_100092F5((int)v4, v7);
+	}
+	v10 = GetDlgItem(v4, 1006);
+	if ( local_10007C3B(v4, v10, v3, a3) )
+	{
+		v11 = SelHero_1000B7B3();
+		result = strlen(v11);
+		if ( result )
+		{
+			v7 = 1006;
+			return OkCancel_100092F5((int)v4, v7);
+		}
+	}
+	else
+	{
+		v12 = GetDlgItem(v4, 1105);
+		result = local_10007C3B(v4, v12, v3, a3);
+		if ( result )
+		{
+			v13 = GetDlgItem(v4, 1105);
+			v14 = Sbar_100099DC(v13, v3, a3) - 1;
+			if ( v14 )
+			{
+				v15 = v14 - 1;
+				if ( v15 )
+				{
+					v16 = v15 - 1;
+					if ( v16 )
+					{
+						result = v16 - 1;
+						if ( !result )
+						{
+							v17 = GetFocus();
+							result = (int)SelList_1000DE18(v17);
+						}
+					}
+					else
+					{
+						v18 = GetFocus();
+						result = (int)SelList_1000DEF4(v18);
+					}
+				}
+				else
+				{
+					v19 = GetFocus();
+					result = (int)SelList_1000DFAB(v19);
+				}
+			}
+			else
+			{
+				v20 = GetFocus();
+				result = (int)SelList_1000E043(v20);
+			}
+		}
+	}
+	return result;
+} */

--- a/DiabloUI/selload.cpp
+++ b/DiabloUI/selload.cpp
@@ -1,0 +1,147 @@
+// ref: 0x1000E1C2
+int __stdcall SelLoad_1000E1C2(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	LONG v5; // edx
+	HWND v6; // eax
+	HWND v7; // eax
+	HWND v9; // eax
+
+	if ( Msg == 2 )
+	{
+		SelLoad_1000E30E(hDlg);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v9 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v9, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	if ( Msg == 272 )
+	{
+		SelLoad_1000E34B(hDlg);
+		return 0;
+	}
+	if ( Msg != 273 )
+	{
+		if ( Msg != 275 )
+		{
+			if ( Msg == 513 )
+			{
+				v4 = GetDlgItem(hDlg, 1056);
+				if ( local_10007C3B(hDlg, v4, (unsigned short)lParam, (unsigned int)lParam >> 16) )
+				{
+					v5 = 1;
+LABEL_19:
+					SelLoad_1000E3E2((int)hDlg, v5);
+					return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+				}
+				v6 = GetDlgItem(hDlg, 1054);
+				if ( local_10007C3B(hDlg, v6, (unsigned short)lParam, (unsigned int)lParam >> 16) )
+				{
+LABEL_21:
+					v5 = 2;
+					goto LABEL_19;
+				}
+			}
+			return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+		}
+		v7 = GetFocus();
+		Focus_100075DC(hDlg, v7);
+		return 0;
+	}
+	if ( HIWORD(wParam) == 7 )
+	{
+		Focus_100075B7(hDlg, (HWND)lParam);
+	}
+	else
+	{
+		if ( HIWORD(wParam) != 6 )
+		{
+			v5 = 1;
+			if ( wParam == 327681 )
+				goto LABEL_19;
+			if ( (_WORD)wParam != 2 )
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+			goto LABEL_21;
+		}
+		Focus_10007458((void *)lParam);
+		Focus_100075DC(hDlg, (HWND)lParam);
+	}
+	return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x1000E30E
+HWND UNKCALL SelLoad_1000E30E(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // eax
+
+	v1 = hDlg;
+	Focus_100076C3();
+	Doom_10006C53(v1, (int *)&unk_100231C0);
+	Doom_10006C53(v1, (int *)&unk_100231B4);
+	Doom_10006C53(v1, (int *)&unk_100231AC);
+	v2 = GetParent(v1);
+	return SelHero_1000BA7B(v2, 0);
+} */
+
+// ref: 0x1000E34B
+int UNKCALL SelLoad_1000E34B(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // edi
+	LONG v3; // eax
+	CHAR Buffer; // [esp+8h] [ebp-20h]
+
+	v1 = hWnd;
+	v2 = GetParent(hWnd);
+	LoadStringA(hInstance, 0x1Du, &Buffer, 31);
+	SelHero_1000BA7B(v2, &Buffer);
+	v3 = GetWindowLongA(v2, -21);
+	SetWindowLongA(v1, -21, v3);
+	local_10007CB5(v1, (int *)&unk_100231C0);
+	Doom_100068AB(v1, (int *)&unk_100231AC, 5);
+	Doom_1000658C(v1, (int *)&unk_100231B4, 4, 0);
+	Doom_1000658C(v1, (int *)&unk_100231C0, 2, 1);
+	Focus_10007719("ui_art\\focus16.pcx");
+	return SDlgSetTimer(v1, 1, 55, 0);
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000E3E2
+int __fastcall SelLoad_1000E3E2(int a1, LONG a2) { return 0; }
+/* {
+	LONG v2; // esi
+	int v3; // edi
+	HWND v4; // eax
+
+	v2 = a2;
+	v3 = a1;
+	TitleSnd_1001031F();
+	SDlgKillTimer(v3, 1);
+	if ( v2 == 1 )
+	{
+		v4 = GetFocus();
+		v2 = GetWindowLongA(v4, -12);
+	}
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x1000E41A
+signed int SelLoad_1000E41A() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A4C8 = 2139095040;
+	return result;
+} */
+// 1002A4C8: using guessed type int dword_1002A4C8;

--- a/DiabloUI/selmodem.cpp
+++ b/DiabloUI/selmodem.cpp
@@ -1,0 +1,893 @@
+// ref: 0x1000E42A
+signed int SelModem_1000E42A() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A4CC = 2139095040;
+	return result;
+} */
+// 1002A4CC: using guessed type int dword_1002A4CC;
+
+// ref: 0x1000E435
+int __fastcall SelModem_1000E435(void *a1, int a2, int a3, char *a4, char *a5) { return 0; }
+/* {
+	void *v5; // edi
+
+	dword_1002A4DC = 0;
+	dword_1002A4D8 = 0;
+	dword_1002A4E8 = a3;
+	dword_1002A4D4 = a4;
+	v5 = a1;
+	dword_1002A4E0 = a2;
+	dword_1002A4D0 = (int)a5;
+	SNetEnumDevices(SelModem_1000E497);
+	if ( !dword_1002A4D8 )
+		return SelModem_1000E505(v5);
+	if ( dword_1002A4D8 == 1 )
+		return SelModem_1000E51E();
+	return SelModem_1000E5CC();
+} */
+// 10010496: using guessed type int __stdcall SNetEnumDevices(_DWORD);
+// 1002A4D0: using guessed type int dword_1002A4D0;
+// 1002A4DC: using guessed type int dword_1002A4DC;
+// 1002A4E0: using guessed type int dword_1002A4E0;
+// 1002A4E8: using guessed type int dword_1002A4E8;
+
+// ref: 0x1000E497
+int __stdcall SelModem_1000E497(int a1, char *a2, char *a3) { return 0; }
+/* {
+	int result; // eax
+	int v4; // esi
+	_DWORD *v5; // eax
+
+	result = SelModem_1000E4EC();
+	v4 = result;
+	if ( result )
+	{
+		*(_DWORD *)result = 0;
+		*(_DWORD *)(result + 4) = a1;
+		strcpy((char *)(result + 8), a2);
+		strcpy((char *)(v4 + 136), a3);
+		v5 = SelModem_1000E500(dword_1002A4DC, (_DWORD *)v4);
+		++dword_1002A4D8;
+		dword_1002A4DC = (int)v5;
+		result = 1;
+	}
+	return result;
+} */
+// 1002A4DC: using guessed type int dword_1002A4DC;
+
+// ref: 0x1000E4EC
+int SelModem_1000E4EC() { return 0; }
+/* {
+	return SMemAlloc(264, "C:\\Src\\Diablo\\DiabloUI\\SelModem.cpp", 72, 0);
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000E500
+_DWORD *__fastcall SelModem_1000E500(int a1, _DWORD *a2) { return 0; }
+/* {
+	_DWORD *result; // eax
+
+	result = a2;
+	*a2 = a1;
+	return result;
+} */
+
+// ref: 0x1000E505
+signed int UNKCALL SelModem_1000E505(void *arg) { return 0; }
+/* {
+	if ( arg != (void *)1297040461 )
+		return 1;
+	SErrSetLastError(1222);
+	return 0;
+} */
+// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+
+// ref: 0x1000E51E
+signed int SelModem_1000E51E() { return 0; }
+/* {
+	signed int result; // eax
+
+	if ( SelModem_1000E57B(*((_DWORD *)dword_1002A4D4 + 2), *(_DWORD *)(dword_1002A4DC + 4)) )
+	{
+		SelModem_1000E553((_DWORD *)dword_1002A4DC);
+		result = 1;
+	}
+	else
+	{
+		SErrSetLastError(-2062548879);
+		result = 0;
+	}
+	return result;
+} */
+// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 1002A4DC: using guessed type int dword_1002A4DC;
+
+// ref: 0x1000E553
+int __fastcall SelModem_1000E553(_DWORD *a1) { return 0; }
+/* {
+	_DWORD *v1; // esi
+	int result; // eax
+
+	if ( a1 )
+	{
+		do
+		{
+			v1 = (_DWORD *)*a1;
+			result = SelModem_1000E567(a1);
+			a1 = v1;
+		}
+		while ( v1 );
+	}
+	return result;
+} */
+
+// ref: 0x1000E567
+int UNKCALL SelModem_1000E567(void *arg) { return 0; }
+/* {
+	int result; // eax
+
+	if ( arg )
+		result = SMemFree(arg, "C:\\Src\\Diablo\\DiabloUI\\SelModem.cpp", 77, 0);
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000E57B
+int __fastcall SelModem_1000E57B(int a1, int a2) { return 0; }
+/* {
+	int v2; // ebx
+	int v3; // esi
+	int v5; // [esp+8h] [ebp-50h]
+	int v6; // [esp+10h] [ebp-48h]
+	int (__stdcall *v7)(char *, int, int, int, int); // [esp+30h] [ebp-28h]
+
+	v2 = a2;
+	v3 = a1;
+	memcpy(&v5, dword_1002A4D4, 0x50u);
+	v7 = ModmStat_10008C62;
+	v5 = 80;
+	v6 = v3;
+	return SNetInitializeDevice(v2, dword_1002A4E0, dword_1002A4E8, &v5, dword_1002A4D0);
+} */
+// 1001049C: using guessed type int __stdcall SNetInitializeDevice(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A4D0: using guessed type int dword_1002A4D0;
+// 1002A4E0: using guessed type int dword_1002A4E0;
+// 1002A4E8: using guessed type int dword_1002A4E8;
+
+// ref: 0x1000E5CC
+signed int SelModem_1000E5CC() { return 0; }
+/* {
+	signed int v0; // esi
+	signed int result; // eax
+
+	v0 = 1;
+	if ( SDlgDialogBoxParam(hInstance, "SELMODEM_DIALOG", *((_DWORD *)dword_1002A4D4 + 2), SelModem_1000E63E, 0) == 1 )
+	{
+		if ( !SelModem_1000E57B(*((_DWORD *)dword_1002A4D4 + 2), dword_1002A4E4) )
+		{
+			SErrSetLastError(-2062548879);
+			v0 = 0;
+		}
+		SelModem_1000E553((_DWORD *)dword_1002A4DC);
+		result = v0;
+	}
+	else
+	{
+		SelModem_1000E553((_DWORD *)dword_1002A4DC);
+		SErrSetLastError(1223);
+		result = 0;
+	}
+	return result;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 1002A4DC: using guessed type int dword_1002A4DC;
+// 1002A4E4: using guessed type int dword_1002A4E4;
+
+// ref: 0x1000E63E
+int __stdcall SelModem_1000E63E(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	int v4; // edx
+	HWND v5; // eax
+	HWND v7; // eax
+	int v8; // [esp+0h] [ebp-Ch]
+
+	if ( Msg > 0x201 )
+	{
+		if ( Msg == 514 )
+		{
+			v7 = GetDlgItem(hDlg, 1105);
+			if ( !Sbar_100099C0(v7) )
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+LABEL_27:
+			SelModem_1000E7E9(hDlg);
+			return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+		}
+		if ( Msg != 515 )
+		{
+			if ( Msg != 2024 )
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+			if ( !Fade_1000739F() )
+				Fade_100073FD(hDlg, v8);
+			return 0;
+		}
+LABEL_25:
+		SelModem_1000EE78(hDlg, (unsigned short)lParam, (unsigned int)lParam >> 16);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	if ( Msg == 513 )
+		goto LABEL_25;
+	if ( Msg == 2 )
+	{
+		SelModem_1000E783(hDlg);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v5 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v5, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	if ( Msg == 272 )
+	{
+		SelModem_1000E843(hDlg);
+		return 0;
+	}
+	if ( Msg == 273 )
+	{
+		if ( HIWORD(wParam) == 7 )
+		{
+			Focus_100075B7(hDlg, (HWND)lParam);
+			return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+		}
+		if ( HIWORD(wParam) == 6 )
+		{
+			Focus_10007458((void *)lParam);
+			Focus_100075DC(hDlg, (HWND)lParam);
+			goto LABEL_27;
+		}
+		v4 = 1;
+		if ( wParam != 327681 )
+		{
+			if ( (_WORD)wParam != 2 )
+				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+			v4 = 2;
+		}
+		SelModem_1000EE29((int)hDlg, v4);
+	}
+	return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x1000E783
+void UNKCALL SelModem_1000E783(HWND hDlg) { return; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	Sbar_10009CD2(hDlg, 1105);
+	Doom_10006C53(v1, &dword_100231F4);
+	Doom_10006C53(v1, (int *)&unk_100231E8);
+	Doom_10006C53(v1, (int *)&unk_100231CC);
+	Doom_10006C53(v1, (int *)&unk_100231D4);
+	Doom_10006C53(v1, (int *)&unk_100231E0);
+	Focus_10007818(v1);
+	local_1000811B();
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+} */
+// 100231F4: using guessed type int dword_100231F4;
+
+// ref: 0x1000E7E9
+HWND UNKCALL SelModem_1000E7E9(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // eax
+	int v3; // eax
+
+	v1 = hDlg;
+	v2 = GetFocus();
+	v3 = SelModem_1000E80E(v2);
+	return Sbar_10009A99(v1, 1105, dword_1002A4D8, v3);
+} */
+
+// ref: 0x1000E80E
+int UNKCALL SelModem_1000E80E(HWND hWnd) { return 0; }
+/* {
+	LONG v1; // eax
+	_DWORD *v2; // ecx
+	_DWORD *v3; // eax
+	int v5; // edx
+
+	if ( !hWnd )
+		return 0;
+	v1 = GetWindowLongA(hWnd, -21);
+	if ( !v1 )
+		return 0;
+	v2 = (_DWORD *)dword_1002A4DC;
+	if ( !dword_1002A4DC )
+		return 0;
+	v3 = *(_DWORD **)(v1 + 12);
+	if ( !v3 )
+		return 0;
+	v5 = 0;
+	do
+	{
+		if ( v2 == v3 )
+			break;
+		v2 = (_DWORD *)*v2;
+		++v5;
+	}
+	while ( v2 );
+	return v5;
+} */
+// 1002A4DC: using guessed type int dword_1002A4DC;
+
+// ref: 0x1000E843
+HWND UNKCALL SelModem_1000E843(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+	int *v3; // edi
+	HWND result; // eax
+	HWND v5; // eax
+	HWND v6; // [esp+0h] [ebp-Ch]
+
+	v1 = hWnd;
+	GetParent(hWnd);
+	SelModem_1000E9B2(v1);
+	Focus_100077E9((int)v1, "ui_art\\focus16.pcx", v6);
+	local_100080F1();
+	v2 = local_10007F46();
+	v3 = (int *)v2;
+	if ( v2 )
+	{
+		SetWindowLongA(v1, -21, v2);
+		local_10007944((int)v1, 0, "popup", -1, 1, (int)"ui_art\\seldiff.pcx", v3, v3 + 1, 0);
+	}
+	Fade_100073C5(v1, 0);
+	PostMessageA(v1, 0x7E8u, 0, 0);
+	Doom_100068AB(v1, (int *)&unk_100231E0, 1);
+	Doom_100068AB(v1, (int *)&unk_100231D4, 3);
+	Doom_100068AB(v1, (int *)&unk_100231CC, 5);
+	Doom_1000658C(v1, (int *)&unk_100231E8, 4, 0);
+	Doom_1000658C(v1, &dword_100231F4, 0, 1);
+	SelModem_1000E932(v1, (const char *)dword_1002A4DC);
+	result = Sbar_10009BF1(v1, 1105);
+	if ( dword_1002A4D8 <= 6 )
+	{
+		v5 = GetDlgItem(v1, 1105);
+		result = (HWND)ShowWindow(v5, 0);
+	}
+	return result;
+} */
+// 100231F4: using guessed type int dword_100231F4;
+// 1002A4DC: using guessed type int dword_1002A4DC;
+
+// ref: 0x1000E932
+int __fastcall SelModem_1000E932(HWND a1, const char *a2) { return 0; }
+/* {
+	const char *v2; // edi
+	int *v3; // ebp
+	HWND v4; // eax
+	HWND v5; // esi
+	int v6; // esi
+	HWND hDlg; // [esp+8h] [ebp-4h]
+
+	v2 = a2;
+	hDlg = a1;
+	v3 = &dword_100231F4;
+	if ( dword_100231F4 )
+	{
+		do
+		{
+			v4 = GetDlgItem(hDlg, *v3);
+			v5 = v4;
+			if ( v4 )
+			{
+				if ( v2 )
+				{
+					EnableWindow(v4, 1);
+					v6 = GetWindowLongA(v5, -21);
+					local_10007FA4(v6, v2 + 8);
+					if ( v6 )
+						*(_DWORD *)(v6 + 12) = v2;
+					v2 = *(const char **)v2;
+				}
+				else
+				{
+					EnableWindow(v4, 0);
+				}
+			}
+			++v3;
+		}
+		while ( *v3 );
+	}
+	return Doom_1000680A(hDlg, &dword_100231F4, 0, 1);
+} */
+// 100231F4: using guessed type int dword_100231F4;
+
+// ref: 0x1000E9B2
+void UNKCALL SelModem_1000E9B2(HWND hDlg) { return; }
+/* {
+	HWND v1; // ebx
+	int *v2; // edi
+	HWND v3; // eax
+	HWND v4; // esi
+	void *v5; // eax
+
+	v1 = hDlg;
+	v2 = &dword_100231F4;
+	if ( dword_100231F4 )
+	{
+		do
+		{
+			v3 = GetDlgItem(v1, *v2);
+			v4 = v3;
+			if ( v3 )
+			{
+				v5 = (void *)GetWindowLongA(v3, -4);
+				SetPropA(v4, "UIOLDPROC", v5);
+				SetWindowLongA(v4, -4, (LONG)SelModem_1000EA04);
+			}
+			++v2;
+		}
+		while ( *v2 );
+	}
+} */
+// 100231F4: using guessed type int dword_100231F4;
+
+// ref: 0x1000EA04
+LRESULT __stdcall SelModem_1000EA04(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	LRESULT (__stdcall *v4)(HWND, UINT, WPARAM, LPARAM); // edi
+	HWND v5; // eax
+	WPARAM v7; // [esp-8h] [ebp-14h]
+
+	v4 = (LRESULT (__stdcall *)(HWND, UINT, WPARAM, LPARAM))GetPropA(hWnd, "UIOLDPROC");
+	switch ( Msg )
+	{
+		case 2u:
+			RemovePropA(hWnd, "UIOLDPROC");
+			if ( !v4 )
+				return DefWindowProcA(hWnd, Msg, wParam, lParam);
+			SetWindowLongA(hWnd, -4, (LONG)v4);
+			break;
+		case 0xFu:
+			local_10007C95(hWnd);
+			return 0;
+		case 0x87u:
+			return 4;
+		case 0x100u:
+			if ( wParam > 0x21 )
+			{
+				if ( wParam == 34 )
+				{
+					SelModem_1000EC0E(hWnd);
+				}
+				else if ( wParam > 0x24 )
+				{
+					if ( wParam <= 0x26 )
+					{
+						SelModem_1000EDBC(hWnd);
+					}
+					else if ( wParam <= 0x28 )
+					{
+						SelModem_1000ED3B(hWnd);
+					}
+				}
+				return 0;
+			}
+			if ( wParam == 33 )
+			{
+				SelModem_1000ECB2(hWnd);
+				return 0;
+			}
+			if ( wParam == 9 )
+			{
+				if ( GetKeyState(16) >= 0 )
+					SelModem_1000EB2C(hWnd);
+				else
+					SelModem_1000EB9D(hWnd);
+				return 0;
+			}
+			if ( wParam != 13 )
+			{
+				if ( wParam == 27 )
+				{
+					v7 = 2;
+					goto LABEL_13;
+				}
+				if ( wParam != 32 )
+					return 0;
+			}
+			v7 = 1;
+LABEL_13:
+			v5 = GetParent(hWnd);
+			SendMessageA(v5, 0x111u, v7, 0);
+			return 0;
+	}
+	if ( v4 )
+		return CallWindowProcA(v4, hWnd, Msg, wParam, lParam);
+	return DefWindowProcA(hWnd, Msg, wParam, lParam);
+} */
+
+// ref: 0x1000EB2C
+HWND UNKCALL SelModem_1000EB2C(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // ebx
+	int nIDDlgItem[1107]; // [esp+0h] [ebp-1170h]
+	int v5; // [esp+114Ch] [ebp-24h]
+	int v6; // [esp+1158h] [ebp-18h]
+	int v7; // [esp+115Ch] [ebp-14h]
+	int v8; // [esp+1160h] [ebp-10h]
+	int v9; // [esp+1164h] [ebp-Ch]
+	int v10; // [esp+1168h] [ebp-8h]
+	int v11; // [esp+116Ch] [ebp-4h]
+
+	v1 = hWnd;
+	v6 = 1111;
+	v7 = 1112;
+	v8 = 1113;
+	v9 = 1114;
+	v10 = 1115;
+	v11 = 1110;
+	v2 = GetParent(hWnd);
+	do
+	{
+		v5 = nIDDlgItem[GetWindowLongA(v1, -12)];
+		v1 = GetDlgItem(v2, v5);
+	}
+	while ( !IsWindowEnabled(v1) );
+	return SetFocus(v1);
+} */
+// 1000EB2C: using guessed type int nIDDlgItem[1107];
+
+// ref: 0x1000EB9D
+HWND UNKCALL SelModem_1000EB9D(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // ebx
+	int nIDDlgItem[1107]; // [esp+0h] [ebp-1170h]
+	int v5; // [esp+114Ch] [ebp-24h]
+	int v6; // [esp+1158h] [ebp-18h]
+	int v7; // [esp+115Ch] [ebp-14h]
+	int v8; // [esp+1160h] [ebp-10h]
+	int v9; // [esp+1164h] [ebp-Ch]
+	int v10; // [esp+1168h] [ebp-8h]
+	int v11; // [esp+116Ch] [ebp-4h]
+
+	v1 = hWnd;
+	v6 = 1115;
+	v7 = 1110;
+	v8 = 1111;
+	v9 = 1112;
+	v10 = 1113;
+	v11 = 1114;
+	v2 = GetParent(hWnd);
+	do
+	{
+		v5 = nIDDlgItem[GetWindowLongA(v1, -12)];
+		v1 = GetDlgItem(v2, v5);
+	}
+	while ( !IsWindowEnabled(v1) );
+	return SetFocus(v1);
+} */
+// 1000EB9D: using guessed type int nIDDlgItem[1107];
+
+// ref: 0x1000EC0E
+HWND UNKCALL SelModem_1000EC0E(HWND hWnd) { return 0; }
+/* {
+	HWND result; // eax
+	HWND v2; // edi
+	HWND v3; // ebx
+	HWND v4; // eax
+	_DWORD *v5; // eax
+	int v6; // eax
+	const char *v7; // esi
+
+	result = GetParent(hWnd);
+	v2 = result;
+	if ( result )
+	{
+		result = GetDlgItem(result, 1110);
+		v3 = result;
+		if ( result )
+		{
+			v4 = GetDlgItem(v2, 1115);
+			result = (HWND)GetWindowLongA(v4, -21);
+			if ( result )
+			{
+				v5 = (_DWORD *)*((_DWORD *)result + 3);
+				if ( v5 && *v5 )
+				{
+					v6 = SelModem_1000E80E(v3) + 6;
+					if ( v6 > dword_1002A4D8 - 6 )
+						v6 = dword_1002A4D8 - 6;
+					result = (HWND)SelModem_1000EC9F(v6);
+					v7 = (const char *)result;
+					if ( result )
+					{
+						TitleSnd_10010315();
+						SelModem_1000E932(v2, v7);
+						result = SelModem_1000E7E9(v2);
+					}
+				}
+				else
+				{
+					result = SelModem_1000EB9D(v3);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000EC9F
+_DWORD *__fastcall SelModem_1000EC9F(int a1) { return 0; }
+/* {
+	_DWORD *result; // eax
+
+	result = (_DWORD *)dword_1002A4DC;
+	while ( result && a1 )
+	{
+		result = (_DWORD *)*result;
+		--a1;
+	}
+	return result;
+} */
+// 1002A4DC: using guessed type int dword_1002A4DC;
+
+// ref: 0x1000ECB2
+HWND UNKCALL SelModem_1000ECB2(HWND hWnd) { return 0; }
+/* {
+	HWND result; // eax
+	HWND v2; // edi
+	HWND v3; // esi
+	HWND v4; // eax
+	int v5; // eax
+	const char *v6; // esi
+
+	result = GetParent(hWnd);
+	v2 = result;
+	if ( result )
+	{
+		result = GetDlgItem(result, 1110);
+		v3 = result;
+		if ( result )
+		{
+			result = (HWND)GetWindowLongA(result, -21);
+			if ( result )
+			{
+				result = (HWND)*((_DWORD *)result + 3);
+				if ( result )
+				{
+					if ( result == (HWND)dword_1002A4DC )
+					{
+						v4 = GetDlgItem(v2, 1115);
+						result = SelModem_1000EB2C(v4);
+					}
+					else
+					{
+						v5 = SelModem_1000E80E(v3) - 6;
+						if ( v5 < 0 )
+							v5 = 0;
+						result = (HWND)SelModem_1000EC9F(v5);
+						v6 = (const char *)result;
+						if ( result )
+						{
+							TitleSnd_10010315();
+							SelModem_1000E932(v2, v6);
+							result = SelModem_1000E7E9(v2);
+						}
+					}
+				}
+			}
+		}
+	}
+	return result;
+} */
+// 1002A4DC: using guessed type int dword_1002A4DC;
+
+// ref: 0x1000ED3B
+HWND UNKCALL SelModem_1000ED3B(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND result; // eax
+	HWND v3; // eax
+	const char *v4; // esi
+	HWND v5; // eax
+	HWND v6; // eax
+
+	v1 = hWnd;
+	result = (HWND)GetWindowLongA(hWnd, -21);
+	if ( result )
+	{
+		result = (HWND)*((_DWORD *)result + 3);
+		if ( result )
+		{
+			if ( *(_DWORD *)result )
+			{
+				if ( GetWindowLongA(v1, -12) >= 1115 )
+				{
+					v3 = GetParent(v1);
+					result = GetDlgItem(v3, 1111);
+					if ( result )
+					{
+						result = (HWND)GetWindowLongA(result, -21);
+						if ( result )
+						{
+							v4 = (const char *)*((_DWORD *)result + 3);
+							if ( v4 )
+							{
+								TitleSnd_10010315();
+								v5 = GetParent(v1);
+								SelModem_1000E932(v5, v4);
+								v6 = GetParent(v1);
+								result = SelModem_1000E7E9(v6);
+							}
+						}
+					}
+				}
+				else
+				{
+					result = SelModem_1000EB2C(v1);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000EDBC
+HWND UNKCALL SelModem_1000EDBC(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // ebx
+	HWND result; // eax
+	const char *v3; // esi
+	HWND v4; // eax
+	HWND v5; // eax
+
+	v1 = hWnd;
+	if ( GetWindowLongA(hWnd, -12) > 1110 )
+		return SelModem_1000EB9D(v1);
+	result = (HWND)GetWindowLongA(v1, -21);
+	if ( result )
+	{
+		result = (HWND)*((_DWORD *)result + 3);
+		if ( result )
+		{
+			v3 = (const char *)dword_1002A4DC;
+			if ( result != (HWND)dword_1002A4DC )
+			{
+				while ( v3 && *(HWND *)v3 != result )
+					v3 = *(const char **)v3;
+				TitleSnd_10010315();
+				v4 = GetParent(v1);
+				SelModem_1000E932(v4, v3);
+				v5 = GetParent(v1);
+				result = SelModem_1000E7E9(v5);
+			}
+		}
+	}
+	return result;
+} */
+// 1002A4DC: using guessed type int dword_1002A4DC;
+
+// ref: 0x1000EE29
+int __fastcall SelModem_1000EE29(int a1, int a2) { return 0; }
+/* {
+	int v2; // esi
+	int v3; // edi
+	HWND v4; // eax
+	LONG v5; // eax
+	int v6; // eax
+
+	v2 = a2;
+	v3 = a1;
+	TitleSnd_1001031F();
+	if ( v2 == 1 )
+	{
+		v4 = GetFocus();
+		if ( v4 )
+		{
+			v5 = GetWindowLongA(v4, -21);
+			if ( v5 )
+			{
+				v6 = *(_DWORD *)(v5 + 12);
+				if ( v6 )
+					dword_1002A4E4 = *(_DWORD *)(v6 + 4);
+			}
+		}
+	}
+	Fade_100073B4();
+	Fade_100072BE(10);
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 1002A4E4: using guessed type int dword_1002A4E4;
+
+// ref: 0x1000EE78
+HWND __fastcall SelModem_1000EE78(HWND hWnd, int a2, int a3) { return 0; }
+/* {
+	int v3; // ebx
+	HWND v4; // esi
+	int v5; // ST08_4
+	HWND v6; // eax
+	int v7; // edx
+	HWND result; // eax
+	HWND v9; // eax
+	HWND v10; // eax
+	HWND v11; // eax
+	int v12; // eax
+	int v13; // eax
+	int v14; // eax
+	HWND v15; // eax
+	HWND v16; // eax
+	HWND v17; // eax
+	HWND v18; // eax
+
+	v3 = a2;
+	v4 = hWnd;
+	v5 = a2;
+	v6 = GetDlgItem(hWnd, 1056);
+	if ( local_10007C3B(v4, v6, v5, a3) )
+	{
+		v7 = 1;
+		return (HWND)SelModem_1000EE29((int)v4, v7);
+	}
+	v9 = GetDlgItem(v4, 1054);
+	if ( local_10007C3B(v4, v9, v3, a3) )
+	{
+		v7 = 2;
+		return (HWND)SelModem_1000EE29((int)v4, v7);
+	}
+	v10 = GetDlgItem(v4, 1105);
+	result = (HWND)local_10007C3B(v4, v10, v3, a3);
+	if ( result )
+	{
+		v11 = GetDlgItem(v4, 1105);
+		v12 = Sbar_100099DC(v11, v3, a3) - 1;
+		if ( v12 )
+		{
+			v13 = v12 - 1;
+			if ( v13 )
+			{
+				v14 = v13 - 1;
+				if ( v14 )
+				{
+					result = (HWND)(v14 - 1);
+					if ( !result )
+					{
+						v15 = GetFocus();
+						result = SelModem_1000EC0E(v15);
+					}
+				}
+				else
+				{
+					v16 = GetFocus();
+					result = SelModem_1000ECB2(v16);
+				}
+			}
+			else
+			{
+				v17 = GetFocus();
+				result = SelModem_1000ED3B(v17);
+			}
+		}
+		else
+		{
+			v18 = GetFocus();
+			result = SelModem_1000EDBC(v18);
+		}
+	}
+	return result;
+} */

--- a/DiabloUI/selregn.cpp
+++ b/DiabloUI/selregn.cpp
@@ -1,0 +1,892 @@
+// ref: 0x1000EF42
+int SelRegn_1000EF42() { return 0; }
+/* {
+	return SMemAlloc(136, "C:\\Src\\Diablo\\DiabloUI\\SelRegn.cpp", 76, 0);
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000EF56
+_DWORD *__fastcall SelRegn_1000EF56(int a1, _DWORD *a2) { return 0; }
+/* {
+	_DWORD *result; // eax
+
+	result = a2;
+	*a2 = a1;
+	return result;
+} */
+
+// ref: 0x1000EF60
+signed int SelRegn_1000EF60() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A4F0 = 2139095040;
+	return result;
+} */
+// 1002A4F0: using guessed type int dword_1002A4F0;
+
+// ref: 0x1000EF6B
+int __stdcall SelRegn_1000EF6B(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	HWND v6; // eax
+	int v7; // [esp+0h] [ebp-Ch]
+
+	if ( Msg > 0x201 )
+	{
+		if ( Msg == 514 )
+		{
+			v6 = GetDlgItem(hWnd, 1105);
+			if ( !Sbar_100099C0(v6) )
+				return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+			goto LABEL_27;
+		}
+		if ( Msg != 515 )
+		{
+			if ( Msg != 2024 )
+				return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+			if ( !Fade_1000739F() )
+				Fade_100073FD(hWnd, v7);
+			return 0;
+		}
+LABEL_25:
+		SelRegn_1000F929(hWnd, (unsigned short)lParam, (unsigned int)lParam >> 16);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg == 513 )
+		goto LABEL_25;
+	if ( Msg == 2 )
+	{
+		SelRegn_1000F161(hWnd);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg <= 0x103 )
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	if ( Msg <= 0x105 )
+	{
+		v4 = (HWND)SDrawGetFrameWindow();
+		SendMessageA(v4, Msg, wParam, lParam);
+		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+	}
+	if ( Msg == 272 )
+	{
+		SelRegn_1000F1FC(hWnd);
+		PostMessageA(hWnd, 0x7E8u, 0, 0);
+		return 0;
+	}
+	if ( Msg == 273 )
+	{
+		if ( HIWORD(wParam) == 7 )
+		{
+			Focus_100075B7(hWnd, (HWND)lParam);
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		if ( HIWORD(wParam) != 6 )
+		{
+			if ( wParam == 327681 )
+			{
+				SelRegn_1000F8DD(hWnd);
+			}
+			else if ( (_WORD)wParam == 2 )
+			{
+				SelConn_1000AC07((int)hWnd, 2);
+			}
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		Focus_10007458((void *)lParam);
+		Focus_100075DC(hWnd, (HWND)lParam);
+		SelRegn_1000F0D7(hWnd, (unsigned short)wParam);
+LABEL_27:
+		SelRegn_1000F109(hWnd);
+	}
+	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x1000F0D7
+HWND __fastcall SelRegn_1000F0D7(HWND hDlg, int nIDDlgItem) { return 0; }
+/* {
+	HWND v2; // esi
+	HWND result; // eax
+
+	v2 = hDlg;
+	result = GetDlgItem(hDlg, nIDDlgItem);
+	if ( result )
+	{
+		result = (HWND)GetWindowLongA(result, -21);
+		if ( result )
+		{
+			if ( *((_DWORD *)result + 3) )
+				result = (HWND)Doom_10006A13(v2, (int *)&unk_10023250, 1);
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000F109
+HWND UNKCALL SelRegn_1000F109(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	int v2; // eax
+
+	v1 = hDlg;
+	v2 = SelRegn_1000F126();
+	return Sbar_10009A99(v1, 1105, dword_1002A4F4, v2);
+} */
+
+// ref: 0x1000F126
+int SelRegn_1000F126() { return 0; }
+/* {
+	HWND v0; // eax
+	LONG v1; // eax
+	_DWORD *v2; // ecx
+	_DWORD *v3; // eax
+	int v5; // edx
+
+	v0 = GetFocus();
+	if ( !v0 )
+		return 0;
+	v1 = GetWindowLongA(v0, -21);
+	if ( !v1 )
+		return 0;
+	v2 = (_DWORD *)dword_1002A4EC;
+	if ( !dword_1002A4EC )
+		return 0;
+	v3 = *(_DWORD **)(v1 + 12);
+	if ( !v3 )
+		return 0;
+	v5 = 0;
+	do
+	{
+		if ( v2 == v3 )
+			break;
+		v2 = (_DWORD *)*v2;
+		++v5;
+	}
+	while ( v2 );
+	return v5;
+} */
+// 1002A4EC: using guessed type int dword_1002A4EC;
+
+// ref: 0x1000F161
+void UNKCALL SelRegn_1000F161(HWND hDlg) { return; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	Title_100100E7(hDlg);
+	Focus_10007818(v1);
+	Sbar_10009CD2(v1, 1105);
+	SelRegn_1000F1D4((_DWORD *)dword_1002A4EC);
+	Doom_10006C53(v1, &dword_1002326C);
+	Doom_10006C53(v1, (int *)&unk_10023260);
+	Doom_10006C53(v1, (int *)&unk_10023244);
+	Doom_10006C53(v1, (int *)&unk_10023258);
+	Doom_10006C53(v1, (int *)&unk_10023250);
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+} */
+// 1002326C: using guessed type int dword_1002326C;
+// 1002A4EC: using guessed type int dword_1002A4EC;
+
+// ref: 0x1000F1D4
+int __fastcall SelRegn_1000F1D4(_DWORD *a1) { return 0; }
+/* {
+	_DWORD *v1; // esi
+	int result; // eax
+
+	if ( a1 )
+	{
+		do
+		{
+			v1 = (_DWORD *)*a1;
+			result = SelRegn_1000F1E8(a1);
+			a1 = v1;
+		}
+		while ( v1 );
+	}
+	return result;
+} */
+
+// ref: 0x1000F1E8
+int UNKCALL SelRegn_1000F1E8(void *arg) { return 0; }
+/* {
+	int result; // eax
+
+	if ( arg )
+		result = SMemFree(arg, "C:\\Src\\Diablo\\DiabloUI\\SelRegn.cpp", 82, 0);
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000F1FC
+HWND UNKCALL SelRegn_1000F1FC(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // ST1C_4
+	int v3; // eax
+	int *v4; // edi
+	HWND result; // eax
+	HWND v6; // eax
+	HWND v7; // [esp+0h] [ebp-Ch]
+
+	v1 = hWnd;
+	SelRegn_1000F3C2(hWnd);
+	Focus_100077E9((int)v1, "ui_art\\focus16.pcx", v7);
+	Title_1001009E(v1, (int)"ui_art\\smlogo.pcx", v2);
+	v3 = local_10007F46();
+	v4 = (int *)v3;
+	if ( v3 )
+	{
+		SetWindowLongA(v1, -21, v3);
+		local_10007944((int)v1, 0, &byte_10029448, -1, 1, (int)"ui_art\\selregn.pcx", v4, v4 + 1, 0);
+		Fade_100073C5(v1, 1);
+	}
+	Doom_100068AB(v1, (int *)&unk_10023250, 1);
+	Doom_100068AB(v1, (int *)&unk_10023258, 1);
+	Doom_100068AB(v1, (int *)&unk_10023244, 5);
+	Doom_1000658C(v1, (int *)&unk_10023260, 4, 0);
+	Doom_1000658C(v1, &dword_1002326C, 0, 1);
+	dword_1002A4F4 = 0;
+	dword_1002A4EC = 0;
+	SelRegn_1000F2ED();
+	SelRegn_1000F346(v1, (const char *)dword_1002A4EC);
+	result = Sbar_10009BF1(v1, 1105);
+	if ( dword_1002A4F4 <= 6 )
+	{
+		v6 = GetDlgItem(v1, 1105);
+		result = (HWND)ShowWindow(v6, 0);
+	}
+	return result;
+} */
+// 1002326C: using guessed type int dword_1002326C;
+// 1002A4EC: using guessed type int dword_1002A4EC;
+
+// ref: 0x1000F2ED
+signed int SelRegn_1000F2ED() { return 0; }
+/* {
+	signed int i; // edi
+	char *v1; // eax
+	char *v2; // esi
+	const char *v3; // eax
+	_DWORD *v4; // eax
+
+	for ( i = dword_10029488; ; --i )
+	{
+		if ( i <= 0 )
+			return 1;
+		v1 = (char *)SelRegn_1000EF42();
+		v2 = v1;
+		if ( !v1 )
+			break;
+		*(_DWORD *)v1 = 0;
+		*((_DWORD *)v1 + 1) = i;
+		v3 = BNetGW_10002B21(&unk_10029480, i);
+		strcpy(v2 + 8, v3);
+		v4 = SelRegn_1000EF56(dword_1002A4EC, v2);
+		++dword_1002A4F4;
+		dword_1002A4EC = (int)v4;
+	}
+	return 0;
+} */
+// 10029488: using guessed type int dword_10029488;
+// 1002A4EC: using guessed type int dword_1002A4EC;
+
+// ref: 0x1000F346
+int __fastcall SelRegn_1000F346(HWND a1, const char *a2) { return 0; }
+/* {
+	const char *v2; // edi
+	int *v3; // ebx
+	HWND v4; // eax
+	HWND v5; // esi
+	int v6; // eax
+	HWND hDlg; // [esp+8h] [ebp-4h]
+
+	v2 = a2;
+	hDlg = a1;
+	v3 = &dword_1002326C;
+	if ( dword_1002326C )
+	{
+		do
+		{
+			v4 = GetDlgItem(hDlg, *v3);
+			v5 = v4;
+			if ( v4 )
+			{
+				if ( v2 )
+				{
+					EnableWindow(v4, 1);
+					v6 = GetWindowLongA(v5, -21);
+					if ( v6 )
+					{
+						*(_DWORD *)(v6 + 12) = v2;
+						local_10007FA4(v6, v2 + 8);
+						v2 = *(const char **)v2;
+					}
+				}
+				else
+				{
+					EnableWindow(v4, 0);
+				}
+			}
+			++v3;
+		}
+		while ( *v3 );
+	}
+	return Doom_1000680A(hDlg, &dword_1002326C, 0, 1);
+} */
+// 1002326C: using guessed type int dword_1002326C;
+
+// ref: 0x1000F3C2
+void UNKCALL SelRegn_1000F3C2(HWND hDlg) { return; }
+/* {
+	HWND v1; // ebx
+	int *v2; // edi
+	HWND v3; // eax
+	HWND v4; // esi
+	void *v5; // eax
+
+	v1 = hDlg;
+	v2 = &dword_1002326C;
+	if ( dword_1002326C )
+	{
+		do
+		{
+			v3 = GetDlgItem(v1, *v2);
+			v4 = v3;
+			if ( v3 )
+			{
+				v5 = (void *)GetWindowLongA(v3, -4);
+				SetPropA(v4, "UIOLDPROC", v5);
+				SetWindowLongA(v4, -4, (LONG)SelRegn_1000F414);
+			}
+			++v2;
+		}
+		while ( *v2 );
+	}
+} */
+// 1002326C: using guessed type int dword_1002326C;
+
+// ref: 0x1000F414
+LRESULT __stdcall SelRegn_1000F414(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	LRESULT (__stdcall *v4)(HWND, UINT, WPARAM, LPARAM); // edi
+	HWND v5; // eax
+	WPARAM v7; // [esp-8h] [ebp-14h]
+
+	v4 = (LRESULT (__stdcall *)(HWND, UINT, WPARAM, LPARAM))GetPropA(hWnd, "UIOLDPROC");
+	switch ( Msg )
+	{
+		case 2u:
+			RemovePropA(hWnd, "UIOLDPROC");
+			if ( !v4 )
+				return DefWindowProcA(hWnd, Msg, wParam, lParam);
+			SetWindowLongA(hWnd, -4, (LONG)v4);
+			break;
+		case 0xFu:
+			local_10007C95(hWnd);
+			return 0;
+		case 0x87u:
+			return 4;
+		case 0x100u:
+			if ( wParam > 0x21 )
+			{
+				if ( wParam == 34 )
+				{
+					SelRegn_1000F61E(hWnd);
+				}
+				else if ( wParam > 0x24 )
+				{
+					if ( wParam <= 0x26 )
+					{
+						SelRegn_1000F859(hWnd);
+					}
+					else if ( wParam <= 0x28 )
+					{
+						SelRegn_1000F7C1(hWnd);
+					}
+				}
+				return 0;
+			}
+			if ( wParam == 33 )
+			{
+				SelRegn_1000F711(hWnd);
+				return 0;
+			}
+			if ( wParam == 9 )
+			{
+				if ( GetKeyState(16) >= 0 )
+					SelRegn_1000F53C(hWnd);
+				else
+					SelRegn_1000F5AD(hWnd);
+				return 0;
+			}
+			if ( wParam != 13 )
+			{
+				if ( wParam == 27 )
+				{
+					v7 = 2;
+					goto LABEL_13;
+				}
+				if ( wParam != 32 )
+					return 0;
+			}
+			v7 = 1;
+LABEL_13:
+			v5 = GetParent(hWnd);
+			SendMessageA(v5, 0x111u, v7, 0);
+			return 0;
+	}
+	if ( v4 )
+		return CallWindowProcA(v4, hWnd, Msg, wParam, lParam);
+	return DefWindowProcA(hWnd, Msg, wParam, lParam);
+} */
+
+// ref: 0x1000F53C
+HWND UNKCALL SelRegn_1000F53C(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // ebx
+	int nIDDlgItem[1132]; // [esp+0h] [ebp-11D4h]
+	int v5; // [esp+11B0h] [ebp-24h]
+	int v6; // [esp+11BCh] [ebp-18h]
+	int v7; // [esp+11C0h] [ebp-14h]
+	int v8; // [esp+11C4h] [ebp-10h]
+	int v9; // [esp+11C8h] [ebp-Ch]
+	int v10; // [esp+11CCh] [ebp-8h]
+	int v11; // [esp+11D0h] [ebp-4h]
+
+	v1 = hWnd;
+	v6 = 1136;
+	v7 = 1137;
+	v8 = 1138;
+	v9 = 1139;
+	v10 = 1140;
+	v11 = 1135;
+	v2 = GetParent(hWnd);
+	do
+	{
+		v5 = nIDDlgItem[GetWindowLongA(v1, -12)];
+		v1 = GetDlgItem(v2, v5);
+	}
+	while ( !IsWindowEnabled(v1) );
+	return SetFocus(v1);
+} */
+// 1000F53C: using guessed type int nIDDlgItem[1132];
+
+// ref: 0x1000F5AD
+HWND UNKCALL SelRegn_1000F5AD(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND v2; // ebx
+	int nIDDlgItem[1132]; // [esp+0h] [ebp-11D4h]
+	int v5; // [esp+11B0h] [ebp-24h]
+	int v6; // [esp+11BCh] [ebp-18h]
+	int v7; // [esp+11C0h] [ebp-14h]
+	int v8; // [esp+11C4h] [ebp-10h]
+	int v9; // [esp+11C8h] [ebp-Ch]
+	int v10; // [esp+11CCh] [ebp-8h]
+	int v11; // [esp+11D0h] [ebp-4h]
+
+	v1 = hWnd;
+	v6 = 1140;
+	v7 = 1135;
+	v8 = 1136;
+	v9 = 1137;
+	v10 = 1138;
+	v11 = 1139;
+	v2 = GetParent(hWnd);
+	do
+	{
+		v5 = nIDDlgItem[GetWindowLongA(v1, -12)];
+		v1 = GetDlgItem(v2, v5);
+	}
+	while ( !IsWindowEnabled(v1) );
+	return SetFocus(v1);
+} */
+// 1000F5AD: using guessed type int nIDDlgItem[1132];
+
+// ref: 0x1000F61E
+HWND UNKCALL SelRegn_1000F61E(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // ebp
+	HWND result; // eax
+	HWND v3; // esi
+	HWND v4; // ebx
+	HWND v5; // eax
+	_DWORD *v6; // eax
+	int v7; // eax
+	const char *v8; // ebx
+	int v9; // eax
+
+	v1 = hWnd;
+	result = GetParent(hWnd);
+	v3 = result;
+	if ( result )
+	{
+		result = GetDlgItem(result, 1135);
+		v4 = result;
+		if ( result )
+		{
+			v5 = GetDlgItem(v3, 1140);
+			result = (HWND)GetWindowLongA(v5, -21);
+			if ( result )
+			{
+				v6 = (_DWORD *)*((_DWORD *)result + 3);
+				if ( v6 && *v6 )
+				{
+					v7 = SelRegn_1000F6C9(v4) + 6;
+					if ( v7 > dword_1002A4F4 - 6 )
+						v7 = dword_1002A4F4 - 6;
+					result = (HWND)SelRegn_1000F6FE(v7);
+					v8 = (const char *)result;
+					if ( result )
+					{
+						TitleSnd_10010315();
+						SelRegn_1000F346(v3, v8);
+						v9 = GetWindowLongA(v1, -12);
+						SelRegn_1000F0D7(v3, v9);
+						result = SelRegn_1000F109(v3);
+					}
+				}
+				else
+				{
+					result = SelRegn_1000F5AD(v4);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000F6C9
+int UNKCALL SelRegn_1000F6C9(HWND hWnd) { return 0; }
+/* {
+	LONG v1; // eax
+	_DWORD *v2; // ecx
+	_DWORD *v3; // eax
+	int v5; // edx
+
+	if ( !hWnd )
+		return 0;
+	v1 = GetWindowLongA(hWnd, -21);
+	if ( !v1 )
+		return 0;
+	v2 = (_DWORD *)dword_1002A4EC;
+	if ( !dword_1002A4EC )
+		return 0;
+	v3 = *(_DWORD **)(v1 + 12);
+	if ( !v3 )
+		return 0;
+	v5 = 0;
+	do
+	{
+		if ( v2 == v3 )
+			break;
+		v2 = (_DWORD *)*v2;
+		++v5;
+	}
+	while ( v2 );
+	return v5;
+} */
+// 1002A4EC: using guessed type int dword_1002A4EC;
+
+// ref: 0x1000F6FE
+_DWORD *__fastcall SelRegn_1000F6FE(int a1) { return 0; }
+/* {
+	_DWORD *result; // eax
+
+	result = (_DWORD *)dword_1002A4EC;
+	while ( result && a1 )
+	{
+		result = (_DWORD *)*result;
+		--a1;
+	}
+	return result;
+} */
+// 1002A4EC: using guessed type int dword_1002A4EC;
+
+// ref: 0x1000F711
+HWND UNKCALL SelRegn_1000F711(HWND hWnd) { return 0; }
+/* {
+	HWND result; // eax
+	HWND v2; // esi
+	HWND v3; // edi
+	HWND v4; // eax
+	int v5; // eax
+	const char *v6; // edi
+	int v7; // eax
+	HWND hWnda; // [esp+10h] [ebp-4h]
+
+	hWnda = hWnd;
+	result = GetParent(hWnd);
+	v2 = result;
+	if ( result )
+	{
+		result = GetDlgItem(result, 1135);
+		v3 = result;
+		if ( result )
+		{
+			result = (HWND)GetWindowLongA(result, -21);
+			if ( result )
+			{
+				result = (HWND)*((_DWORD *)result + 3);
+				if ( result )
+				{
+					if ( result == (HWND)dword_1002A4EC )
+					{
+						v4 = GetDlgItem(v2, 1140);
+						result = SelRegn_1000F53C(v4);
+					}
+					else
+					{
+						v5 = SelRegn_1000F6C9(v3) - 6;
+						if ( v5 < 0 )
+							v5 = 0;
+						result = (HWND)SelRegn_1000F6FE(v5);
+						v6 = (const char *)result;
+						if ( result )
+						{
+							TitleSnd_10010315();
+							SelRegn_1000F346(v2, v6);
+							v7 = GetWindowLongA(hWnda, -12);
+							SelRegn_1000F0D7(v2, v7);
+							result = SelRegn_1000F109(v2);
+						}
+					}
+				}
+			}
+		}
+	}
+	return result;
+} */
+// 1002A4EC: using guessed type int dword_1002A4EC;
+
+// ref: 0x1000F7C1
+HWND UNKCALL SelRegn_1000F7C1(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND result; // eax
+	HWND v3; // eax
+	const char *v4; // ebp
+	HWND v5; // eax
+	int v6; // ebx
+	HWND v7; // eax
+	HWND v8; // eax
+
+	v1 = hWnd;
+	result = (HWND)GetWindowLongA(hWnd, -21);
+	if ( result )
+	{
+		result = (HWND)*((_DWORD *)result + 3);
+		if ( result )
+		{
+			if ( *(_DWORD *)result )
+			{
+				if ( GetWindowLongA(v1, -12) >= 1140 )
+				{
+					v3 = GetParent(v1);
+					result = GetDlgItem(v3, 1136);
+					if ( result )
+					{
+						result = (HWND)GetWindowLongA(result, -21);
+						if ( result )
+						{
+							v4 = (const char *)*((_DWORD *)result + 3);
+							if ( v4 )
+							{
+								TitleSnd_10010315();
+								v5 = GetParent(v1);
+								SelRegn_1000F346(v5, v4);
+								v6 = GetWindowLongA(v1, -12);
+								v7 = GetParent(v1);
+								SelRegn_1000F0D7(v7, v6);
+								v8 = GetParent(v1);
+								result = SelRegn_1000F109(v8);
+							}
+						}
+					}
+				}
+				else
+				{
+					result = SelRegn_1000F53C(v1);
+				}
+			}
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000F859
+HWND UNKCALL SelRegn_1000F859(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // edi
+	HWND result; // eax
+	const char *v3; // ebx
+	HWND v4; // eax
+	int v5; // ebx
+	HWND v6; // eax
+	HWND v7; // eax
+
+	v1 = hWnd;
+	if ( GetWindowLongA(hWnd, -12) > 1135 )
+		return SelRegn_1000F5AD(v1);
+	result = (HWND)GetWindowLongA(v1, -21);
+	if ( result )
+	{
+		result = (HWND)*((_DWORD *)result + 3);
+		if ( result )
+		{
+			v3 = (const char *)dword_1002A4EC;
+			if ( result != (HWND)dword_1002A4EC )
+			{
+				while ( v3 && *(HWND *)v3 != result )
+					v3 = *(const char **)v3;
+				TitleSnd_10010315();
+				v4 = GetParent(v1);
+				SelRegn_1000F346(v4, v3);
+				v5 = GetWindowLongA(v1, -12);
+				v6 = GetParent(v1);
+				SelRegn_1000F0D7(v6, v5);
+				v7 = GetParent(v1);
+				result = SelRegn_1000F109(v7);
+			}
+		}
+	}
+	return result;
+} */
+// 1002A4EC: using guessed type int dword_1002A4EC;
+
+// ref: 0x1000F8DD
+signed int UNKCALL SelRegn_1000F8DD(void *arg) { return 0; }
+/* {
+	int v1; // esi
+	signed int result; // eax
+
+	v1 = (int)arg;
+	result = SelRegn_1000F8F6();
+	if ( result )
+		result = SelConn_1000AC07(v1, 1);
+	return result;
+} */
+
+// ref: 0x1000F8F6
+signed int SelRegn_1000F8F6() { return 0; }
+/* {
+	HWND v0; // eax
+	LONG v1; // eax
+	int v2; // eax
+
+	TitleSnd_1001031F();
+	v0 = GetFocus();
+	v1 = GetWindowLongA(v0, -21);
+	if ( !v1 )
+		return 0;
+	v2 = *(_DWORD *)(v1 + 12);
+	if ( !v2 )
+		return 0;
+	BNetGW_10002B51(&unk_10029480, *(_DWORD *)(v2 + 4));
+	return 1;
+} */
+
+// ref: 0x1000F929
+HWND __fastcall SelRegn_1000F929(HWND hWnd, int a2, int a3) { return 0; }
+/* {
+	int v3; // ebx
+	HWND v4; // esi
+	int v5; // ST08_4
+	HWND v6; // eax
+	HWND result; // eax
+	HWND v8; // eax
+	HWND v9; // eax
+	HWND v10; // eax
+	int v11; // eax
+	int v12; // eax
+	int v13; // eax
+	HWND v14; // eax
+	HWND v15; // eax
+	HWND v16; // eax
+	HWND v17; // eax
+
+	v3 = a2;
+	v4 = hWnd;
+	v5 = a2;
+	v6 = GetDlgItem(hWnd, 1056);
+	if ( local_10007C3B(v4, v6, v5, a3) )
+		return (HWND)SelRegn_1000F8DD(v4);
+	v8 = GetDlgItem(v4, 1054);
+	if ( local_10007C3B(v4, v8, v3, a3) )
+		return (HWND)SelConn_1000AC07((int)v4, 2);
+	v9 = GetDlgItem(v4, 1105);
+	result = (HWND)local_10007C3B(v4, v9, v3, a3);
+	if ( result )
+	{
+		v10 = GetDlgItem(v4, 1105);
+		v11 = Sbar_100099DC(v10, v3, a3) - 1;
+		if ( v11 )
+		{
+			v12 = v11 - 1;
+			if ( v12 )
+			{
+				v13 = v12 - 1;
+				if ( v13 )
+				{
+					result = (HWND)(v13 - 1);
+					if ( !result )
+					{
+						v14 = GetFocus();
+						result = SelRegn_1000F61E(v14);
+					}
+				}
+				else
+				{
+					v15 = GetFocus();
+					result = SelRegn_1000F711(v15);
+				}
+			}
+			else
+			{
+				v16 = GetFocus();
+				result = SelRegn_1000F7C1(v16);
+			}
+		}
+		else
+		{
+			v17 = GetFocus();
+			result = SelRegn_1000F859(v17);
+		}
+	}
+	return result;
+} */
+
+// ref: 0x1000F9F7
+signed int __stdcall UiSelectRegion(_DWORD *a1) { return 0; }
+/* {
+	int v1; // eax
+	int v2; // eax
+	signed int result; // eax
+
+	artfont_10001159();
+	v1 = SDrawGetFrameWindow();
+	v2 = SDlgDialogBoxParam(hInstance, "SELREGION_DIALOG", v1, SelRegn_1000EF6B, 0);
+	if ( a1 )
+		*a1 = dword_1002948C;
+	if ( v2 == 1 )
+	{
+		local_100078B6();
+		result = 1;
+	}
+	else
+	{
+		SErrSetLastError(1223);
+		result = 0;
+	}
+	return result;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 1002948C: using guessed type int dword_1002948C;

--- a/DiabloUI/selyesno.cpp
+++ b/DiabloUI/selyesno.cpp
@@ -1,0 +1,250 @@
+// ref: 0x1000FA49
+int __fastcall SelYesNo_1000FA49(int a1, const CHAR *a2, int a3, int a4) { return 0; }
+/* {
+	dword_1002A4F8 = a2;
+	dword_1002A504 = a3;
+	dword_1002A500 = a4;
+	dword_1002A50C = 0;
+	dword_1002A508 = 0;
+	return SDlgDialogBoxParam(hInstance, "SELYESNO_DIALOG", a1, SelYesNo_1000FA87, 0);
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A500: using guessed type int dword_1002A500;
+// 1002A504: using guessed type int dword_1002A504;
+// 1002A508: using guessed type int (*dword_1002A508)(void);
+// 1002A50C: using guessed type int dword_1002A50C;
+
+// ref: 0x1000FA87
+int __stdcall SelYesNo_1000FA87(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v4; // eax
+	HWND v5; // eax
+	LONG v7; // edx
+	HWND v8; // eax
+	LONG v9; // eax
+	HWND v10; // ecx
+	HWND v11; // eax
+
+	if ( Msg == 2 )
+	{
+		SelYesNo_1000FBC7(hDlg);
+		return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+	}
+	if ( Msg > 0x103 )
+	{
+		if ( Msg <= 0x105 )
+		{
+			v11 = (HWND)SDrawGetFrameWindow();
+			SendMessageA(v11, Msg, wParam, lParam);
+			return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+		}
+		switch ( Msg )
+		{
+			case 0x110u:
+				SelYesNo_1000FC1C(hDlg);
+				return 0;
+			case 0x111u:
+				if ( HIWORD(wParam) == 7 )
+				{
+					Focus_100075B7(hDlg, (HWND)lParam);
+				}
+				else if ( HIWORD(wParam) == 6 )
+				{
+					Focus_10007458((void *)lParam);
+					Focus_100075DC(hDlg, (HWND)lParam);
+				}
+				else
+				{
+					v7 = 1;
+					if ( (_WORD)wParam == 1 )
+					{
+						v8 = GetFocus();
+						v9 = GetWindowLongA(v8, -12);
+						v10 = hDlg;
+						if ( v9 == 1109 )
+							v7 = 1;
+						else
+							v7 = 2;
+					}
+					else
+					{
+						if ( (_WORD)wParam == 2 )
+						{
+							v7 = 2;
+						}
+						else if ( (_WORD)wParam != 1109 )
+						{
+							return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+						}
+						v10 = hDlg;
+					}
+					SelYesNo_1000FCF6((int)v10, v7);
+				}
+				break;
+			case 0x113u:
+				v4 = GetFocus();
+				if ( !Focus_100075DC(hDlg, v4) )
+				{
+					v5 = GetDlgItem(hDlg, 1109);
+					if ( !v5 )
+						v5 = GetDlgItem(hDlg, 2);
+					SetFocus(v5);
+				}
+				return 0;
+		}
+	}
+	return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x1000FBC7
+HWND UNKCALL SelYesNo_1000FBC7(HWND hDlg) { return 0; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+	HWND result; // eax
+	HWND v4; // eax
+
+	v1 = hDlg;
+	v2 = (_DWORD *)GetWindowLongA(hDlg, -21);
+	local_10007F72(v2);
+	if ( dword_1002A500 )
+		Focus_100076C3();
+	Doom_10006C53(v1, (int *)&unk_100232DC);
+	result = (HWND)Doom_10006C53(v1, (int *)&unk_100232D4);
+	if ( dword_1002A504 )
+	{
+		v4 = GetParent(v1);
+		result = SelHero_1000BA7B(v4, 0);
+	}
+	return result;
+} */
+// 1002A500: using guessed type int dword_1002A500;
+// 1002A504: using guessed type int dword_1002A504;
+
+// ref: 0x1000FC1C
+int UNKCALL SelYesNo_1000FC1C(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	HWND v2; // eax
+	int v3; // eax
+	int *v4; // edi
+	const char *v5; // eax
+	const CHAR *v6; // ST18_4
+	HWND v7; // eax
+
+	v1 = hWnd;
+	v2 = GetParent(hWnd);
+	if ( dword_1002A504 )
+		SelHero_1000BA7B(v2, (const char *)dword_1002A504);
+	v3 = local_10007F46();
+	v4 = (int *)v3;
+	if ( v3 )
+	{
+		SetWindowLongA(v1, -21, v3);
+		if ( dword_1002A50C )
+		{
+			if ( DiabloUI_10005C2A() )
+				v5 = "ui_art\\swmmpop.pcx";
+			else
+				v5 = "ui_art\\mmpopup.pcx";
+		}
+		else
+		{
+			v5 = "ui_art\\black.pcx";
+		}
+		local_10007944((int)v1, 0, "Popup", -1, 1, (int)v5, v4, v4 + 1, 1);
+	}
+	v6 = dword_1002A4F8;
+	v7 = GetDlgItem(v1, 1026);
+	SetWindowTextA(v7, v6);
+	Doom_100068AB(v1, (int *)&unk_100232D4, 3);
+	Doom_1000658C(v1, (int *)&unk_100232DC, 4, 1);
+	if ( dword_1002A500 )
+		Focus_10007719("ui_art\\focus.pcx");
+	else
+		Focus_100076FA();
+	SDlgSetTimer(v1, 1, 55, 0);
+	return local_10007DE9(v1, (int *)&unk_100232DC);
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A500: using guessed type int dword_1002A500;
+// 1002A504: using guessed type int dword_1002A504;
+// 1002A50C: using guessed type int dword_1002A50C;
+
+// ref: 0x1000FCF6
+int __fastcall SelYesNo_1000FCF6(int a1, LONG a2) { return 0; }
+/* {
+	LONG v2; // esi
+	int v3; // edi
+	HWND v4; // eax
+
+	v2 = a2;
+	v3 = a1;
+	TitleSnd_1001031F();
+	SDlgKillTimer(v3, 1);
+	if ( v2 == 2 )
+	{
+		if ( !dword_1002A508 )
+			return SDlgEndDialog(v3, v2);
+		dword_1002A508();
+	}
+	if ( v2 == 1 )
+	{
+		v4 = GetFocus();
+		v2 = GetWindowLongA(v4, -12);
+	}
+	return SDlgEndDialog(v3, v2);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 1002A508: using guessed type int (*dword_1002A508)(void);
+
+// ref: 0x1000FD39
+int __fastcall SelYesNo_1000FD39(int a1, const CHAR *a2, int a3, int a4) { return 0; }
+/* {
+	dword_1002A4F8 = a2;
+	dword_1002A504 = a3;
+	dword_1002A500 = a4;
+	dword_1002A50C = 0;
+	dword_1002A508 = 0;
+	return SDlgDialogBoxParam(hInstance, "SELOK_DIALOG", a1, SelYesNo_1000FA87, 0);
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A500: using guessed type int dword_1002A500;
+// 1002A504: using guessed type int dword_1002A504;
+// 1002A508: using guessed type int (*dword_1002A508)(void);
+// 1002A50C: using guessed type int dword_1002A50C;
+
+// ref: 0x1000FD77
+int __fastcall SelYesNo_1000FD77(int a1, UINT a2, int a3) { return 0; }
+/* {
+	int v3; // esi
+	CHAR Buffer; // [esp+4h] [ebp-100h]
+
+	v3 = a1;
+	LoadStringA(hInstance, a2, &Buffer, 255);
+	dword_1002A50C = a3;
+	dword_1002A500 = 0;
+	dword_1002A504 = 0;
+	dword_1002A4F8 = &Buffer;
+	dword_1002A508 = 0;
+	return SDlgDialogBoxParam(hInstance, "SPAWNERR_DIALOG", v3, SelYesNo_1000FA87, 0);
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A500: using guessed type int dword_1002A500;
+// 1002A504: using guessed type int dword_1002A504;
+// 1002A508: using guessed type int (*dword_1002A508)(void);
+// 1002A50C: using guessed type int dword_1002A50C;
+
+// ref: 0x1000FDE3
+signed int SelYesNo_1000FDE3() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A4FC = 2139095040;
+	return result;
+} */
+// 1002A4FC: using guessed type int dword_1002A4FC;

--- a/DiabloUI/title.cpp
+++ b/DiabloUI/title.cpp
@@ -1,0 +1,352 @@
+// ref: 0x1000FDEE
+_DWORD *UNKCALL Title_1000FDEE(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // edi
+	_DWORD *result; // eax
+	int v4; // eax
+	_DWORD *v5; // esi
+	struct tagRECT Rect; // [esp+Ch] [ebp-18h]
+	HWND v7; // [esp+1Ch] [ebp-8h]
+	HWND hWnda; // [esp+20h] [ebp-4h]
+
+	v1 = hWnd;
+	v7 = hWnd;
+	v2 = (_DWORD *)GetWindowLongA(hWnd, -21);
+	hWnda = GetDlgItem(v1, 1043);
+	result = (_DWORD *)IsWindowVisible(v1);
+	if ( result && hWnda && v2 && *v2 && dword_1002A510[0] )
+	{
+		v4 = dword_1002A58C + 1;
+		dword_1002A58C = v4;
+		if ( !dword_1002A510[v4] || v4 >= 30 )
+			dword_1002A58C = 0;
+		GetWindowRect(hWnda, &Rect);
+		ScreenToClient(v1, (LPPOINT)&Rect);
+		ScreenToClient(v7, (LPPOINT)&Rect.right);
+		result = GetPropA(v7, "TITLE_BUFFER");
+		v5 = result;
+		if ( result )
+		{
+			SBltROP3(*result, Rect.left + *v2 + Rect.top * v2[1], result[1], result[2], result[1], v2[1], 0, 13369376);
+			STransBlt(*v5, 0, 0, v5[1], dword_1002A510[dword_1002A58C]);
+			result = (_DWORD *)InvalidateRect(hWnda, 0, 0);
+		}
+	}
+	return result;
+} */
+// 1001036A: using guessed type int __stdcall STransBlt(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100103F4: using guessed type int __stdcall SBltROP3(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A58C: using guessed type int dword_1002A58C;
+
+// ref: 0x1000FEED
+int Title_1000FEED() { return 0; }
+/* {
+	int *v0; // esi
+	int result; // eax
+
+	v0 = dword_1002A510;
+	do
+	{
+		result = *v0;
+		if ( *v0 )
+		{
+			result = STransDelete(*v0);
+			*v0 = 0;
+		}
+		++v0;
+	}
+	while ( (signed int)v0 < (signed int)&dword_1002A588 );
+	return result;
+} */
+// 1001033A: using guessed type int __stdcall STransDelete(_DWORD);
+// 1002A588: using guessed type int dword_1002A588;
+
+// ref: 0x1000FF0F
+_DWORD *UNKCALL Title_1000FF0F(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+	_DWORD *result; // eax
+	_DWORD *v3; // esi
+	int v4; // eax
+
+	v1 = hWnd;
+	Title_1000FEED();
+	result = RemovePropA(v1, "TITLE_BUFFER");
+	v3 = result;
+	if ( result )
+	{
+		v4 = *result;
+		if ( v4 )
+		{
+			SMemFree(v4, "C:\\Src\\Diablo\\DiabloUI\\Title.cpp", 114, 0);
+			*v3 = 0;
+		}
+		result = (_DWORD *)SMemFree(v3, "C:\\Src\\Diablo\\DiabloUI\\Title.cpp", 117, 0);
+	}
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000FF51
+HWND UNKCALL Title_1000FF51(HWND arg) { return 0; }
+/* {
+	HWND result; // eax
+	int *v2; // esi
+	int v3; // eax
+	struct tagRECT Rect; // [esp+0h] [ebp-18h]
+	HWND v5; // [esp+10h] [ebp-8h]
+	HWND hDlg; // [esp+14h] [ebp-4h]
+
+	hDlg = arg;
+	Title_1000FF0F(arg);
+	result = GetDlgItem(hDlg, 1043);
+	v5 = result;
+	if ( result )
+	{
+		GetClientRect(result, &Rect);
+		v2 = (int *)SMemAlloc(12, "C:\\Src\\Diablo\\DiabloUI\\Title.cpp", 134, 0);
+		v3 = SMemAlloc(Rect.right * Rect.bottom, "C:\\Src\\Diablo\\DiabloUI\\Title.cpp", 136, 8);
+		*v2 = v3;
+		v2[1] = Rect.right;
+		v2[2] = Rect.bottom;
+		SDlgSetBitmapI(v5, 0, 0, -1, 1, v3, 0, Rect.right, Rect.bottom, -1);
+		result = (HWND)SetPropA(hDlg, "TITLE_BUFFER", v2);
+	}
+	return result;
+} */
+// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x1000FFE8
+_DWORD *__fastcall Title_1000FFE8(HWND hWnd, int a2) { return 0; }
+/* {
+	HWND v2; // esi
+	int v3; // edi
+	_DWORD *result; // eax
+	int v5; // esi
+	int v6; // ebx
+	int v7; // [esp+8h] [ebp-20h]
+	int v8; // [esp+Ch] [ebp-1Ch]
+	int v9; // [esp+10h] [ebp-18h]
+	int v10; // [esp+14h] [ebp-14h]
+	char v11; // [esp+18h] [ebp-10h]
+	int v12; // [esp+1Ch] [ebp-Ch]
+	int *v13; // [esp+20h] [ebp-8h]
+	int v14; // [esp+24h] [ebp-4h]
+
+	v2 = hWnd;
+	v3 = 0;
+	v14 = 0;
+	local_100078BE(a2, &v14, &v11);
+	result = GetPropA(v2, "TITLE_BUFFER");
+	v5 = (int)result;
+	if ( v14 )
+	{
+		if ( result )
+		{
+			v6 = v12 / result[2];
+			if ( v6 > 30 )
+				v6 = 30;
+			if ( v6 > 0 )
+			{
+				v13 = dword_1002A510;
+				do
+				{
+					v7 = 0;
+					v9 = *(_DWORD *)(v5 + 4) - 1;
+					v8 = v3 * *(_DWORD *)(v5 + 8);
+					v10 = *(_DWORD *)(v5 + 8) + v8 - 1;
+					STransCreateI(v14, *(_DWORD *)(v5 + 4), *(_DWORD *)(v5 + 8), 8, &v7, 16777466, v13);
+					++v13;
+					++v3;
+				}
+				while ( v3 < v6 );
+			}
+		}
+		result = (_DWORD *)SMemFree(v14, "C:\\Src\\Diablo\\DiabloUI\\Title.cpp", 197, 0);
+	}
+	dword_1002A58C = 0;
+	return result;
+} */
+// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010346: using guessed type int __stdcall STransCreateI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1002A58C: using guessed type int dword_1002A58C;
+
+// ref: 0x1001009E
+int __fastcall Title_1001009E(HWND hWnd, int a2, HWND hWnda) { return 0; }
+/* {
+	int v3; // edi
+	HWND v4; // esi
+
+	v3 = a2;
+	v4 = hWnd;
+	Title_1000FF51(hWnd);
+	Title_1000FFE8(v4, v3);
+	Title_1000FDEE(v4);
+	return SDlgSetTimer(v4, 2, 55, Title_100100CB);
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x100100CB
+_DWORD *__stdcall Title_100100CB(HWND hWnd, int a2, int a3, int a4) { return 0; }
+/* {
+	return Title_1000FDEE(hWnd);
+} */
+
+// ref: 0x100100DC
+signed int Title_100100DC() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A588 = 2139095040;
+	return result;
+} */
+// 1002A588: using guessed type int dword_1002A588;
+
+// ref: 0x100100E7
+_DWORD *UNKCALL Title_100100E7(HWND hWnd) { return 0; }
+/* {
+	HWND v1; // esi
+
+	v1 = hWnd;
+	SDlgKillTimer(hWnd, 2);
+	return Title_1000FF0F(v1);
+} */
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+
+// ref: 0x100100FA
+void __stdcall UiTitleDialog(int a1) { return; }
+/* {
+	int v1; // eax
+
+	artfont_10001159();
+	v1 = SDrawGetFrameWindow();
+	SDlgDialogBoxParam(hInstance, "TITLESCREEN_DIALOG", v1, Title_10010126, a1);
+	return 1;
+} */
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x10010126
+int __stdcall Title_10010126(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
+/* {
+	HWND v5; // eax
+	int v6; // [esp+0h] [ebp-8h]
+
+	if ( Msg <= 0x111 )
+	{
+		if ( Msg != 273 )
+		{
+			if ( Msg != 2 )
+			{
+				if ( Msg == 135 )
+					return 4;
+				if ( Msg != 256 )
+				{
+					if ( Msg > 0x103 )
+					{
+						if ( Msg <= 0x105 )
+						{
+							v5 = (HWND)SDrawGetFrameWindow();
+							SendMessageA(v5, Msg, wParam, lParam);
+						}
+						else if ( Msg == 272 )
+						{
+							Title_1001025A(hWnd, lParam);
+							PostMessageA(hWnd, 0x7E8u, 0, 0);
+							return 1;
+						}
+					}
+					return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+				}
+				goto LABEL_25;
+			}
+			Title_10010235(hWnd);
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+		goto LABEL_25;
+	}
+	if ( Msg != 275 )
+	{
+		if ( Msg != 513 && Msg != 516 )
+		{
+			if ( Msg == 528 )
+			{
+				if ( (_WORD)wParam == 513 || (_WORD)wParam == 516 )
+					Title_100102D7(hWnd);
+			}
+			else if ( Msg == 2024 )
+			{
+				if ( !Fade_1000739F() )
+					Fade_100073FD(hWnd, v6);
+				return 0;
+			}
+			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		}
+LABEL_25:
+		Title_100102D7(hWnd);
+		return 0;
+	}
+	if ( wParam == 1 )
+		goto LABEL_25;
+	return 0;
+} */
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+
+// ref: 0x10010235
+void UNKCALL Title_10010235(HWND hDlg) { return; }
+/* {
+	HWND v1; // esi
+	_DWORD *v2; // eax
+
+	v1 = hDlg;
+	Title_100100E7(hDlg);
+	Doom_10006C53(v1, (int *)&unk_10023340);
+	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	local_10007F72(v2);
+} */
+
+// ref: 0x1001025A
+int __fastcall Title_1001025A(HWND hWnd, int a2) { return 0; }
+/* {
+	int v2; // ebx
+	HWND v3; // esi
+	int *v4; // edi
+	int result; // eax
+	HWND v6; // [esp+0h] [ebp-Ch]
+
+	v2 = a2;
+	v3 = hWnd;
+	v4 = (int *)local_10007F46();
+	SetWindowLongA(v3, -21, (LONG)v4);
+	if ( v4 )
+	{
+		local_10007944((int)v3, 0, &byte_10029448, -1, 1, (int)"ui_art\\title.pcx", v4, v4 + 1, 0);
+		Fade_100073C5(v3, 0);
+	}
+	Doom_100068AB(v3, (int *)&unk_10023340, 3);
+	Title_1001009E(v3, (int)"ui_art\\logo.pcx", v6);
+	if ( v2 )
+		result = SDlgSetTimer(v3, 1, 1000 * v2, 0);
+	else
+		result = SDlgSetTimer(v3, 1, 5000, 0);
+	return result;
+} */
+// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+
+// ref: 0x100102D7
+int UNKCALL Title_100102D7(void *arg) { return 0; }
+/* {
+	void *v1; // esi
+
+	v1 = arg;
+	Fade_100073B4();
+	SDlgKillTimer(v1, 1);
+	Fade_100072BE(10);
+	return SDlgEndDialog(v1, 1);
+} */
+// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);

--- a/DiabloUI/titlesnd.cpp
+++ b/DiabloUI/titlesnd.cpp
@@ -1,0 +1,49 @@
+// ref: 0x10010306
+void UNKCALL TitleSnd_10010306(void *arg) { return; }
+/* {
+	dword_1002A594 = (int (__stdcall *)(_DWORD))arg;
+} */
+// 1002A594: using guessed type int (__stdcall *dword_1002A594)(_DWORD);
+
+// ref: 0x1001030D
+void TitleSnd_1001030D() { return; }
+/* {
+	dword_1002A594 = 0;
+} */
+// 1002A594: using guessed type int (__stdcall *dword_1002A594)(_DWORD);
+
+// ref: 0x10010315
+int (__stdcall *TitleSnd_10010315())(_DWORD) { return 0; }
+/* {
+	int (__stdcall *result)(_DWORD); // eax
+
+	result = dword_1002A594;
+	if ( dword_1002A594 )
+		result = (int (__stdcall *)(_DWORD))dword_1002A594("sfx\\items\\titlemov.wav");
+	return result;
+} */
+// 1002A594: invalid function type has been ignored
+// 1002A594: using guessed type int (__stdcall *dword_1002A594)(_DWORD);
+
+// ref: 0x1001031F
+int (__stdcall *TitleSnd_1001031F())(_DWORD) { return 0; }
+/* {
+	int (__stdcall *result)(_DWORD); // eax
+
+	result = dword_1002A594;
+	if ( dword_1002A594 )
+		result = (int (__stdcall *)(_DWORD))dword_1002A594("sfx\\items\\titlslct.wav");
+	return result;
+} */
+// 1002A594: using guessed type int (__stdcall *dword_1002A594)(_DWORD);
+
+// ref: 0x1001032E
+signed int TitleSnd_1001032E() { return 0; }
+/* {
+	signed int result; // eax
+
+	result = 2139095040;
+	dword_1002A590 = 2139095040;
+	return result;
+} */
+// 1002A590: using guessed type int dword_1002A590;


### PR DESCRIPTION
A slightly different approach to reverse engineering here. Basically since we have a working version of the game already, we dont need to reverse the whole UI. Especially since a lot of code is related to Modems (which no one uses in this day and age) and battle.net (which isn't relevant for single player). The idea is that it is a lot less stressful and easier to reverse if we break things down and uncomment functions as we go, instead of having to fix *everything* all at once when only small parts are necessary for testing.

Edit: also, DiabloUI was conveniently linked in alphabetical order just like Diablo.exe. The naming convention of the files usually followed the dialog in the resources, so even though a few were guessed we can be 95% sure all file names are correct.