### PR TITLE
add missing va_end "calls"

### DIFF
--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -214,6 +214,7 @@ void TermMsg(char *pszFmt, ...)
 	FreeDlg();
 	if ( pszFmt )
 		MsgBox(pszFmt, arglist);
+	va_end(arglist);
 	init_cleanup(0);
 	exit(1);
 }
@@ -254,6 +255,7 @@ void DrawDlg(char *pszFmt, ...)
 
 	va_start(arglist, pszFmt);
 	wvsprintf(text, pszFmt, arglist);
+	va_end(arglist);
 	SDrawMessageBox(text, "Diablo", MB_TASKMODAL|MB_ICONEXCLAMATION);
 }
 

--- a/Source/logging.cpp
+++ b/Source/logging.cpp
@@ -178,6 +178,7 @@ void log_printf(const char *pszFmt, ...)
 	va_start(va, pszFmt);
 	EnterCriticalSection(&sgMemCrit);
 	_vsnprintf(v3, 0x200u, pszFmt, va);
+	va_end(va);
 	v3[511] = 0;
 	v1 = strlen(v3);
 	if ( v1 + nNumberOfBytesToWrite > 0x1000 )

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1878,6 +1878,7 @@ void msg_errorf(char *pszFmt, ...)
 		vsprintf(v2, pszFmt, va);
 		ErrorPlrMsg(v2);
 	}
+	va_end(va);
 }
 // 67619C: using guessed type int msg_err_timer;
 


### PR DESCRIPTION
This is a cosmetic change because x86 va_end is a macro that doesn't do anything.