### PR TITLE
spells64

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -103,13 +103,9 @@ void __cdecl TakeGoldCheat()
 
 void __cdecl MaxSpellsCheat()
 {
-	int i; // ebp
-
-	for(i = 1; i < MAX_SPELLS; i++)
-	{
-		if ( spelldata[i].sBookLvl != -1 )
-		{
-			*(_QWORD *)plr[myplr]._pMemSpells |= (__int64)1 << (i - 1);
+	for(int i = 1; i < MAX_SPELLS; i++) {
+		if ( spelldata[i].sBookLvl != -1 ) {
+			plr[myplr]._pMemSpells64 |= (__int64)1 << (i - 1);
 			plr[myplr]._pSplLvl[i] = 10;
 		}
 	}
@@ -117,7 +113,7 @@ void __cdecl MaxSpellsCheat()
 
 void __fastcall SetSpellLevelCheat(char spl, int spllvl)
 {
-	*(_QWORD *)plr[myplr]._pMemSpells |= (__int64)1 << (spl - 1);
+	plr[myplr]._pMemSpells64 |= (__int64)1 << (spl - 1);
 	plr[myplr]._pSplLvl[spl] = spllvl;
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1145,19 +1145,9 @@ void __fastcall CalcPlrScrolls(int p)
 
 void __fastcall CalcPlrStaff(int pnum)
 {
-	int v1; // esi
-	bool v2; // zf
-	signed __int64 v3; // rax
-
-	v1 = pnum;
-	v2 = plr[pnum].InvBody[INVLOC_HAND_LEFT]._itype == ITYPE_NONE;
-	plr[v1]._pISpells[0] = 0;
-	plr[v1]._pISpells[1] = 0;
-	if ( !v2 && plr[v1].InvBody[INVLOC_HAND_LEFT]._iStatFlag && plr[v1].InvBody[INVLOC_HAND_LEFT]._iCharges > 0 )
-	{
-		v3 = (__int64)1 << (_LOBYTE(plr[v1].InvBody[INVLOC_HAND_LEFT]._iSpell) - 1);
-		plr[v1]._pISpells[0] = v3;
-		plr[v1]._pISpells[1] = HIDWORD(v3);
+	plr[pnum]._pISpells64 = 0;
+	if ( plr[pnum].InvBody[INVLOC_HAND_LEFT]._itype != ITYPE_NONE && plr[pnum].InvBody[INVLOC_HAND_LEFT]._iStatFlag && plr[pnum].InvBody[INVLOC_HAND_LEFT]._iCharges > 0 ) {
+		plr[pnum]._pISpells64 |= (__int64)1 << (plr[pnum].InvBody[INVLOC_HAND_LEFT]._iSpell - 1);
 	}
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1119,58 +1119,24 @@ void __fastcall CalcPlrItemVals(int p, BOOL Loadgfx)
 
 void __fastcall CalcPlrScrolls(int p)
 {
-	int v1; // esi
-	int v2; // eax
-	int *v3; // edi
-	int v4; // ebx
-	signed __int64 v5; // rax
-	int *v6; // edi
-	signed int v7; // ebx
-	signed __int64 v8; // rax
-	__int64 v9; // rax
+	plr[p]._pScrlSpells64 = 0;
+	for (int i = 0; i < plr[p]._pNumInv; i++ ) {
+		if ( plr[p].InvList[i]._itype != ITYPE_NONE && (plr[p].InvList[i]._iMiscId == IMISC_SCROLL || plr[p].InvList[i]._iMiscId == IMISC_SCROLLT) ) {
+			if ( plr[p].InvList[i]._iStatFlag )
+				plr[p]._pScrlSpells64 |= (__int64)1 << (plr[p].InvList[i]._iSpell - 1);
+		}
+	}
 
-	v1 = p;
-	v2 = plr[p]._pNumInv;
-	plr[v1]._pScrlSpells[0] = 0;
-	plr[v1]._pScrlSpells[1] = 0;
-	if ( v2 > 0 )
-	{
-		v3 = &plr[v1].InvList[0]._iMiscId;
-		v4 = v2;
-		do
-		{
-			if ( *(v3 - 53) != -1 && (*v3 == IMISC_SCROLL || *v3 == IMISC_SCROLLT) && v3[34] )
-			{
-				v5 = (__int64)1 << (*((_BYTE *)v3 + 4) - 1);
-				plr[v1]._pScrlSpells[0] |= v5;
-				plr[v1]._pScrlSpells[1] |= HIDWORD(v5);
-			}
-			v3 += 92;
-			--v4;
+	for (int j = 0; j < MAXBELTITEMS; j++) {
+		if ( plr[p].SpdList[j]._itype != ITYPE_NONE && (plr[p].SpdList[j]._iMiscId == IMISC_SCROLL || plr[p].SpdList[j]._iMiscId == IMISC_SCROLLT) ) {
+			if ( plr[p].SpdList[j]._iStatFlag )
+				plr[p]._pScrlSpells64 |= (__int64)1 << (plr[p].SpdList[j]._iSpell - 1);
 		}
-		while ( v4 );
 	}
-	v6 = &plr[v1].SpdList[0]._iMiscId;
-	v7 = MAXBELTITEMS;
-	do
-	{
-		if ( *(v6 - 53) != -1 && (*v6 == IMISC_SCROLL || *v6 == IMISC_SCROLLT) && v6[34] )
-		{
-			v8 = (__int64)1 << (*((_BYTE *)v6 + 4) - 1);
-			plr[v1]._pScrlSpells[0] |= v8;
-			plr[v1]._pScrlSpells[1] |= HIDWORD(v8);
-		}
-		v6 += 92;
-		--v7;
-	}
-	while ( v7 );
-	if ( _LOBYTE(plr[v1]._pRSplType) == 2 )
-	{
-		v9 = 1 << (_LOBYTE(plr[v1]._pRSpell) - 1);
-		if ( !(plr[v1]._pScrlSpells[1] & HIDWORD(v9) | plr[v1]._pScrlSpells[0] & (unsigned int)v9) )
-		{
-			plr[v1]._pRSpell = -1;
-			_LOBYTE(plr[v1]._pRSplType) = 4;
+	if ( plr[p]._pRSplType == RSPLTYPE_SCROLL ) {
+		if ( !(plr[p]._pScrlSpells64 & 1 << (plr[p]._pRSpell - 1)) ) {
+			plr[p]._pRSpell = SPL_INVALID;
+			plr[p]._pRSplType = RSPLTYPE_INVALID;
 			drawpanflag = 255;
 		}
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4581,7 +4581,7 @@ LABEL_71:
 					if ( v24 != 2 )
 						return;
 					v25 = p;
-					*(_QWORD *)plr[p]._pMemSpells |= (__int64)1 << ((unsigned char)spl - 1);
+					plr[p]._pMemSpells64 |= (__int64)1 << (spl - 1);
 					v26 = &plr[p]._pSplLvl[spl];
 					if ( *v26 < 15 )
 						++*v26;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -5215,12 +5215,12 @@ LABEL_47:
 					return;
 				v7 = 21720 * arglist;
 				plr[arglist]._pMemSpells64 |= (__int64)1 << (SPL_FIREBOLT - 1);
-				v67 = plr[arglist]._pSplLvl[1];
+				v67 = plr[arglist]._pSplLvl[SPL_FIREBOLT];
 				if ( v67 < 15 )
-					plr[0]._pSplLvl[v7 + 1] = v67 + 1;
-				v68 = plr[0]._pSplLvl[v7 + 1];
+					plr[0]._pSplLvl[v7 + SPL_FIREBOLT] = v67 + 1;
+				v68 = plr[0]._pSplLvl[v7 + SPL_FIREBOLT];
 				if ( v68 < 15 )
-					plr[0]._pSplLvl[v7 + 1] = v68 + 1;
+					plr[0]._pSplLvl[v7 + SPL_FIREBOLT] = v68 + 1;
 				v69 = *(int *)((char *)&plr[0]._pMaxManaBase + v7);
 				v70 = *(int *)((char *)&plr[0]._pManaBase + v7);
 				v71 = *(int *)((char *)&plr[0]._pMana + v7) - v70;
@@ -5408,12 +5408,12 @@ LABEL_47:
 					return;
 				v7 = 21720 * arglist;
 				plr[arglist]._pMemSpells64 |= (__int64)1 << (SPL_CBOLT - 1);
-				v96 = plr[arglist]._pSplLvl[30];
+				v96 = plr[arglist]._pSplLvl[SPL_CBOLT];
 				if ( v96 < 15 )
-					plr[0]._pSplLvl[v7 + 30] = v96 + 1;
-				v97 = plr[0]._pSplLvl[v7 + 30];
+					plr[0]._pSplLvl[v7 + SPL_CBOLT] = v96 + 1;
+				v97 = plr[0]._pSplLvl[v7 + SPL_CBOLT];
 				if ( v97 < 15 )
-					plr[0]._pSplLvl[v7 + 30] = v97 + 1;
+					plr[0]._pSplLvl[v7 + SPL_CBOLT] = v97 + 1;
 				v98 = *(int *)((char *)&plr[0]._pMaxManaBase + v7);
 				v99 = *(int *)((char *)&plr[0]._pManaBase + v7);
 				v100 = *(int *)((char *)&plr[0]._pMana + v7) - v99;
@@ -5534,12 +5534,12 @@ LABEL_47:
 					return;
 				v7 = 21720 * arglist;
 				plr[arglist]._pMemSpells64 |= (__int64)1 << (SPL_HBOLT - 1);
-				v115 = plr[arglist]._pSplLvl[31];
+				v115 = plr[arglist]._pSplLvl[SPL_HBOLT];
 				if ( v115 < 15 )
-					plr[0]._pSplLvl[v7 + 31] = v115 + 1;
-				v116 = plr[0]._pSplLvl[v7 + 31];
+					plr[0]._pSplLvl[v7 + SPL_HBOLT] = v115 + 1;
+				v116 = plr[0]._pSplLvl[v7 + SPL_HBOLT];
 				if ( v116 < 15 )
-					plr[0]._pSplLvl[v7 + 31] = v116 + 1;
+					plr[0]._pSplLvl[v7 + SPL_HBOLT] = v116 + 1;
 				v117 = *(int *)((char *)&plr[0]._pMaxManaBase + v7);
 				v118 = *(int *)((char *)&plr[0]._pManaBase + v7);
 				v119 = *(int *)((char *)&plr[0]._pMana + v7) - v118;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3971,24 +3971,17 @@ LABEL_17:
 
 void __fastcall OperateBook(int pnum, int i)
 {
-	int esi1; // esi
 	int v3; // edx
 	signed int v4; // ecx
 	int v5; // eax
 	bool v6; // zf
-	int v7; // ecx
-	int *v8; // eax
 	int j; // esi
-	int v10; // [esp+Ch] [ebp-14h]
 	signed int v11; // [esp+10h] [ebp-10h]
 	signed int v1; // [esp+14h] [ebp-Ch]
 	signed int v2; // [esp+18h] [ebp-8h]
 	int v14; // [esp+1Ch] [ebp-4h]
 
-	esi1 = i;
-	v3 = pnum;
-	v10 = pnum;
-	if ( !object[esi1]._oSelFlag )
+	if ( !object[i]._oSelFlag )
 		return;
 	if ( !setlevel || setlvlnum != SL_VILEBETRAYER )
 		goto LABEL_17;
@@ -4020,41 +4013,34 @@ void __fastcall OperateBook(int pnum, int i)
 			if ( v4 )
 			{
 				++object[dObject[35][36]-1]._oVar5; // ++objectavail[30 * dObject[35][36] + 123]; /* fix */
-				AddMissile(plr[v3].WorldX, plr[v3].WorldY, v1, v2, plr[v3]._pdir, MIS_RNDTELEPORT, 0, v3, 0, 0);
+				AddMissile(plr[pnum].WorldX, plr[pnum].WorldY, v1, v2, plr[pnum]._pdir, MIS_RNDTELEPORT, 0, pnum, 0, 0);
 				v11 = 1;
 				v4 = 0;
 			}
 			if ( ++v14 >= nobjects )
 				break;
-			v3 = v10;
 		}
 		if ( v11 )
 		{
-			v3 = v10;
 LABEL_17:
-			++object[esi1]._oAnimFrame;
+			++object[i]._oAnimFrame;
 			v6 = setlevel == 0;
-			object[esi1]._oSelFlag = 0;
+			object[i]._oSelFlag = 0;
 			if ( !v6 )
 			{
-				if ( setlvlnum == SL_BONECHAMB )
-				{
-					v7 = 21720 * myplr;
-					v8 = plr[myplr]._pMemSpells;
-					*((_BYTE *)v8 + 1) |= 0x10u;
-					v8[1] = v8[1];
-					if ( plr[v3]._pSplLvl[SPL_GUARDIAN] < 15 )
-						++plr[0]._pSplLvl[v7 + SPL_GUARDIAN];
+				if ( setlvlnum == SL_BONECHAMB ) {
+					plr[myplr]._pMemSpells64 |= 0x10;
+					if ( plr[pnum]._pSplLvl[SPL_GUARDIAN] < 15 )
+						plr[myplr]._pSplLvl[SPL_GUARDIAN]++;
 					quests[QTYPE_BONE]._qactive = 3;
 					if ( !deltaload )
-						PlaySfxLoc(IS_QUESTDN, object[esi1]._ox, object[esi1]._oy);
-					_LOBYTE(v7) = 43;
-					InitDiabloMsg(v7);
+						PlaySfxLoc(IS_QUESTDN, object[i]._ox, object[i]._oy);
+					InitDiabloMsg(43);
 					AddMissile(
 						plr[myplr].WorldX,
 						plr[myplr].WorldY,
-						object[esi1]._ox - 2,
-						object[esi1]._oy - 4,
+						object[i]._ox - 2,
+						object[i]._oy - 4,
 						plr[myplr]._pdir,
 						MIS_GUARDIAN,
 						0,
@@ -4067,10 +4053,10 @@ LABEL_17:
 					if ( setlvlnum == SL_VILEBETRAYER )
 					{
 						ObjChangeMapResync(
-							object[esi1]._oVar1,
-							object[esi1]._oVar2,
-							object[esi1]._oVar3,
-							object[esi1]._oVar4);
+							object[i]._oVar1,
+							object[i]._oVar2,
+							object[i]._oVar3,
+							object[i]._oVar4);
 						for ( j = 0; j < nobjects; ++j )
 							SyncObjectAnim(objectactive[j]);
 					}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4029,7 +4029,7 @@ LABEL_17:
 			if ( !v6 )
 			{
 				if ( setlvlnum == SL_BONECHAMB ) {
-					plr[myplr]._pMemSpells64 |= 0x10;
+					plr[myplr]._pMemSpells64 |= (__int64)1 << (SPL_GUARDIAN - 1);
 					if ( plr[pnum]._pSplLvl[SPL_GUARDIAN] < 15 )
 						plr[myplr]._pSplLvl[SPL_GUARDIAN]++;
 					quests[QTYPE_BONE]._qactive = 3;
@@ -4720,12 +4720,12 @@ void __fastcall OperateShrine(int pnum, int i, int sType)
 	int *v49; // ecx
 	int *v50; // eax
 	signed int v51; // ecx
-	signed int v52; // edi
+	__int64 v52; // edi
 	int v53; // esi
 	int v54; // ebx
 	int v55; // eax
 	bool v56; // zf
-	signed int v57; // ebx
+	__int64 v57; // ebx
 	unsigned int v58; // edi
 	signed int v59; // edx
 	int v60; // ebx
@@ -5151,37 +5151,28 @@ LABEL_47:
 				if ( v5 || arglist != myplr )
 					return;
 				sfx_ida = 0;
-				v138 = 0;
 				v52 = 1;
 				v53 = arglist;
-				v54 = plr[arglist]._pMemSpells[1];
-				v139 = 37;
+				v139 = MAX_SPELLS;
 				do
 				{
-					v7 = v138 & v54;
-					if ( v138 & v54 | v52 & plr[arglist]._pMemSpells[0] )
+					if ( v52 & plr[arglist]._pMemSpells64 )
 						++sfx_ida;
-					v55 = __PAIR__((unsigned int)v138, v52) >> 31;
 					v52 *= 2;
 					v56 = v139-- == 1;
-					v138 = v55;
 				}
 				while ( !v56 );
 				v57 = 1;
 				if ( sfx_ida > 1 )
 				{
-					v58 = 0;
 					v59 = 1;
 					do
 					{
-						v7 = v58 & plr[v53]._pMemSpells[1];
-						if ( v7 | v57 & plr[v53]._pMemSpells[0] )
-						{
+						if ( v57 & plr[v53]._pMemSpells64 ) {
 							v7 = (int)&plr[v53]._pSplLvl[v59];
 							if ( *(_BYTE *)v7 < 15 )
 								++*(_BYTE *)v7;
 						}
-						v58 = __PAIR__(v58, v57) >> 31;
 						v57 *= 2;
 						++v59;
 					}
@@ -5189,9 +5180,8 @@ LABEL_47:
 					do
 					{
 						v60 = random(0, MAX_SPELLS);
-						v7 = v60;
 					}
-					while ( !(plr[v53]._pMemSpells[1] & ((unsigned __int64)((__int64)1 << v60) >> 32) | plr[v53]._pMemSpells[0] & (unsigned int)((__int64)1 << v60)) );
+					while ( !(plr[v53]._pMemSpells64 & ((__int64)1 << v60)) );
 					v61 = &plr[v53]._pSplLvl[v60 + 1];
 					if ( *v61 < 2 )
 						*v61 = 0;
@@ -5224,10 +5214,7 @@ LABEL_47:
 				if ( v5 || arglist != myplr )
 					return;
 				v7 = 21720 * arglist;
-				v65 = plr[arglist]._pMemSpells;
-				v66 = plr[arglist]._pMemSpells[1];
-				*v65 |= 1u;
-				v65[1] = v66;
+				plr[arglist]._pMemSpells64 |= (__int64)1 << (SPL_FIREBOLT - 1);
 				v67 = plr[arglist]._pSplLvl[1];
 				if ( v67 < 15 )
 					plr[0]._pSplLvl[v7 + 1] = v67 + 1;
@@ -5420,10 +5407,7 @@ LABEL_47:
 				if ( v5 || arglist != myplr )
 					return;
 				v7 = 21720 * arglist;
-				v94 = plr[arglist]._pMemSpells;
-				v95 = plr[arglist]._pMemSpells[1];
-				*((_BYTE *)v94 + 3) |= 0x20u;
-				v94[1] = v95;
+				plr[arglist]._pMemSpells64 |= (__int64)1 << (SPL_CBOLT - 1);
 				v96 = plr[arglist]._pSplLvl[30];
 				if ( v96 < 15 )
 					plr[0]._pSplLvl[v7 + 30] = v96 + 1;
@@ -5549,10 +5533,7 @@ LABEL_47:
 				if ( v5 || arglist != myplr )
 					return;
 				v7 = 21720 * arglist;
-				v113 = plr[arglist]._pMemSpells;
-				v114 = plr[arglist]._pMemSpells[1];
-				*((_BYTE *)v113 + 3) |= 0x40u;
-				v113[1] = v114;
+				plr[arglist]._pMemSpells64 |= (__int64)1 << (SPL_HBOLT - 1);
 				v115 = plr[arglist]._pSplLvl[31];
 				if ( v115 < 15 )
 					plr[0]._pSplLvl[v7 + 31] = v115 + 1;
@@ -7176,7 +7157,7 @@ void __fastcall GetObjectStr(int i)
 			_LOBYTE(infoclr) = 2;
 		}
 	}
-} 
+}
 // 4B883C: using guessed type int infoclr;
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -47,8 +47,7 @@ void __fastcall PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield)
 	pPack->pMaxHPBase = pPlayer->_pMaxHPBase;
 	pPack->pManaBase = pPlayer->_pManaBase;
 	pPack->pMaxManaBase = pPlayer->_pMaxManaBase;
-	pPack->pMemSpells = pPlayer->_pMemSpells[0];
-	pPack->pMemSpells2 = pPlayer->_pMemSpells[1];
+	pPack->pMemSpells = pPlayer->_pMemSpells64;
 
 	for(i = 0; i < MAX_SPELLS; i++)
 		pPack->pSplLvl[i] = pPlayer->_pSplLvl[i];
@@ -196,8 +195,7 @@ void __fastcall UnPackPlayer(PkPlayerStruct *pPack, int pnum, bool killok)
 	}
 	pPlayer->_pMaxManaBase = pPack->pMaxManaBase;
 	pPlayer->_pManaBase = pPack->pManaBase;
-	pPlayer->_pMemSpells[0] = pPack->pMemSpells;
-	pPlayer->_pMemSpells[1] = pPack->pMemSpells2;
+	pPlayer->_pMemSpells64 = pPack->pMemSpells;
 
 	for(i = 0; i < MAX_SPELLS; i++)
 		pPlayer->_pSplLvl[i] = pPack->pSplLvl[i];

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -622,7 +622,7 @@ void __fastcall CreatePlayer(int pnum, char c)
     plr[pnum]._pSpellFlags = 0;
 
     if (plr[pnum]._pClass == PC_SORCERER) {
-        plr[pnum]._pSplLvl[1] = 2;
+        plr[pnum]._pSplLvl[SPL_FIREBOLT] = 2;
     }
 
     // interestingly, only the first three hotkeys are reset

--- a/structs.h
+++ b/structs.h
@@ -1396,8 +1396,7 @@ struct PkPlayerStruct {
     int pManaBase;
     int pMaxManaBase;
     char pSplLvl[MAX_SPELLS];
-    int pMemSpells; /* __int64 */
-    int pMemSpells2;
+    unsigned __int64 pMemSpells;
     PkItemStruct InvBody[7];
     PkItemStruct InvList[40];
     char InvGrid[40];


### PR DESCRIPTION
This is mostly to clean up some of the code surrounding the union types for spells. OperateBook is bin exact except for using a DWORD instead of CHAR when adding the guardian spell. Everything else also improves the diff, but not in a significant way.