### PR TITLE
Fix "DiabloUI" for GCC + disclaim.cpp

### DIFF
--- a/3rdParty/Storm/Source/storm_gcc.def
+++ b/3rdParty/Storm/Source/storm_gcc.def
@@ -72,11 +72,12 @@ EXPORTS
   SDlgBeginPaint                 @201 NONAME
   SDlgBeginPaint@8               @201 NONAME
   SDlgBltToWindowI              @202 NONAME
-  SDlgBltToWindowI@28           @202 NONAME
+  SDlgBltToWindowI@40           @202 NONAME
   ;SDlgCheckTimers               @203 NONAME
   ;SDlgCreateDialogIndirectParam @204 NONAME
   ;SDlgCreateDialogParam         @205 NONAME
   SDlgDefDialogProc             @206 NONAME
+  SDlgDefDialogProc@16          @206 NONAME
 
   SDlgDialogBoxIndirectParam    @208 NONAME
   SDlgDialogBoxParam            @209 NONAME
@@ -84,6 +85,7 @@ EXPORTS
   SDlgDrawBitmap                @210 NONAME
   SDlgDrawBitmap@28             @210 NONAME
   SDlgEndDialog                 @211 NONAME
+  SDlgEndDialog@8               @211 NONAME
   SDlgEndPaint                  @212 NONAME
   SDlgEndPaint@8                @212 NONAME
   SDlgKillTimer                 @213 NONAME
@@ -92,6 +94,7 @@ EXPORTS
   SDlgSetBitmapI                @215 NONAME
   SDlgSetBitmapI@40             @215 NONAME
   SDlgSetControlBitmaps         @216 NONAME
+  SDlgSetControlBitmaps@28      @216 NONAME
   SDlgSetCursor                 @217 NONAME
   SDlgSetCursor@16              @217 NONAME
   SDlgSetSystemCursor           @218 NONAME
@@ -177,6 +180,7 @@ EXPORTS
 
   ;SBltGetSCode                  @312 NONAME
   SBltROP3                      @313 NONAME
+  SBltROP3@32                   @313 NONAME
   SBltROP3Clipped               @314 NONAME
   SBltROP3Tiled                 @315 NONAME
   SBltROP3Tiled@40              @315 NONAME
@@ -184,6 +188,7 @@ EXPORTS
   SBmpDecodeImage               @321 NONAME
 
   SBmpLoadImage                 @323 NONAME
+  SBmpLoadImage@28              @323 NONAME
   SBmpSaveImage                 @324 NONAME
   SBmpAllocLoadImage            @325 NONAME
   ;SBmpSaveImageEx               @326 NONAME
@@ -197,7 +202,7 @@ EXPORTS
   SDrawAutoInitialize           @341 NONAME
   SDrawCaptureScreen            @342 NONAME
   SDrawClearSurface             @343 NONAME
-  SDrawClearSurface@0           @343 NONAME
+  SDrawClearSurface@4           @343 NONAME
   SDrawDestroy                  @344 NONAME
   ;SDrawFlipPage                 @345 NONAME
   SDrawGetFrameWindow           @346 NONAME
@@ -230,13 +235,17 @@ EXPORTS
   ;SGdiBitBlt                    @381 NONAME
   ;SGdiCreateFont                @382 NONAME
   SGdiDeleteObject              @383 NONAME
+  SGdiDeleteObject@4            @383 NONAME
   ;SGdiDestroy                   @384 NONAME
   SGdiExtTextOut                @385 NONAME
   SGdiImportFont                @386 NONAME
+  SGdiImportFont@8              @386 NONAME
   ;SGdiLoadFont                  @387 NONAME
   ;SGdiRectangle                 @388 NONAME
   SGdiSelectObject              @389 NONAME
+  SGdiSelectObject@4            @389 NONAME
   SGdiSetPitch                  @390 NONAME
+  SGdiSetPitch@4                @390 NONAME
   SGdiTextOut                   @391 NONAME
   SGdiTextOut@24                @391 NONAME
   ;SGdi392                       @392 NONAME
@@ -279,10 +288,12 @@ EXPORTS
   ;SReg429                       @429 NONAME
   ;SReg430                       @430 NONAME
   STransBlt                     @431 NONAME
+  STransBlt@20                  @431 NONAME
   STransBltUsingMask            @432 NONAME
   STransCreateI                 @433 NONAME
   STransCreateI@28              @433 NONAME
   STransDelete                  @434 NONAME
+  STransDelete@4                @434 NONAME
 
   STransDuplicate               @436 NONAME
   STransIntersectDirtyArray     @437 NONAME
@@ -357,6 +368,7 @@ EXPORTS
   SStrCopy@12                   @501 NONAME
   SStrHash                      @502 NONAME
   SStrPack                      @503 NONAME
+  SStrPack@12                   @503 NONAME
   ;SStrTokenize                  @504 NONAME
   ;SStrPack                      @505 NONAME
   SStrLen                       @506 NONAME

--- a/DiabloUI/_temp_data.cpp
+++ b/DiabloUI/_temp_data.cpp
@@ -16,6 +16,7 @@ int CreaStat_cpp_float_value = 2139095040; // weak
 int credits_cpp_float_value = 2139095040; // weak
 int DiabEdit_cpp_float_value = 2139095040; // weak
 int DiabloUI_cpp_float_value = 2139095040; // weak
+int disclaim_cpp_float_value = 2139095040; // weak
 int doom_cpp_float_value = 2139095040; // weak
 int EntName_cpp_float_value = 2139095040; // weak
 int fade_cpp_float_value = 2139095040; // weak
@@ -58,8 +59,8 @@ int dword_10022A38[2] = { 1097, 0 };
 int dword_10022A40[2] = { 1102, 0 };
 int dword_10022A48[3] = { 1056, 1054, 0 };
 int dword_10022A54[3] = { 1100, 1101, 0 };
-int dword_10022A98[3] = { 1082, 1083, 0 };
-int dword_10022AA4[4] = { 1084, 1085, 1086, 0 };
+int disclaim_msgtbl1[3] = { 1082, 1083, 0 };
+int disclaim_msgtbl2[4] = { 1084, 1085, 1086, 0 };
 int dword_10022AFC[2] = { 1038, 0 };
 int dword_10022B04[3] = { 1056, 1054, 0 };
 int dword_10022B10[2] = { 1116, 0 };
@@ -231,7 +232,7 @@ int dword_10029840; // weak
 int dword_10029844; // weak
 void *dword_10029848; // idb
 int dword_1002984C; // weak
-int dword_10029850; // weak
+int disclaim_cpp_float; // weak
 int doom_cpp_float; // weak
 LPSTR dword_10029858; // idb
 int dword_1002985C; // weak

--- a/DiabloUI/_temp_funcs.h
+++ b/DiabloUI/_temp_funcs.h
@@ -191,12 +191,13 @@ signed int __stdcall DirLink_1000632B(int a1, char *a2, char *a3);
 HWND __fastcall DirLink_10006359(HWND hWnd, int a2, int height);
 
 
-//signed int __stdcall UiBetaDisclaimer(int a1);
-int __stdcall disclaim_100063DA(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam); // idb
-void UNKCALL disclaim_100064C9(HWND hDlg);
-int UNKCALL disclaim_100064F3(HWND hWnd); // idb
-int UNKCALL disclaim_10006552(void *arg);
-signed int disclaim_10006571();
+BOOL __stdcall UiBetaDisclaimer(int a1);
+LRESULT __stdcall disclaim_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+void __fastcall disclaim_DelDisclaimProcs(HWND hWnd);
+void __fastcall disclaim_LoadDisclaimGFX(HWND hWnd);
+void __fastcall disclaim_FadeFromDisclaim(HWND hWnd);
+void __cdecl j_disclaim_cpp_init();
+void __cdecl disclaim_cpp_init();
 
 
 void __cdecl j_Doom_cpp_init();

--- a/DiabloUI/diabloui.h
+++ b/DiabloUI/diabloui.h
@@ -56,6 +56,7 @@ BOOL __stdcall UiCreatePlayerDescription(_uiheroinfo *info, int mode, char *desc
 void __stdcall UiSetupPlayerInfo(char *infostr, _uiheroinfo *pInfo, int type);
 void __stdcall UiCreateGameCriteria(_uiheroinfo *pInfo, char *str);
 BOOL __stdcall UiGetDefaultStats(int pclass, _uidefaultstats *pStats);
+BOOL __stdcall UiBetaDisclaimer(int a1);
 
 #ifdef __GNUC__
 }

--- a/DiabloUI/diabloui_gcc.def
+++ b/DiabloUI/diabloui_gcc.def
@@ -2,55 +2,56 @@ LIBRARY "DiabloUI"
 
 EXPORTS
 	UiValidPlayerName              @1
-	@UiValidPlayerName@4           @1
+	@UiValidPlayerName@4           @1  NONAME
 	UiAppActivate                  @2
-	UiAppActivate@4                @2
+	UiAppActivate@4                @2  NONAME
 	UiArtCallback                  @3
-	UiArtCallback@32               @3
+	UiArtCallback@32               @3  NONAME
 	UiAuthCallback                 @4
-	UiAuthCallback@28              @4
+	UiAuthCallback@28              @4  NONAME
 	UiBetaDisclaimer               @5
+	UiBetaDisclaimer@4             @5  NONAME
 	UiCategoryCallback             @6
-	UiCategoryCallback@28          @6
+	UiCategoryCallback@28          @6  NONAME
 	UiCopyProtError                @7
 	UiCreateGameCallback           @8
-	UiCreateGameCallback@24        @8
+	UiCreateGameCallback@24        @8  NONAME
 	UiCreateGameCriteria           @9
 	UiCreatePlayerDescription      @10
-	UiCreatePlayerDescription@12   @10
+	UiCreatePlayerDescription@12   @10 NONAME
 	UiCreditsDialog                @11
-	UiCreditsDialog@4              @11
+	UiCreditsDialog@4              @11 NONAME
 	UiDestroy                      @12
 	UiDrawDescCallback             @13
-	UiDrawDescCallback@32          @13
+	UiDrawDescCallback@32          @13 NONAME
 	UiGetDataCallback              @14
-	UiGetDataCallback@20           @14
+	UiGetDataCallback@20           @14 NONAME
 	UiGetDefaultStats              @15
 	UiInitialize                   @16
 	UiMainMenuDialog               @17
-	UiMainMenuDialog@16            @17
+	UiMainMenuDialog@16            @17 NONAME
 	UiMessageBoxCallback           @18
-	UiMessageBoxCallback@16        @18
+	UiMessageBoxCallback@16        @18 NONAME
 	UiOnPaint                      @19
 	UiProfileCallback              @20
 	UiProfileDraw                  @21
 	UiProfileGetString             @22
 	UiProgressDialog               @23
-	UiProgressDialog@20            @23
+	UiProgressDialog@20            @23 NONAME
 	UiSelHeroMultDialog            @24
-	UiSelHeroMultDialog@28         @24
+	UiSelHeroMultDialog@28         @24 NONAME
 	UiSelHeroSingDialog            @25
-	UiSelHeroSingDialog@28         @25
+	UiSelHeroSingDialog@28         @25 NONAME
 	UiSelectGame                   @26
-	UiSelectGame@24                @26
+	UiSelectGame@24                @26 NONAME
 	UiSelectProvider               @27
-	UiSelectProvider@24            @27
+	UiSelectProvider@24            @27 NONAME
 	UiSelectRegion                 @28
 	UiSetBackgroundBitmap          @29
 	UiSetSpawned                   @30
 	UiSetupPlayerInfo              @31
-	UiSetupPlayerInfo@12           @31
+	UiSetupPlayerInfo@12           @31 NONAME
 	UiSoundCallback                @32
-	UiSoundCallback@12             @32
+	UiSoundCallback@12             @32 NONAME
 	UiTitleDialog                  @33
-	UiTitleDialog@4                @33
+	UiTitleDialog@4                @33 NONAME

--- a/DiabloUI/disclaim.cpp
+++ b/DiabloUI/disclaim.cpp
@@ -1,20 +1,18 @@
 // ref: 0x100063B3
-signed int __stdcall UiBetaDisclaimer(int a1) { return 0; }
-/* {
+BOOL __stdcall UiBetaDisclaimer(int a1)
+{
 	int v1; // eax
 
-	v1 = SDrawGetFrameWindow();
-	SDlgDialogBoxParam(hInstance, "DISCLAIMER_DIALOG", v1, disclaim_100063DA, a1);
+	v1 = (int)SDrawGetFrameWindow();
+	SDlgDialogBoxParam(ghUiInst, "DISCLAIMER_DIALOG", v1, disclaim_WndProc, a1);
 	return 1;
-} */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+}
 // 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x100063DA
-int __stdcall disclaim_100063DA(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
-/* {
+LRESULT __stdcall disclaim_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+{
 	HWND v5; // eax
-	int v6; // [esp+0h] [ebp-8h]
 
 	if ( Msg > 0x111 )
 	{
@@ -23,15 +21,15 @@ int __stdcall disclaim_100063DA(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 			if ( Msg == 528 )
 			{
 				if ( (_WORD)wParam == 513 || (_WORD)wParam == 516 )
-					disclaim_10006552(hWnd);
+					disclaim_FadeFromDisclaim(hWnd);
 			}
 			else if ( Msg == 2024 )
 			{
-				if ( !Fade_1000739F() )
-					Fade_100073FD(hWnd, v6);
+				if ( !Fade_CheckRange5() )
+					Fade_SetFadeTimer((int)hWnd);
 				return 0;
 			}
-			return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+			return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 		}
 	}
 	else if ( Msg != 273 )
@@ -49,77 +47,63 @@ int __stdcall disclaim_100063DA(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 					}
 					else if ( Msg == 272 )
 					{
-						disclaim_100064F3(hWnd);
+						disclaim_LoadDisclaimGFX(hWnd);
 						PostMessageA(hWnd, 0x7E8u, 0, 0);
 						return 1;
 					}
 				}
-				return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+				return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 			}
 			goto LABEL_21;
 		}
-		disclaim_100064C9(hWnd);
-		return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
+		disclaim_DelDisclaimProcs(hWnd);
+		return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 	}
 LABEL_21:
-	disclaim_10006552(hWnd);
+	disclaim_FadeFromDisclaim(hWnd);
 	return 0;
-} */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
+}
 // 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x100064C9
-void UNKCALL disclaim_100064C9(HWND hDlg) { return; }
-/* {
-	HWND v1; // esi
-	_DWORD *v2; // eax
+void __fastcall disclaim_DelDisclaimProcs(HWND hWnd)
+{
+	void **v2; // eax
 
-	v1 = hDlg;
-	Doom_10006C53(hDlg, (int *)&unk_10022AA4);
-	Doom_10006C53(v1, (int *)&unk_10022A98);
-	v2 = (_DWORD *)GetWindowLongA(v1, -21);
-	local_10007F72(v2);
-} */
+	Doom_DeleteFreeProcs(hWnd, disclaim_msgtbl2);
+	Doom_DeleteFreeProcs(hWnd, disclaim_msgtbl1);
+	v2 = (void **)GetWindowLongA(hWnd, -21);
+	local_FreeMemPtr(v2);
+}
 
 // ref: 0x100064F3
-int UNKCALL disclaim_100064F3(HWND hWnd) { return 0; }
-/* {
-	HWND v1; // edi
-	int v2; // eax
-	int *v3; // esi
+void __fastcall disclaim_LoadDisclaimGFX(HWND hWnd)
+{
+	DWORD *v2; // eax MAPDST
 
-	v1 = hWnd;
-	v2 = local_10007F46();
-	v3 = (int *)v2;
+	v2 = local_AllocWndLongData();
 	if ( v2 )
 	{
-		SetWindowLongA(v1, -21, v2);
-		local_10007944((int)v1, 0, &byte_10029448, -1, 1, (int)"ui_art\\disclaim.pcx", v3, v3 + 1, 0);
-		Fade_100073C5(v1, 0);
+		SetWindowLongA(hWnd, -21, (LONG)v2);
+		local_LoadArtWithPal(hWnd, 0, &nullcharacter, -1, 1, "ui_art\\disclaim.pcx", (BYTE **)v2, v2 + 1, 0);
+		Fade_NoInputAndArt(hWnd, 0);
 	}
-	Doom_100068AB(v1, (int *)&unk_10022A98, 5);
-	return Doom_100068AB(v1, (int *)&unk_10022AA4, 2);
-} */
+	Doom_ParseWndProc3(hWnd, disclaim_msgtbl1, 5);
+	Doom_ParseWndProc3(hWnd, disclaim_msgtbl2, 2);
+}
 
 // ref: 0x10006552
-int UNKCALL disclaim_10006552(void *arg) { return 0; }
-/* {
-	void *v1; // esi
-
-	v1 = arg;
-	Fade_100073B4();
-	Fade_100072BE(10);
-	return SDlgEndDialog(v1, 1);
-} */
-// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+void __fastcall disclaim_FadeFromDisclaim(HWND hWnd)
+{
+	Fade_Range5SetZero();
+	Fade_UpdatePaletteRange(10);
+	SDlgEndDialog(hWnd, (void *)HANDLE_FLAG_INHERIT);
+}
 
 // ref: 0x10006571
-signed int disclaim_10006571() { return 0; }
-/* {
-	signed int result; // eax
-
-	result = 2139095040;
-	dword_10029850 = 2139095040;
-	return result;
-} */
-// 10029850: using guessed type int dword_10029850;
+void __cdecl disclaim_cpp_init()
+{
+	disclaim_cpp_float = disclaim_cpp_float_value;
+}
+// 1001F418: using guessed type int disclaim_cpp_float_value;
+// 10029850: using guessed type int disclaim_cpp_float;


### PR DESCRIPTION
Implemented disclaim.cpp, you can now call it to show the Battle.net Beta disclaimer (kinda funny).

DiabloUI now has preliminary support for compiling under GCC. Just have to update the Makefile