### PR TITLE
Fix bugs in DiabloUI+cleanup

### DIFF
--- a/DiabloUI/artfont.cpp
+++ b/DiabloUI/artfont.cpp
@@ -1,62 +1,32 @@
 // ref: 0x10001058
 void __fastcall artfont_SetArtFont(int nFont)
 {
-	int v1; // ecx
-	int v2; // ecx
-	int v3; // ecx
-	int v4; // ecx
-	int v5; // ecx
-
-	if ( nFont )
+	switch ( nFont )
 	{
-		v1 = nFont - 2;
-		if ( v1 )
-		{
-			v2 = v1 - 1;
-			if ( v2 )
-			{
-				v3 = v2 - 1;
-				if ( v3 )
-				{
-					v4 = v3 - 1;
-					if ( v4 )
-					{
-						v5 = v4 - 1;
-						if ( v5 )
-						{
-							if ( v5 == 1 )
-								sgpCurrFont = &font42y;
-							else
-								sgpCurrFont = &font16s;
-						}
-						else
-						{
-							sgpCurrFont = &font42g;
-						}
-					}
-					else
-					{
-						sgpCurrFont = &font30s;
-					}
-				}
-				else
-				{
-					sgpCurrFont = &font30g;
-				}
-			}
-			else
-			{
-				sgpCurrFont = &font24s;
-			}
-		}
-		else
-		{
+		case 0:
+			sgpCurrFont = &font16g;
+			break;
+		case 2:
 			sgpCurrFont = &font24g;
-		}
-	}
-	else
-	{
-		sgpCurrFont = &font16g;
+			break;
+		case 3:
+			sgpCurrFont = &font24s;
+			break;
+		case 4:
+			sgpCurrFont = &font30g;
+			break;
+		case 5:
+			sgpCurrFont = &font30s;
+			break;
+		case 6:
+			sgpCurrFont = &font42g;
+			break;
+		case 7:
+			sgpCurrFont = &font42y;
+			break;
+		default:
+			sgpCurrFont = &font16s;
+			break;
 	}
 }
 


### PR DESCRIPTION
Ok so this commit itself is just a cleanup of `artfont_SetArtFont` because I got sick of looking at that function. (the switch case is present in older patches but garbled in 1.09 because of optimizations).

The real reason is to document the changes [of this commit](https://github.com/diasurgical/devilution/commit/1d27aab18ca19c48db4d03b70051364f461fa258) which I accidentally pushed earlier today:

- Implemented "EntName.cpp" and "SelClass.cpp". Creating new characters is now fully functional.
- Renamed the unknown data to `connect_subnet_ip` thanks to @OneMeanDragon
- Fixed a bug with the cursor not drawing at all, stupid me another instance of `DWORD x[2]` :frowning: 
- Fixed a bug where user input was not being noticed in the character selection menu.

The last bug was caused by optimizations where the decompiler treated checking the low and high `WORD` of `WPARAM` in the same conditional. Another thanks to older patches where this code was retained, and the logic was untangled.