### PR TITLE
clean msgcmd.cpp

### DIFF
--- a/3rdParty/Storm/Source/storm.cpp
+++ b/3rdParty/Storm/Source/storm.cpp
@@ -134,11 +134,11 @@ BOOL STORMAPI SGdiSetPitch(int pitch) rBool;
 
 BOOL STORMAPI Ordinal393(char *string, int, int) rBool;
 
-void* STORMAPI SMemAlloc(size_t amount, char *logfilename, int logline, char defaultValue) rPVoid;
+void* STORMAPI SMemAlloc(size_t amount, const char *logfilename, int logline, int flags) rPVoid;
 
-BOOL STORMAPI SMemFree(void *location, char *logfilename, int logline, char defaultValue) rBool;
+BOOL STORMAPI SMemFree(void *location, const char *logfilename, int logline, char defaultValue) rBool;
 
-void* STORMAPI SMemReAlloc(void *location, size_t amount, char *logfilename, int logline, char defaultValue) rPVoid;
+void* STORMAPI SMemReAlloc(void *location, size_t amount, const char *logfilename, int logline, int flags) rPVoid;
 
 BOOL STORMAPI SRegLoadData(const char *keyname, const char *valuename, int size, LPBYTE lpData, BYTE flags, LPDWORD lpcbData) rBool;
 BOOL STORMAPI SRegLoadString(const char *keyname, const char *valuename, BYTE flags, char *buffer, size_t buffersize) rBool;

--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -51,7 +51,8 @@ typedef struct _WSIZE
   WORD  cy;
 } WSIZE, *PWSIZE;
 
-
+// flags for memory allocation
+#define SMEM_CLEAR        (1<<3)
 
 // Game states
 #define GAMESTATE_PRIVATE 0x01
@@ -794,9 +795,9 @@ void*
 STORMAPI
 SMemAlloc(
     size_t amount,
-    char  *logfilename,
+    const char  *logfilename,
     int   logline,
-    char  defaultValue = 0);
+    int   flags = 0);
 
 #define SMAlloc(amount) SMemAlloc((amount), __FILE__, __LINE__)
 
@@ -817,7 +818,7 @@ BOOL
 STORMAPI
 SMemFree(
     void *location,
-    char *logfilename,
+    const char *logfilename,
     int  logline,
     char defaultValue = 0);
 
@@ -844,9 +845,9 @@ STORMAPI
 SMemReAlloc(
     void    *location,
     size_t  amount,
-    char    *logfilename,
+    const char    *logfilename,
     int     logline,
-    char    defaultValue = 0);
+    int     flags = 0);
 
 #define SMReAlloc(loc,s) SMemReAlloc((loc),(s), __FILE__, __LINE__)
 

--- a/MakefileVC
+++ b/MakefileVC
@@ -36,7 +36,7 @@ else
 	VC6_LINK = wine $(VC6_BIN_DIR)/link.exe
 endif
 
-CFLAGS=/nologo /c /GX /W3 /O1 /I $(VC6_INC_DIR) /FD /MT /D "NDEBUG" /D "WIN32" /D "_WINDOWS" /Fp"Diablo.pch" /YX /Gm /Zi
+CFLAGS=/nologo /c /GX- /W3 /O1 /I $(VC6_INC_DIR) /FD /MT /D "NDEBUG" /D "WIN32" /D "_WINDOWS" /Fp"Diablo.pch" /YX /Gm /Zi
 LINKFLAGS=/nologo /subsystem:windows /machine:I386 /incremental:no
 
 ifeq ($(MAKE_BUILD),pdb)

--- a/Source/msgcmd.cpp
+++ b/Source/msgcmd.cpp
@@ -1,272 +1,196 @@
 //HEADER_GOES_HERE
 
 #include "../types.h"
+//#include <new>
 
-/* TODO: decompile and fix, commands are NOT deleted properly */
+// remove this when <new> is available
+static __inline void* operator new(size_t count, void* _p) { return _p; }
 
-int msgcmd_cpp_init_value; // weak
-ChatCmd sgChat_Cmd;
-int sgdwMsgCmdTimer;
+static float msgcmd_cpp_init_value = INFINITY;
 
-const int msgcmd_inf = 0x7F800000; // weak
+// hack to get the object name from a pointer without using type_info.raw_name()
+#define OBJECT_NAME(obj) (((const char*)&typeid(obj))+8)
 
-struct msgcmd_cpp_init_1
-{
-	msgcmd_cpp_init_1()
-	{
-		msgcmd_cpp_init_value = msgcmd_inf;
-	}
-} _msgcmd_cpp_init_1;
-// 47F150: using guessed type int msgcmd_inf;
-// 6761A0: using guessed type int msgcmd_cpp_init_value;
+// double-linked list implementation
+struct LListNode {
+	struct LListNode *prev;
+	struct LListNode *next;
+	LListNode() : prev(NULL), next(NULL) {}
+	~LListNode();
+};
 
-struct msgcmd_cpp_init_2
-{
-	msgcmd_cpp_init_2()
-	{
-		msgcmd_init_event();
-		msgcmd_cleanup_chatcmd_atexit();
-	}
-} _msgcmd_cpp_init_2;
+struct EXTERNMESSAGE {
+	struct LListNode node;
+	char command[128];
+	// stupid compiler won't generate a scalar destructor, fake it
+	void* Cleanup(char final=0);
+};
 
-void __cdecl msgcmd_init_event()
-{
-	msgcmd_init_chatcmd(&sgChat_Cmd);
-}
+struct ChatCmd {
+	int default_size;
+	struct LListNode node;
+	ChatCmd();
+	~ChatCmd() { Cleanup(); }
+	struct LListNode* delete_server_cmd_W(struct EXTERNMESSAGE* msg);
+	struct EXTERNMESSAGE* msgcmd_alloc_event(int type, size_t extra_len=0, int flags=0);
+	void msgcmd_event_type(struct EXTERNMESSAGE *msg, int type, struct LListNode *tail);
+	void msgcmd_free_event();
+	void Cleanup();
+};
 
-void __cdecl msgcmd_cleanup_chatcmd_atexit()
-{
-	atexit(msgcmd_cleanup_chatcmd);
-}
-
-void __cdecl msgcmd_cleanup_chatcmd()
-{
-	msgcmd_cleanup_chatcmd_1(&sgChat_Cmd);
-	msgcmd_cleanup_extern_msg(sgChat_Cmd.extern_msgs);
-}
+static ChatCmd sgChat_Cmd;
 
 void __cdecl msgcmd_cmd_cleanup()
 {
-	msgcmd_free_event(&sgChat_Cmd);
+	sgChat_Cmd.msgcmd_free_event();
 }
 
 void __cdecl msgcmd_send_chat()
 {
-	ServerCommand *v0; // esi
-	int v1; // eax
+	static DWORD sgdwMsgCmdTimer;
+	DWORD tick;
+	struct EXTERNMESSAGE *msg;
 
-	if ( (signed int)sgChat_Cmd.extern_msgs[1] > 0 )
-	{
-		v0 = sgChat_Cmd.extern_msgs[1];
-		v1 = GetTickCount();
-		if ( (unsigned int)(v1 - sgdwMsgCmdTimer) >= 2000 )
-		{
-			sgdwMsgCmdTimer = v1;
-			SNetSendServerChatCommand(v0->command);
-			msgcmd_delete_server_cmd_W(&sgChat_Cmd, v0);
-		}
+	if ((int)sgChat_Cmd.node.next <= 0)
+		return;
+
+	msg = (struct EXTERNMESSAGE*)sgChat_Cmd.node.next;
+	tick = GetTickCount();
+	if (tick - sgdwMsgCmdTimer >= 2000) {
+		sgdwMsgCmdTimer = tick;
+		SNetSendServerChatCommand(msg->command);
+		sgChat_Cmd.delete_server_cmd_W(msg);
 	}
 }
 
-bool __fastcall msgcmd_add_server_cmd_W(char *chat_message)
+BOOL __fastcall msgcmd_add_server_cmd_W(const char *chat_message)
 {
-	if ( *chat_message != '/' )
-		return 0;
+	if (chat_message[0] != '/')
+		return FALSE;
 	msgcmd_add_server_cmd(chat_message);
-	return 1;
+	return TRUE;
 }
 
-void __fastcall msgcmd_add_server_cmd(char *command)
+void __fastcall msgcmd_add_server_cmd(const char *command)
 {
-	char *v1; // edi
-	size_t v2; // eax
-	int v3; // edx
-	size_t v4; // esi
-	ChatCmd *v5; // eax
-
-	v1 = command;
-	v2 = strlen(command);
-	if ( v2 )
-	{
-		v4 = v2 + 1;
-		if ( v2 + 1 <= 0x80 )
-		{
-			v5 = msgcmd_alloc_event(&sgChat_Cmd, v3, 2, 0, 0);
-			memcpy(&v5->extern_msgs[1], v1, v4);
-		}
+	size_t len = strlen(command);
+	if (len && ++len <= 128) {
+		struct EXTERNMESSAGE *msg = sgChat_Cmd.msgcmd_alloc_event(2);
+		memcpy(msg->command, command, len);
 	}
 }
 
-void __fastcall msgcmd_init_chatcmd(ChatCmd *chat_cmd)
+ChatCmd::ChatCmd()
 {
-	ServerCommand **v1; // edx
-
-	v1 = chat_cmd->extern_msgs;
-	*v1 = 0;
-	v1[1] = 0;
-	*v1 = (ServerCommand *)v1;
-	chat_cmd->next = 0;
-	chat_cmd->extern_msgs[1] = (ServerCommand *)~(unsigned int)chat_cmd->extern_msgs;
+	node.prev = &node;
+	default_size = 0;
+	node.next = (struct LListNode*)~((int)&node);
 }
 
-void __fastcall msgcmd_free_event(ChatCmd *a1)
-{
-	int v1; // edx
-	ChatCmd *v2; // edi
-	ChatCmd *v3; // esi
-
-	v2 = a1;
-	while ( 1 )
-	{
-		v3 = (ChatCmd *)v2->extern_msgs[1];
-		if ( (signed int)v3 <= 0 )
-			break;
-		msgcmd_remove_event(v3, v1);
-		SMemFree(v3, ".?AUEXTERNMESSAGE@@", -2, 0);
+void ChatCmd::msgcmd_free_event() {
+	while (1) {
+		struct EXTERNMESSAGE *msg = (struct EXTERNMESSAGE*)node.next;
+		if ((int)msg <= 0)
+			return;
+		msg->Cleanup();
+		SMemFree(msg, OBJECT_NAME(*msg), SLOG_OBJECT);
 	}
 }
 
-bool __fastcall msgcmd_delete_server_cmd_W(ChatCmd *cmd, ServerCommand *extern_msg)
-{
-	char *v2; // eax
-	ServerCommand *v3; // eax
-	bool v4; // si
-	ChatCmd *ptr; // [esp+Ch] [ebp+4h]
+struct LListNode* ChatCmd::delete_server_cmd_W(struct EXTERNMESSAGE *msg) {
+	struct LListNode *n;
+	struct LListNode *Node;
 
-	v2 = (char *)ptr;
-	if ( !ptr )
-		v2 = (char *)cmd->extern_msgs;
-	v3 = (ServerCommand *)*((_DWORD *)v2 + 1);
-	if ( (signed int)v3 > 0 )
-		v4 = (char)v3;
+	Node = msg ? &msg->node : &node;
+	if ((int)Node->next <= 0)
+		n = NULL;
 	else
-		v4 = 0;
-	msgcmd_remove_event(ptr, (int)extern_msg);
-	SMemFree(ptr, ".?AUEXTERNMESSAGE@@", -2, 0);
-	return v4;
+		n = Node->next;
+
+	msg->Cleanup();
+	SMemFree(msg, OBJECT_NAME(*msg), SLOG_OBJECT);
+	return n;
 }
 
-ChatCmd *__fastcall msgcmd_alloc_event(ChatCmd *a1, int a2, int a3, int a4, int a5)
-{
-	int v5; // eax
-	ChatCmd *v6; // edi
-	ChatCmd *v7; // eax
-	int v8; // edx
-	ChatCmd *v9; // esi
-
-	v5 = a5;
-	_LOBYTE(v5) = a5 | 8;
-	v6 = a1;
-	v7 = (ChatCmd *)SMemAlloc(a4 + 136, ".?AUEXTERNMESSAGE@@", -2, v5);
-	if ( v7 )
-	{
-		v7->next = 0;
-		v7->extern_msgs[0] = 0;
-		v9 = v7;
-	}
-	else
-	{
-		v9 = 0;
-	}
-	if ( a3 )
-		msgcmd_event_type(v6, v8, (int *)v9, a3, 0);
-	return v9;
+struct EXTERNMESSAGE* ChatCmd::msgcmd_alloc_event(int type, size_t extra_len, int flags) {
+	struct EXTERNMESSAGE *msg;
+	void *obj = SMemAlloc(sizeof(*msg)+extra_len, OBJECT_NAME(*msg), SLOG_OBJECT, flags|SMEM_CLEAR);
+	msg = new(obj) EXTERNMESSAGE();
+	if (type)
+		msgcmd_event_type(msg, type, NULL);
+	return msg;
 }
 
-void __fastcall msgcmd_remove_event(ChatCmd *a1, int a2)
+void* EXTERNMESSAGE::Cleanup(char final)
 {
-	ServerCommand **v2; // esi
-
-	v2 = (ServerCommand **)a1;
-	msgcmd_cleanup_extern_msg((ServerCommand **)a1);
-	msgcmd_cleanup_extern_msg(v2);
-	if ( a2 & 1 )
-	{
-		if ( v2 )
-			SMemFree(v2, "delete", -1, 0);
-	}
+	// BUGFIX: no need to explicitly call member destructor
+	node.~LListNode();
+	this->~EXTERNMESSAGE();
+	if (final&1 && this)
+		SMemFree(this, "delete", SLOG_FUNCTION);
+	return this;
 }
 
-void __fastcall msgcmd_event_type(ChatCmd *a1, int a2, int *a3, int a4, int a5)
-{
-	ChatCmd *v5; // edi
-	int *v6; // esi
-	int *v7; // eax
-	int v8; // ecx
-	int v9; // edx
-	int v10; // ecx
-	int v11; // edx
-
-	v5 = a1;
-	v6 = a3;
-	if ( !a3 )
-		v6 = (int *)a1->extern_msgs;
-	if ( *v6 )
-		msgcmd_cleanup_extern_msg((ServerCommand **)v6);
-	v7 = (int *)a5;
-	if ( !a5 )
-		v7 = (int *)v5->extern_msgs;
-	if ( a4 == 1 )
-	{
-		*v6 = (int)v7;
-		v6[1] = v7[1];
-		v9 = v7[1];
-		v10 = (int)v5->next;
-		if ( v9 > 0 )
-		{
-			if ( v10 < 0 )
-				v10 = (int)v7 - *(_DWORD *)(*v7 + 4);
-			v11 = v10 + v9;
-		}
-		else
-		{
-			v11 = ~v9;
-		}
-		*(_DWORD *)v11 = (unsigned int)v6;
-		v7[1] = (int)a3;
-	}
-	else if ( a4 == 2 )
-	{
-		v8 = *v7;
-		*v6 = *v7;
-		v6[1] = *(_DWORD *)(v8 + 4);
-		*(_DWORD *)(v8 + 4) = (unsigned int)a3;
-		*v7 = (int)v6;
-	}
-}
-
-void __fastcall msgcmd_cleanup_chatcmd_1(ChatCmd *a1)
-{
-	ChatCmd *v1; // esi
-	ServerCommand **v2; // ecx
-
-	v1 = a1;
-	while ( 1 )
-	{
-		v2 = (ServerCommand **)v1->extern_msgs[1];
-		if ( (signed int)v2 <= 0 )
+void ChatCmd::msgcmd_event_type(struct EXTERNMESSAGE *msg, int type, struct LListNode *tail) {
+	int len;
+	struct LListNode *Node = &msg->node;
+	struct LListNode *head;
+	if (msg == NULL)
+		Node = &node;
+	if (Node->prev)
+		Node->~LListNode();
+	if (tail == NULL)
+		tail = &node;
+	switch (type) {
+		case 1:
+			Node->prev = tail;
+			Node->next = tail->next;
+			head = tail->next;
+			len = default_size;
+			if ((int)head <= 0)
+				head = (struct LListNode*)~(int)head;
+			else {
+				if (len < 0)
+					len = (char*)tail - (char*)tail->prev->next;
+				head = (struct LListNode*)((char*)head + len);
+			}
+			head->prev = Node;
+			tail->next = &msg->node;
 			break;
-		msgcmd_cleanup_extern_msg(v2);
+		case 2:
+			head = tail->prev;
+			Node->prev = head;
+			Node->next = head->next;
+			head->next = &msg->node;
+			tail->prev = Node;
 	}
 }
 
-void __fastcall msgcmd_cleanup_extern_msg(ServerCommand **extern_msgs)
+void ChatCmd::Cleanup()
 {
-	ServerCommand *v1; // esi
-	signed int v2; // edx
-	int v3; // edx
-
-	v1 = *extern_msgs;
-	if ( *extern_msgs )
-	{
-		v2 = (signed int)extern_msgs[1];
-		if ( v2 > 0 )
-			v3 = (int)extern_msgs + v2 - v1->field_4;
-		else
-			v3 = ~v2;
-		*(_DWORD *)v3 = (unsigned int)v1;
-		(*extern_msgs)->field_4 = (int)extern_msgs[1];
-		*extern_msgs = 0;
-		extern_msgs[1] = 0;
+	while (1) {
+		if ((int)node.next <= 0)
+			return;
+		node.next->~LListNode();
 	}
 }
+
+LListNode::~LListNode()
+{
+	struct LListNode *n;
+	struct LListNode *p = prev;
+
+	if (p) {
+		n = next;
+		if ((int)n <= 0)
+			n = (struct LListNode*)~((size_t)n);
+		else
+			n = (struct LListNode*)((size_t)this - (size_t)p->next + (size_t)n);
+
+		n->prev = p;
+		prev->next = next;
+		prev = NULL;
+		next = NULL;
+	}
+}
+

--- a/Source/msgcmd.h
+++ b/Source/msgcmd.h
@@ -2,30 +2,9 @@
 #ifndef __MSGCMD_H__
 #define __MSGCMD_H__
 
-extern int msgcmd_cpp_init_value; // weak
-extern ChatCmd sgChat_Cmd;
-extern int sgdwMsgCmdTimer;
-
-void __cdecl msgcmd_cpp_init_1();
-void __cdecl msgcmd_cpp_init_2();
-void __cdecl msgcmd_init_event();
-void __cdecl msgcmd_cleanup_chatcmd_atexit();
-void __cdecl msgcmd_cleanup_chatcmd();
-void __cdecl msgcmd_cmd_cleanup();
 void __cdecl msgcmd_send_chat();
-bool __fastcall msgcmd_add_server_cmd_W(char *chat_message);
-void __fastcall msgcmd_add_server_cmd(char *command);
-void __fastcall msgcmd_init_chatcmd(ChatCmd *chat_cmd);
-void __fastcall msgcmd_free_event(ChatCmd *a1);
-bool __fastcall msgcmd_delete_server_cmd_W(ChatCmd *cmd, ServerCommand *extern_msg);
-ChatCmd *__fastcall msgcmd_alloc_event(ChatCmd *a1, int a2, int a3, int a4, int a5);
-void __fastcall msgcmd_remove_event(ChatCmd *a1, int a2);
-void __fastcall msgcmd_event_type(ChatCmd *a1, int a2, int *a3, int a4, int a5);
-void __fastcall msgcmd_cleanup_chatcmd_1(ChatCmd *a1);
-void __fastcall msgcmd_cleanup_extern_msg(ServerCommand **extern_msgs);
-
-/* rdata */
-
-extern const int msgcmd_inf; // weak
+BOOL __fastcall msgcmd_add_server_cmd_W(const char *chat_message);
+void __fastcall msgcmd_add_server_cmd(const char *command);
+void __cdecl msgcmd_cmd_cleanup();
 
 #endif /* __MSGCMD_H__ */

--- a/structs.h
+++ b/structs.h
@@ -1582,17 +1582,3 @@ struct TDataInfo {
     unsigned char *pbSize;
 };
 
-//////////////////////////////////////////////////
-// msgcmd
-//////////////////////////////////////////////////
-
-struct ServerCommand {
-    int field_0;
-    int field_4;
-    char command[128];
-};
-
-struct ChatCmd {
-    struct ChatCmd *next;
-    ServerCommand *extern_msgs[2];
-};


### PR DESCRIPTION
A quick rundown on the state of this spaghetti C++ code.

The Good:
All static initializer/finalizer stubs are produced as per the original binary, are byte exact and in the correct order.
`msgcmd_add_server_cmd_W`, `msgcmd_add_server_cmd`, the ChatCmd constructor (formerly known as msgcmd_init_chatcmd), `::msgcmd_free_event`, `::delete_server_cmd_W`, `::msgcmd_alloc_event`, `EXTERNMESSAGE::Cleanup` (formerly known as msgcmd_remove_event), `::msgcmd_event_type` and `ChatCmd::Cleanup` (formerly known as msgcmd_cleanup_chatcmd_1) are all byte exact.
Found a new flag for SMemAlloc/SMemRealloc that zeroes the newly allocated memory.

The Bad:
`msgcmd_send_chat` has minor diffs; for some reason the original code uses eax at the beginning of the function which is odd, and there's a reordered push further down.
The LListNode destructor (formerly known as msgcmd_cleanup_extern_msg) has a few diffs because it refuses to push esi at the beginning of the function and instead does it in the middle.
Running the comparer obviously doesn't work very well because most of the functions have changed names. I don't know if the original names were authentic, I tried to reuse what I could.
I didn't pay any attention to style because this will need further cleaning up.
The typeid() stuff to get object names is a hack that may not be compatible with other compilers.

The Ugly:
C++ exception handling has to be disabled (/GX-) because otherwise calls to setup the handling frame get inserted everywhere.
The "new" include file is missing from the docker image so I had to improvise and define the placement new operator manually.
The compiler refused to emit a scalar destructor for EXTERNMESSAGE, so I had to improvise and fake one - that's what EXTERNMESSAGE::Cleanup() is.
The implementation is garbage; it assumes valid pointers are always below 0x80000000 which isn't true. There's even a bootflag you can pass to windows to make it put process heaps at the top of the address space instead of the bottom, in which case this code will crash and burn.
The calls to SMemAlloc+placement new and explicit destructors+SMemFree are likely meant to be simple calls to new/delete wrapped in c++ magic. But since c++ is so flexible there's more than a dozen different ways to do everything and the way it is now matches the original. Plus it's just a crappy double linked list implementation to handle commands that are rarely used, who cares - just get it close enough to binary exact so it can be rewritten as something sane.

Not sure what happened to structs.h, looks like it got clobbered during a rebase. Will fix later.