### PR TITLE
Fix declaration of gbValidSaveFile (BOOL)

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -126,8 +126,8 @@ int __fastcall diablo_init_menu(int a1, int bSinglePlayer)
 		if ( !NetInit(v2, &pfExitProgram) )
 			break;
 		byte_678640 = 0;
-		if ( (v3 || !*(_DWORD *)&gbValidSaveFile)
-		  && (InitLevels(), InitQuests(), InitPortals(), InitDungMsgs(myplr), !*(_DWORD *)&gbValidSaveFile)
+		if ( (v3 || !gbValidSaveFile)
+		  && (InitLevels(), InitQuests(), InitPortals(), InitDungMsgs(myplr), !gbValidSaveFile)
 		  || (v4 = WM_DIABLOADGAME, !dword_5256E8) )
 		{
 			v4 = WM_DIABNEWGAME;

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -470,7 +470,7 @@ int __fastcall gmenu_left_mouse(int a1)
 // 634464: using guessed type char byte_634464;
 // 63448C: using guessed type int dword_63448C;
 
-void __fastcall gmenu_enable(TMenuItem *pMenuItem, bool enable)
+void __fastcall gmenu_enable(TMenuItem *pMenuItem, BOOL enable)
 {
 	if ( enable )
 		pMenuItem->dwFlags |= 0x80000000;

--- a/Source/gmenu.h
+++ b/Source/gmenu.h
@@ -31,7 +31,7 @@ void __fastcall gmenu_left_right(int a1);
 int __fastcall gmenu_on_mouse_move(LPARAM lParam);
 bool __fastcall gmenu_valid_mouse_pos(int *plOffset);
 int __fastcall gmenu_left_mouse(int a1);
-void __fastcall gmenu_enable(TMenuItem *pMenuItem, bool enable);
+void __fastcall gmenu_enable(TMenuItem *pMenuItem, BOOL enable);
 void __fastcall gmenu_slider_1(TMenuItem *pItem, int min, int max, int gamma);
 int __fastcall gmenu_slider_get(TMenuItem *pItem, int min, int max);
 void __fastcall gmenu_slider_3(TMenuItem *pItem, int dwTicks);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -872,7 +872,7 @@ void __cdecl SaveGame()
 	v44 = codec_get_encoded_len((_BYTE *)tbuff - (_BYTE *)ptr);
 	pfile_write_save_file(v45, v43, (_BYTE *)tbuff - (_BYTE *)v43, v44);
 	mem_free_dbg(v43);
-	*(_DWORD *)&gbValidSaveFile = 1;
+	gbValidSaveFile = TRUE;
 	pfile_rename_temp_to_perm();
 	pfile_write_hero();
 }

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -4,7 +4,7 @@
 
 int pfile_cpp_init_value;
 char hero_names[MAX_CHARACTERS][PLR_NAME_LEN];
-bool gbValidSaveFile; // idb
+BOOL gbValidSaveFile; // idb
 int save_prev_tc; // weak
 
 const int pfile_inf = 0x7F800000; // weak
@@ -254,7 +254,7 @@ void __cdecl pfile_flush_W()
 	pfile_flush(1, v0);
 }
 
-void __fastcall game_2_ui_player(PlayerStruct *p, _uiheroinfo *heroinfo, bool bHasSaveFile)
+void __fastcall game_2_ui_player(PlayerStruct *p, _uiheroinfo *heroinfo, BOOL bHasSaveFile)
 {
 	_uiheroinfo *v3; // esi
 	PlayerStruct *v4; // edi
@@ -491,19 +491,19 @@ void __fastcall pfile_SFileCloseArchive(void *hsArchive)
 	SFileCloseArchive(hsArchive);
 }
 
-bool __fastcall pfile_archive_contains_game(void *hsArchive)
+BOOL __fastcall pfile_archive_contains_game(void *hsArchive)
 {
 	//int v1; // eax
 	void *file; // [esp+0h] [ebp-4h]
 
 	file = hsArchive;
 	if ( gbMaxPlayers != 1 )
-		return 0;
+		return FALSE;
 	//_LOBYTE(v1) = SFileOpenFileEx(hsArchive, "game", 0, &file);
 	if ( !SFileOpenFileEx(hsArchive, "game", 0, &file) )
-		return 0;
+		return FALSE;
 	SFileCloseFile(file);
-	return 1;
+	return TRUE;
 }
 // 679660: using guessed type char gbMaxPlayers;
 
@@ -639,7 +639,7 @@ void __cdecl pfile_read_player_from_save()
 	if ( !pfile_read_hero(v1, &pkplr) )
 		TermMsg("Unable to load character");
 	UnPackPlayer(&pkplr, myplr, 0);
-	*(_DWORD *)&gbValidSaveFile = pfile_archive_contains_game(v1);
+	gbValidSaveFile = pfile_archive_contains_game(v1);
 	pfile_SFileCloseArchive(v1);
 }
 

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -4,7 +4,7 @@
 
 extern int pfile_cpp_init_value;
 extern char hero_names[MAX_CHARACTERS][PLR_NAME_LEN];
-extern bool gbValidSaveFile; // idb
+extern BOOL gbValidSaveFile; // idb
 extern int save_prev_tc; // weak
 
 void __cdecl pfile_cpp_init();
@@ -19,14 +19,14 @@ void __fastcall pfile_flush(bool is_single_player, int save_num);
 bool __fastcall pfile_create_player_description(char *dst, int len);
 int __fastcall pfile_create_save_file(char *name_1, char *name_2);
 void __cdecl pfile_flush_W();
-void __fastcall game_2_ui_player(PlayerStruct *p, _uiheroinfo *heroinfo, bool bHasSaveFile);
+void __fastcall game_2_ui_player(PlayerStruct *p, _uiheroinfo *heroinfo, BOOL bHasSaveFile);
 char __fastcall game_2_ui_class(PlayerStruct *p);
 BOOL __stdcall pfile_ui_set_hero_infos(BOOL (__stdcall *ui_add_hero_info)(_uiheroinfo *));
 char *__fastcall GetSaveDirectory(char *dst, int dst_size, int save_num);
 bool __fastcall pfile_read_hero(void *archive, PkPlayerStruct *pPack);
 void *__fastcall pfile_open_save_archive(int *unused, int save_num);
 void __fastcall pfile_SFileCloseArchive(void *hsArchive);
-bool __fastcall pfile_archive_contains_game(void *hsArchive);
+BOOL __fastcall pfile_archive_contains_game(void *hsArchive);
 BOOL __stdcall pfile_ui_set_class_stats(int player_class_nr, _uidefaultstats *class_stats);
 int __fastcall pfile_get_player_class(int player_class_nr);
 BOOL __stdcall pfile_ui_save_create(_uiheroinfo *heroinfo);


### PR DESCRIPTION
(I think some patch already had this included, putting out a smaller version that can be reviewed quicker)
This was clearly a `BOOL`.
Also checked the assembly in IDA for these functions, they use 32-bit register references.