### PR TITLE
clean all tmsg functions

### DIFF
--- a/Source/tmsg.cpp
+++ b/Source/tmsg.cpp
@@ -4,7 +4,7 @@
 
 static TMsg *sgpTimedMsgHead;
 
-int __fastcall tmsg_get(UCHAR *pbMsg, DWORD dwMaxLen)
+int __fastcall tmsg_get(BYTE *pbMsg, DWORD dwMaxLen)
 {
 	int len;
 	TMsg *head;
@@ -23,7 +23,7 @@ int __fastcall tmsg_get(UCHAR *pbMsg, DWORD dwMaxLen)
 	return len;
 }
 
-void __fastcall tmsg_add(UCHAR *pbMsg, UCHAR bLen)
+void __fastcall tmsg_add(BYTE *pbMsg, BYTE bLen)
 {
 	TMsg **tail;
 

--- a/Source/tmsg.h
+++ b/Source/tmsg.h
@@ -2,10 +2,8 @@
 #ifndef __TMSG_H__
 #define __TMSG_H__
 
-extern TMsg *sgpTimedMsgHead;
-
-int __fastcall tmsg_get(unsigned char *pbMsg, unsigned int dwMaxLen);
-void __fastcall tmsg_add(unsigned char *pbMsg, unsigned char bLen);
-void __cdecl tmsg_cleanup();
+int __fastcall tmsg_get(UCHAR *pbMsg, DWORD dwMaxLen);
+void __fastcall tmsg_add(UCHAR *pbMsg, UCHAR bLen);
+void* __cdecl tmsg_cleanup();
 
 #endif /* __TMSG_H__ */

--- a/Source/tmsg.h
+++ b/Source/tmsg.h
@@ -2,8 +2,8 @@
 #ifndef __TMSG_H__
 #define __TMSG_H__
 
-int __fastcall tmsg_get(UCHAR *pbMsg, DWORD dwMaxLen);
-void __fastcall tmsg_add(UCHAR *pbMsg, UCHAR bLen);
+int __fastcall tmsg_get(BYTE *pbMsg, DWORD dwMaxLen);
+void __fastcall tmsg_add(BYTE *pbMsg, BYTE bLen);
 void* __cdecl tmsg_cleanup();
 
 #endif /* __TMSG_H__ */

--- a/structs.h
+++ b/structs.h
@@ -1532,13 +1532,15 @@ struct TMsg;
 struct TMsgHdr
 {
 	TMsg *pNext;
-	unsigned int dwTime;
-	unsigned char bLen;
+	DWORD dwTime;
+	UCHAR bLen;
 };
 
 struct TMsg
 {
 	TMsgHdr hdr;
+	// this is actually alignment padding, but the message body is appended to the struct
+	// so it's convenient to use byte-alignment and name it "body"
 	unsigned char body[3];
 };
 #pragma pack(pop)

--- a/structs.h
+++ b/structs.h
@@ -1533,7 +1533,7 @@ struct TMsgHdr
 {
 	TMsg *pNext;
 	DWORD dwTime;
-	UCHAR bLen;
+	BYTE bLen;
 };
 
 struct TMsg


### PR DESCRIPTION
All functions should be binary exact.
Apparently tmsg_cleanup is meant to return a value (judging by its use of eax instead of ecx), I just made it void* because there's no extra information on what it should be.