### PR TITLE
clean dead.cpp

### DIFF
--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -2,148 +2,85 @@
 
 #include "../types.h"
 
+// unused, this was probably for blood boil/burn
 int spurtndx; // weak
+
 DeadStruct dead[MAXDEAD];
 int stonendx;
 
 void __cdecl InitDead()
 {
-	int v0; // ebx
-	int *v1; // edx
-	int *v2; // eax
-	int v3; // ecx
-	int v4; // edx
-	int v5; // eax
-	int v6; // edx
-	int v7; // esi
-	int *v8; // eax
-	int v9; // edx
-	CMonster *v10; // ecx
-	char *v11; // edi
-	int *v12; // ebx
-	int mtypes[MAXMONSTERS]; // [esp+Ch] [ebp-330h]
-	int *v14; // [esp+32Ch] [ebp-10h]
-	int *v15; // [esp+330h] [ebp-Ch]
-	int v16; // [esp+334h] [ebp-8h]
-	int v17; // [esp+338h] [ebp-4h]
+	int i, j;
+	int mtypes[MAXMONSTERS];
+	int idx;
+	
+	for ( i = 0; i < MAXMONSTERS; i++ )
+		mtypes[i] = 0;
 
-	memset(mtypes, 0, sizeof(mtypes));
-	v0 = 0;
-	if ( nummtypes > 0 )
-	{
-		v1 = &dead[0]._deadFrame;
-		v2 = &Monsters[0].Anims[4].Rate;
-		v17 = nummtypes;
-		do
-		{
-			v15 = &mtypes[*((unsigned char *)v2 - 216)];
-			if ( !*v15 )
-			{
-				qmemcpy(v1 - 8, v2 - 8, 0x20u);
-				v3 = *v2;
-				*((_BYTE *)v1 + 12) = 0;
-				*v1 = v3;
-				v1[1] = v2[21];
-				v1[2] = v2[22];
-				*((_BYTE *)v2 + 101) = ++v0;
-				v1 += 12;
-				*v15 = v0;
-			}
-			v2 += 82;
-			--v17;
+	idx = 0;
+	for (i=0; i < nummtypes; i++) {
+		if (!mtypes[Monsters[i].mtype]) {
+			for ( j=0; j < 8; j++)
+				dead[idx]._deadData[j] = Monsters[i].Anims[4].Frames[j];
+			dead[idx]._deadFrame = Monsters[i].Anims[4].Rate;
+			dead[idx]._deadWidth = Monsters[i].flags_1;
+			dead[idx]._deadWidth2 = Monsters[i].flags_2;
+			dead[idx]._deadtrans = 0;
+			Monsters[i].mdeadval = idx+1;
+			mtypes[Monsters[i].mtype] = ++idx;
 		}
-		while ( v17 );
 	}
-	v16 = 0;
-	v4 = v0;
-	memset32(&dead[v0], (unsigned int)misfiledata[16].mAnimData[0], 8u);
-	_LOBYTE(dead[v4]._deadtrans) = 0;
-	dead[v4]._deadFrame = 8;
-	v5 = (unsigned int)misfiledata[18].mAnimData[0];
-	dead[v4]._deadWidth = 128;
-	dead[v4]._deadWidth2 = 32;
-	v6 = v0 + 1;
-	spurtndx = v0 + 1;
-	memset32(&dead[v6], v5, 8u);
-	_LOBYTE(dead[v6]._deadtrans) = 0;
-	stonendx = v0 + 2;
-	v7 = nummonsters;
-	dead[v6]._deadFrame = 12;
-	dead[v6]._deadWidth = 128;
-	dead[v6]._deadWidth2 = 32;
-	v17 = v0 + 2;
-	if ( v7 > 0 )
-	{
-		v8 = &dead[v0 + 2]._deadFrame;
-		do
-		{
-			v9 = monstactive[v16];
-			if ( monster[v9]._uniqtype )
-			{
-				v10 = monster[v9].MType;
-				v11 = (char *)(v8 - 8);
-				v15 = (int *)8;
-				v14 = (int *)v10->Anims[4].Frames;
-				do
-				{
-					v12 = v14;
-					++v14;
-					*(_DWORD *)v11 = *v12;
-					v11 += 4;
-					v15 = (int *)((char *)v15 - 1);
-				}
-				while ( v15 );
-				*v8 = v10->Anims[4].Rate;
-				v8[1] = v10->flags_1;
-				v8[2] = v10->flags_2;
-				*((_BYTE *)v8 + 12) = monster[v9]._uniqtrans + 4;
-				monster[v9]._udeadval = ++v17;
-				v8 += 12;
-			}
-			++v16;
+
+	for (j=0; j < 8; j++)
+		dead[idx]._deadData[j] = misfiledata[MFILE_BLODBUR].mAnimData[0];
+	dead[idx]._deadtrans = 0;
+	dead[idx]._deadFrame = 8;
+	spurtndx = idx + 1;
+	dead[idx]._deadWidth = 128;
+	dead[idx]._deadWidth2 = 32;
+	idx = spurtndx;
+
+	for (j=0; j < 8; j++)
+		dead[idx]._deadData[j] = misfiledata[MFILE_SHATTER1].mAnimData[0];
+	dead[idx]._deadtrans = 0;
+	dead[idx]._deadFrame = 12;
+	stonendx = idx + 1;
+	dead[idx]._deadWidth = 128;
+	dead[idx]._deadWidth2 = 32;
+	idx++;
+
+	for (i=0; i < nummonsters; i++) {
+		int ii = monstactive[i];
+		if ( monster[ii]._uniqtype ) {
+			for (j=0; j < 8; j++)
+				dead[idx]._deadData[j] = monster[ii].MType->Anims[4].Frames[j];
+			dead[idx]._deadFrame = monster[ii].MType->Anims[4].Rate;
+			dead[idx]._deadWidth = monster[ii].MType->flags_1;
+			dead[idx]._deadWidth2 = monster[ii].MType->flags_2;
+			dead[idx]._deadtrans = monster[ii]._uniqtrans + 4;
+			monster[ii]._udeadval = idx+1;
+			idx++;
 		}
-		while ( v16 < v7 );
 	}
 }
 // 4B8CD8: using guessed type int spurtndx;
 
 void __fastcall AddDead(int dx, int dy, char dv, int ddir)
 {
-	dDead[dx][dy] = (dv & 0x1F) + 32 * ddir;
+	dDead[dx][dy] = (dv & 0x1F) + (ddir << 5);
 }
 
 void __cdecl SetDead()
 {
-	int v0; // eax
-	int v1; // esi
-	int v2; // ebp
-	char (*v3)[112]; // ebx
-	int v4; // edi
-	int i; // [esp+0h] [ebp-4h]
-
-	v0 = 0;
-	for ( i = 0; i < nummonsters; ++i )
-	{
-		v1 = monstactive[v0];
-		if ( monster[v1]._uniqtype )
-		{
-			v2 = 0;
-			v3 = dDead;
-			do
-			{
-				v4 = 0;
-				do
-				{
-					if ( ((*v3)[v4] & 0x1F) == monster[v1]._udeadval )
-						ChangeLightXY((unsigned char)monster[v1].mlid, v2, v4);
-					++v4;
+	for ( int i = 0; i < nummonsters; i++ ) {
+		int m = monstactive[i];
+		if ( monster[m]._uniqtype ) {
+			for ( int x=0; x < MAXDUNX; x++ ) {
+				for ( int y=0; y < MAXDUNY; y++) {
+					if ( (dDead[x][y] & 0x1F) == monster[m]._udeadval )
+						ChangeLightXY(monster[m].mlid, x, y);
 				}
-				while ( v4 < 112 );
-				++v3;
-				++v2;
 			}
-			while ( (signed int)v3 < (signed int)&dDead[112][0] );
 		}
-		v0 = i + 1;
 	}
 }

--- a/structs.h
+++ b/structs.h
@@ -1253,7 +1253,7 @@ struct DeadStruct
 	int _deadFrame;
 	int _deadWidth;
 	int _deadWidth2;
-	int _deadtrans;
+	char _deadtrans;
 };
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
AddDead and SetDead should be bin exact.
InitDead is not an exact match because it uses "push 0x20; pop ebx; mov off32[edx], ebx" instead of "mov off32[edx], 0x20". Can't really fault the compiler for doing that when it's one byte shorter and optimize for space is turned on.