### PR TITLE
Improve declaration of _SNETUIDATA.selectnamecallback

### DIFF
--- a/structs.h
+++ b/structs.h
@@ -1367,7 +1367,7 @@ struct _SNETUIDATA
 	void (__cdecl *profilecallback)();
 	int profilefields;
 	void (__cdecl *profilebitmapcallback)();
-	void (__cdecl *selectnamecallback)();
+	void (__cdecl *selectnamecallback)(int u1, int u2, int u3, int u4, int mode, char *cname, int clen, char *cdesc, int cdlen, int *multi);
 	void (__cdecl *changenamecallback)();
 };
 


### PR DESCRIPTION
So it can actually be called from my Storm implementation :sparkles: 