### PR TITLE
add inline assembly code for drawing semi-transparent rectangles

### DIFF
--- a/Source/asm_trans_rect.inc
+++ b/Source/asm_trans_rect.inc
@@ -1,0 +1,84 @@
+/*  Draws a half-transparent rectangle by blacking out odd pixels on odd lines,
+ *  even pixels on even lines.
+ *
+ *  TRANS_RECT_X = x offset of upper-left corner
+ *  TRANS_RECT_Y = y offset of upper-left corner
+ *  TRANS_RECT_WIDTH = width of rectangle
+ *  TRANS_RECT_HEIGHT = height of rectangle
+ */
+
+#if !defined(TRANS_RECT_X) || !defined(TRANS_RECT_Y) || !defined(TRANS_RECT_WIDTH) || !defined(TRANS_RECT_HEIGHT)
+#error ASM_TRANS_RECT: Parameter not set
+#endif
+
+#if defined(_MSC_VER) && defined(_M_IX86)
+__asm {
+	mov edi, gpBuffer
+	// origin is at 64,160
+	add edi, (160+TRANS_RECT_Y+TRANS_RECT_HEIGHT-1)*ROW_PITCH+64+TRANS_RECT_X
+	xor eax, eax
+	mov edx, TRANS_RECT_HEIGHT>>1
+yloop:
+	mov ecx, TRANS_RECT_WIDTH>>1
+x0loop:
+	stosb
+	inc edi
+	loop x0loop
+#if (TRANS_RECT_WIDTH & 1)
+	stosb
+#endif
+	sub edi, ROW_PITCH+TRANS_RECT_WIDTH
+	mov ecx, TRANS_RECT_WIDTH>>1
+x1loop:
+	inc edi
+	stosb
+	loop x1loop
+	sub edi, ROW_PITCH+(TRANS_RECT_WIDTH&~1)
+	dec edx
+	jnz yloop
+#if (TRANS_RECT_HEIGHT & 1)
+	mov ecx, TRANS_RECT_WIDTH>>1
+x2loop:
+	stosb
+	inc edi
+	loop x2loop
+#if (TRANS_RECT_WIDTH & 1)
+	stosb
+#endif
+#endif
+}
+#else  // _MSC_VER && _M_IX86
+{
+	int row, col;
+	char *pix = &gpBuffer->row[TRANS_RECT_Y+TRANS_RECT_HEIGHT-1].pixels[TRANS_RECT_X];
+	for (row = TRANS_RECT_HEIGHT>>1; row != 0; row--) {
+		for (col = TRANS_RECT_WIDTH>>1; col != 0; col--) {
+			*pix++ = 0;
+			pix++;
+		}
+#if (TRANS_RECT_WIDTH & 1)
+		*pix++ = 0;
+#endif
+		pix -= ROW_PITCH+TRANS_RECT_WIDTH;
+		for (col = TRANS_RECT_WIDTH>>1; col != 0; col--) {
+			pix++;
+			*pix++ = 0;
+		}
+		pix -= ROW_PITCH+(TRANS_RECT_WIDTH&~1);
+	}
+#if (TRANS_RECT_HEIGHT & 1)
+	for (col = TRANS_RECT_WIDTH>>1; col != 0; col--) {
+		*pix++ = 0;
+		pix++;
+	}
+#if (TRANS_RECT_WIDTH & 1)
+	*pix++ = 0;
+#endif
+#endif
+}
+#endif
+
+#undef TRANS_RECT_Y
+#undef TRANS_RECT_X
+#undef TRANS_RECT_WIDTH
+#undef TRANS_RECT_HEIGHT

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -99,12 +99,6 @@ void __cdecl DrawDiabloMsg()
 {
 	int v0; // esi
 	signed int v1; // edi
-	char *v2; // edi
-	signed int v3; // edx
-	signed int v4; // ecx
-	int v5; // edi
-	signed int v6; // ecx
-	_BYTE *v7; // edi
 	int v8; // edi
 	signed int v9; // ebx
 	signed int v10; // eax
@@ -141,32 +135,13 @@ void __cdecl DrawDiabloMsg()
 		--v1;
 	}
 	while ( v1 );
-	v2 = &gpBuffer->row[203].pixels[104];
-	v3 = 27;
-	do
-	{
-		v4 = 216;
-		do
-		{
-			*v2 = 0;
-			v2 += 2;
-			--v4;
-		}
-		while ( v4 );
-		v5 = (int)(v2 - 1200);
-		v6 = 216;
-		do
-		{
-			v7 = (_BYTE *)(v5 + 1);
-			*v7 = 0;
-			v5 = (int)(v7 + 1);
-			--v6;
-		}
-		while ( v6 );
-		v2 = (char *)(v5 - 1200);
-		--v3;
-	}
-	while ( v3 );
+
+#define TRANS_RECT_X 104
+#define TRANS_RECT_Y 150
+#define TRANS_RECT_WIDTH 432
+#define TRANS_RECT_HEIGHT 54
+#include "asm_trans_rect.inc"
+
 	strcpy(tempstr, MsgStrings[msgflag]);
 	v8 = screen_y_times_768[342] + 165;
 	v9 = strlen(tempstr);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4006,51 +4006,13 @@ LABEL_104:
 
 void __cdecl DrawUBack()
 {
-	char *v0; // edi
-	signed int v1; // edx
-	signed int v2; // ecx
-	int v3; // edi
-	signed int v4; // ecx
-	_BYTE *v5; // edi
-	signed int v6; // ecx
-
 	CelDecodeOnly(88, 487, pSTextBoxCels, 1, 271);
-	v0 = &gpBuffer->row[324].pixels[27];
-	v1 = 148;
-	do
-	{
-		v2 = 132;
-		do
-		{
-			*v0 = 0;
-			v0 += 2;
-			--v2;
-		}
-		while ( v2 );
-		*v0 = 0;
-		v3 = (int)(v0 - 1032);
-		v4 = 132;
-		do
-		{
-			v5 = (_BYTE *)(v3 + 1);
-			*v5 = 0;
-			v3 = (int)(v5 + 1);
-			--v4;
-		}
-		while ( v4 );
-		v0 = (char *)(v3 - 1032);
-		--v1;
-	}
-	while ( v1 );
-	v6 = 132;
-	do
-	{
-		*v0 = 0;
-		v0 += 2;
-		--v6;
-	}
-	while ( v6 );
-	*v0 = 0;
+
+#define TRANS_RECT_X 27
+#define TRANS_RECT_Y 28
+#define TRANS_RECT_WIDTH 265
+#define TRANS_RECT_HEIGHT 297
+#include "asm_trans_rect.inc"
 }
 
 void __fastcall PrintUString(int x, int y, int cjustflag, char *str, int col)

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -88,51 +88,13 @@ void __fastcall InitQTextMsg(int m)
 
 void __cdecl DrawQTextBack()
 {
-	char *v0; // edi
-	signed int v1; // edx
-	signed int v2; // ecx
-	int v3; // edi
-	signed int v4; // ecx
-	_BYTE *v5; // edi
-	signed int v6; // ecx
-
 	CelDecodeOnly(88, 487, pTextBoxCels, 1, 591);
-	v0 = &gpBuffer->row[324].pixels[27];
-	v1 = 148;
-	do
-	{
-		v2 = 292;
-		do
-		{
-			*v0 = 0;
-			v0 += 2;
-			--v2;
-		}
-		while ( v2 );
-		*v0 = 0;
-		v3 = (int)(v0 - 1352);
-		v4 = 292;
-		do
-		{
-			v5 = (_BYTE *)(v3 + 1);
-			*v5 = 0;
-			v3 = (int)(v5 + 1);
-			--v4;
-		}
-		while ( v4 );
-		v0 = (char *)(v3 - 1352);
-		--v1;
-	}
-	while ( v1 );
-	v6 = 292;
-	do
-	{
-		*v0 = 0;
-		v0 += 2;
-		--v6;
-	}
-	while ( v6 );
-	*v0 = 0;
+
+#define TRANS_RECT_X 27
+#define TRANS_RECT_Y 28
+#define TRANS_RECT_WIDTH 585
+#define TRANS_RECT_HEIGHT 297
+#include "asm_trans_rect.inc"
 }
 
 void __fastcall PrintQTextChr(int screen_x, int screen_y, char *cel_buf, int frame)

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -155,51 +155,13 @@ void __cdecl FreeStoreMem()
 
 void __cdecl DrawSTextBack()
 {
-	char *v0; // edi
-	signed int v1; // edx
-	signed int v2; // ecx
-	int v3; // edi
-	signed int v4; // ecx
-	_BYTE *v5; // edi
-	signed int v6; // ecx
-
 	CelDecodeOnly(408, 487, pSTextBoxCels, 1, 271);
-	v0 = &gpBuffer->row[324].pixels[347];
-	v1 = 148;
-	do
-	{
-		v2 = 132;
-		do
-		{
-			*v0 = 0;
-			v0 += 2;
-			--v2;
-		}
-		while ( v2 );
-		*v0 = 0;
-		v3 = (int)(v0 - 1032);
-		v4 = 132;
-		do
-		{
-			v5 = (_BYTE *)(v3 + 1);
-			*v5 = 0;
-			v3 = (int)(v5 + 1);
-			--v4;
-		}
-		while ( v4 );
-		v0 = (char *)(v3 - 1032);
-		--v1;
-	}
-	while ( v1 );
-	v6 = 132;
-	do
-	{
-		*v0 = 0;
-		v0 += 2;
-		--v6;
-	}
-	while ( v6 );
-	*v0 = 0;
+
+#define TRANS_RECT_X 347
+#define TRANS_RECT_Y 28
+#define TRANS_RECT_WIDTH 265
+#define TRANS_RECT_HEIGHT 297
+#include "asm_trans_rect.inc"
 }
 
 void __fastcall PrintSString(int x, int y, unsigned char cjustflag, char *str, int col, int val)

--- a/defs.h
+++ b/defs.h
@@ -4,6 +4,7 @@
 #define DMAXY					40
 
 #define LIGHTSIZE				6912 // 27 * 256
+#define ROW_PITCH				768
 
 // must be unsigned to generate unsigned comparisons with pnum
 #define MAX_PLRS				4


### PR DESCRIPTION
This is a bit ugly but I can't think of any other way it would have been achieved, given MSVC's abysmal support for inline asm. Anything preceeded by `__asm` gets passed straight through to the assembler (even if it's inside an `if (0)` block) so abusing the preprocessor seems to be the only option.

This code is used for drawing the half-transparent backgrounds for NPC dialogs, store listings, unique item descriptions and "error" messages.
After this change `DrawUBack`, `DrawQTextBack` and `DrawSTextBack` are all byte-exact. `DrawDiabloMsg` has other code around the assembly that I didn't touch so it still needs cleaning.