### PR TITLE
msg.cpp: clean all On_* functions

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2616,7 +2616,7 @@ int __fastcall InvPutItem(int pnum, int x, int y)
 	return yc;
 }
 
-int __fastcall SyncPutItem(int pnum, int x, int y, int idx, int icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, unsigned int ibuff)
+int __fastcall SyncPutItem(int pnum, int x, int y, int idx, WORD icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, unsigned int ibuff)
 {
 	int v13; // ebx
 	int v14; // edi

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -36,7 +36,7 @@ int __fastcall CanPut(int i, int j);
 int __cdecl TryInvPut();
 void __fastcall DrawInvMsg(char *msg);
 int __fastcall InvPutItem(int pnum, int x, int y);
-int __fastcall SyncPutItem(int pnum, int x, int y, int idx, int icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, unsigned int ibuff);
+int __fastcall SyncPutItem(int pnum, int x, int y, int idx, WORD icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, unsigned int ibuff);
 int __cdecl CheckInvHLight();
 void __fastcall RemoveScroll(int pnum);
 BOOL __cdecl UseScroll();

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -5512,7 +5512,7 @@ void __fastcall CreateMagicItem(int x, int y, int imisc, int icurs, int sendmsg,
 	}
 }
 
-bool __fastcall GetItemRecord(int dwSeed, WORD CI, int indx)
+BOOL __fastcall GetItemRecord(int dwSeed, WORD CI, int indx)
 {
 	int v3; // edi
 	int *v4; // ebx

--- a/Source/items.h
+++ b/Source/items.h
@@ -120,7 +120,7 @@ void __cdecl RecalcStoreStats();
 int __cdecl ItemNoFlippy();
 void __fastcall CreateSpellBook(int x, int y, int ispell, bool sendmsg, int delta);
 void __fastcall CreateMagicItem(int x, int y, int imisc, int icurs, int sendmsg, int delta);
-bool __fastcall GetItemRecord(int dwSeed, WORD CI, int indx);
+BOOL __fastcall GetItemRecord(int dwSeed, WORD CI, int indx);
 void __fastcall NextItemRecord(int i);
 void __fastcall SetItemRecord(int dwSeed, WORD CI, int indx);
 void __fastcall PutItemRecord(int seed, WORD ci, int index);

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -43,7 +43,7 @@ void __fastcall NetSendCmdParam3(BOOL bHiPri, BYTE bCmd, WORD wParam1, WORD wPar
 void __fastcall NetSendCmdQuest(BOOL bHiPri, BYTE q);
 void __fastcall NetSendCmdGItem(BOOL bHiPri, BYTE bCmd, BYTE mast, BYTE pnum, int ii);
 void __fastcall NetSendCmdGItem2(BOOL usonly, BYTE bCmd, BYTE mast, BYTE pnum, struct TCmdGItem *p);
-bool __fastcall NetSendCmdReq2(BYTE bCmd, BYTE mast, BYTE pnum, struct TCmdGItem *p);
+BOOL __fastcall NetSendCmdReq2(BYTE bCmd, BYTE mast, BYTE pnum, struct TCmdGItem *p);
 void __fastcall NetSendCmdExtra(struct TCmdGItem *p);
 void __fastcall NetSendCmdPItem(BOOL bHiPri, BYTE bCmd, BYTE x, BYTE y);
 void __fastcall NetSendCmdChItem(BOOL bHiPri, BYTE bLoc);
@@ -131,6 +131,7 @@ int __fastcall On_SETDEX(struct TCmdParam1 *pCmd, int pnum);
 int __fastcall On_SETMAG(struct TCmdParam1 *pCmd, int pnum);
 int __fastcall On_SETVIT(struct TCmdParam1 *pCmd, int pnum);
 int __fastcall On_STRING(struct TCmdString *pCmd, int pnum);
+int __fastcall On_STRING2(int pnum, struct TCmdString *pCmd);
 int __fastcall On_SYNCQUEST(struct TCmdQuest *pCmd, int pnum);
 int __fastcall On_ENDSHIELD(struct TCmd *pCmd, int pnum);
 #ifdef _DEBUG


### PR DESCRIPTION
These should all be bin-exact, except the debug functions which I didn't compare.

The old code for On_MONSTDAMAGE was incorrect, it was checking `(hitpoints >> 6) < 64` instead of `(hitpoints >> 6) < 1` when the damage was being done by a remote player, so possibly that was causing multiplayer desyncs.

On_STRING turned out to be two functions, the first just calls the second with the arguments reversed.