### PR TITLE
Gamemenu.cpp

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -139,7 +139,6 @@ void __cdecl InitAutomap()
 	}
 	while ( v13 < 112 );
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __cdecl StartAutomap()
 {
@@ -304,7 +303,6 @@ void __cdecl DrawAutomap()
 	DrawAutomapGame();
 }
 // 4B8968: using guessed type int sbookflag;
-// 5BB1ED: using guessed type char leveltype;
 // 69BD04: using guessed type int questlog;
 // 69CF0C: using guessed type int gpBufEnd;
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1786,7 +1786,6 @@ LABEL_33:
 // 4B8CC0: using guessed type char pcursitem;
 // 4B8CC1: using guessed type char pcursobj;
 // 4B8CC2: using guessed type char pcursplr;
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall control_print_info_str(int y, char *str, bool center, int lines)
 {
@@ -2516,7 +2515,6 @@ void __cdecl RedBack()
 	}
 }
 // 525728: using guessed type int light4flag;
-// 5BB1ED: using guessed type char leveltype;
 
 char __fastcall GetSBookTrans(int ii, BOOL townok)
 {

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1327,7 +1327,7 @@ void __cdecl DoAutoMap()
 	}
 	else
 	{
-		InitDiabloMsg(1);
+		InitDiabloMsg(EMSG_NO_AUTOMAP_IN_TOWN);
 	}
 }
 // 679660: using guessed type char gbMaxPlayers;

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -1295,5 +1295,4 @@ LABEL_172:
 // 4B8CCC: using guessed type int dword_4B8CCC;
 // 52569C: using guessed type int zoomflag;
 // 52575C: using guessed type int doomflag;
-// 5BB1ED: using guessed type char leveltype;
 // 69BD04: using guessed type int questlog;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -17,7 +17,7 @@ BOOL gbRunGameResult;
 int zoomflag; // weak
 BOOL gbProcessPlayers;
 int glEndSeed[NUMLEVELS];
-int dword_5256E8; // weak
+BOOL dword_5256E8;
 HINSTANCE ghInst; // idb
 int DebugMonsters[10];
 char cineflag; // weak
@@ -122,7 +122,7 @@ int __fastcall diablo_init_menu(int a1, int bSinglePlayer)
 	while ( 1 )
 	{
 		pfExitProgram = 0;
-		dword_5256E8 = 0;
+		dword_5256E8 = FALSE;
 		if ( !NetInit(v2, &pfExitProgram) )
 			break;
 		byte_678640 = 0;
@@ -143,7 +143,6 @@ LABEL_11:
 	SNetDestroy();
 	return gbRunGameResult;
 }
-// 5256E8: using guessed type int dword_5256E8;
 // 678640: using guessed type char byte_678640;
 
 void __fastcall run_game_loop(int uMsg)

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -13,7 +13,7 @@ bool gbGameLoopStartup; // idb
 int glSeedTbl[NUMLEVELS];
 BOOL gbRunGame;
 int glMid3Seed[NUMLEVELS];
-int gbRunGameResult; // weak
+BOOL gbRunGameResult;
 int zoomflag; // weak
 BOOL gbProcessPlayers;
 int glEndSeed[NUMLEVELS];
@@ -143,7 +143,6 @@ LABEL_11:
 	SNetDestroy();
 	return gbRunGameResult;
 }
-// 525698: using guessed type int gbRunGameResult;
 // 5256E8: using guessed type int dword_5256E8;
 // 678640: using guessed type char byte_678640;
 
@@ -163,7 +162,7 @@ void __fastcall run_game_loop(int uMsg)
 	msg_process_net_packets();
 	gbRunGame = TRUE;
 	gbProcessPlayers = TRUE;
-	gbRunGameResult = 1;
+	gbRunGameResult = TRUE;
 	drawpanflag = 255;
 	DrawAndBlit();
 	PaletteFadeIn(8);
@@ -180,7 +179,7 @@ void __fastcall run_game_loop(int uMsg)
 			{
 				if ( msg.message == WM_QUIT )
 				{
-					gbRunGameResult = 0;
+					gbRunGameResult = FALSE;
 					gbRunGame = FALSE;
 					break;
 				}
@@ -225,7 +224,6 @@ void __fastcall run_game_loop(int uMsg)
 		DoEnding();
 	}
 }
-// 525698: using guessed type int gbRunGameResult;
 // 525718: using guessed type char cineflag;
 // 52571C: using guessed type int drawpanflag;
 // 679660: using guessed type char gbMaxPlayers;
@@ -817,7 +815,7 @@ LRESULT __stdcall GM_Game(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			if ( wParam == SC_CLOSE )
 			{
 				gbRunGame = FALSE;
-				gbRunGameResult = 0;
+				gbRunGameResult = FALSE;
 				return 0;
 			}
 			return MainWndProc(hWnd, uMsg, wParam, lParam);
@@ -829,7 +827,6 @@ LRESULT __stdcall GM_Game(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	gmenu_on_mouse_move((unsigned short)lParam);
 	return 0;
 }
-// 525698: using guessed type int gbRunGameResult;
 // 52571C: using guessed type int drawpanflag;
 // 525748: using guessed type char sgbMouseDown;
 // 679660: using guessed type char gbMaxPlayers;
@@ -1032,7 +1029,6 @@ LABEL_98:
 // 4B8CC2: using guessed type char pcursplr;
 // 525740: using guessed type int PauseMode;
 // 52575C: using guessed type int doomflag;
-// 5BB1ED: using guessed type char leveltype;
 // 646D00: using guessed type char qtextflag;
 // 69BD04: using guessed type int questlog;
 // 6AA705: using guessed type char stextflag;
@@ -1448,7 +1444,6 @@ LABEL_101:
 // 4B8C98: using guessed type int spselflag;
 // 525740: using guessed type int PauseMode;
 // 52B9F0: using guessed type char msgdelay;
-// 5BB1ED: using guessed type char leveltype;
 // 646D00: using guessed type char qtextflag;
 // 69BD04: using guessed type int questlog;
 // 6AA705: using guessed type char stextflag;
@@ -1851,7 +1846,6 @@ void __cdecl LoadLvlGFX()
 			return;
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __cdecl LoadAllGFX()
 {
@@ -1906,7 +1900,6 @@ void __fastcall CreateLevel(int lvldir)
 
 	LoadRndLvlPal(hnd);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall LoadGameLevel(BOOL firstflag, int lvldir)
 {
@@ -2132,7 +2125,7 @@ LABEL_72:
 		ProcessLightList();
 		ProcessVisionList();
 	}
-	music_start((unsigned char)leveltype);
+	music_start(leveltype);
 	//do
 	//	_LOBYTE(v19) = IncProgress();
 	while ( !IncProgress() );
@@ -2140,7 +2133,6 @@ LABEL_72:
 		PlaySFX(USFX_SKING1);
 }
 // 525738: using guessed type int setseed;
-// 5BB1ED: using guessed type char leveltype;
 // 5CF31D: using guessed type char setlevel;
 // 679660: using guessed type char gbMaxPlayers;
 
@@ -2231,7 +2223,6 @@ void __cdecl game_logic()
 // 525718: using guessed type char cineflag;
 // 52571C: using guessed type int drawpanflag;
 // 525740: using guessed type int PauseMode;
-// 5BB1ED: using guessed type char leveltype;
 // 679660: using guessed type char gbMaxPlayers;
 
 void __fastcall timeout_cursor(bool bTimeout)
@@ -2285,4 +2276,3 @@ void __cdecl diablo_color_cyc_logic()
 }
 // 484364: using guessed type int fullscreen;
 // 52574C: using guessed type int color_cycle_timer;
-// 5BB1ED: using guessed type char leveltype;

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -13,7 +13,7 @@ extern bool gbGameLoopStartup; // idb
 extern int glSeedTbl[NUMLEVELS];
 extern BOOL gbRunGame;
 extern int glMid3Seed[NUMLEVELS];
-extern int gbRunGameResult; // weak
+extern BOOL gbRunGameResult;
 extern int zoomflag; // weak
 extern BOOL gbProcessPlayers;
 extern int glEndSeed[NUMLEVELS];

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -17,7 +17,7 @@ extern BOOL gbRunGameResult;
 extern int zoomflag; // weak
 extern BOOL gbProcessPlayers;
 extern int glEndSeed[NUMLEVELS];
-extern int dword_5256E8; // weak
+extern BOOL dword_5256E8;
 extern HINSTANCE ghInst; // idb
 extern int DebugMonsters[10];
 extern char cineflag; // weak

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -2,31 +2,28 @@
 
 #include "../types.h"
 
-TMenuItem sgSingleMenu[6] =
-{
-  { 0x80000000, "Save Game", &gamemenu_save_game },
-  { 0x80000000, "Options", &gamemenu_options },
-  { 0x80000000, "New Game", &gamemenu_new_game },
-  { 0x80000000, "Load Game", &gamemenu_load_game },
-  { 0x80000000, "Quit Diablo", &gamemenu_quit_game },
-  { 0x80000000, NULL, NULL }
+TMenuItem sgSingleMenu[6] = {
+    { 0x80000000, "Save Game", &gamemenu_save_game },
+    { 0x80000000, "Options", &gamemenu_options },
+    { 0x80000000, "New Game", &gamemenu_new_game },
+    { 0x80000000, "Load Game", &gamemenu_load_game },
+    { 0x80000000, "Quit Diablo", &gamemenu_quit_game },
+    { 0x80000000, NULL, NULL }
 };
-TMenuItem sgMultiMenu[5] =
-{
-  { 0x80000000, "Options", &gamemenu_options },
-  { 0x80000000, "New Game", &gamemenu_new_game },
-  { 0x80000000, "Restart In Town", &gamemenu_restart_town },
-  { 0x80000000, "Quit Diablo", &gamemenu_quit_game },
-  { 0x80000000, NULL, NULL }
+TMenuItem sgMultiMenu[5] = {
+    { 0x80000000, "Options", &gamemenu_options },
+    { 0x80000000, "New Game", &gamemenu_new_game },
+    { 0x80000000, "Restart In Town", &gamemenu_restart_town },
+    { 0x80000000, "Quit Diablo", &gamemenu_quit_game },
+    { 0x80000000, NULL, NULL }
 };
-TMenuItem sgOptionMenu[6] =
-{
-  { 0xC0000000, NULL, (void (__cdecl *)(void))&gamemenu_music_volume },
-  { 0xC0000000, NULL, (void (__cdecl *)(void))&gamemenu_sound_volume },
-  { 0xC0000000, "Gamma", (void (__cdecl *)(void))&gamemenu_gamma },
-  { 0x80000000, NULL, &gamemenu_color_cycling },
-  { 0x80000000, "Previous Menu", &gamemenu_previous },
-  { 0x80000000, NULL, NULL }
+TMenuItem sgOptionMenu[6] = {
+    { 0xC0000000, NULL, (void(__cdecl *)(void)) & gamemenu_music_volume },
+    { 0xC0000000, NULL, (void(__cdecl *)(void)) & gamemenu_sound_volume },
+    { 0xC0000000, "Gamma", (void(__cdecl *)(void)) & gamemenu_gamma },
+    { 0x80000000, NULL, &gamemenu_color_cycling },
+    { 0x80000000, "Previous Menu", &gamemenu_previous },
+    { 0x80000000, NULL, NULL }
 };
 char *music_toggle_names[] = { "Music", "Music Disabled" };
 char *sound_toggle_names[] = { "Sound", "Sound Disabled" };
@@ -34,280 +31,262 @@ char *color_cycling_toggle_names[] = { "Color Cycling Off", "Color Cycling On" }
 
 void __cdecl gamemenu_previous()
 {
-	void (__cdecl *v0)(); // edx
-	TMenuItem *v1; // ecx
+    void(__cdecl * v0)(); // edx
+    TMenuItem *v1;        // ecx
 
-	if ( gbMaxPlayers == 1 )
-	{
-		v0 = gamemenu_enable_single;
-		v1 = sgSingleMenu;
-	}
-	else
-	{
-		v0 = gamemenu_enable_multi;
-		v1 = sgMultiMenu;
-	}
-	gmenu_call_proc(v1, v0);
-	PressEscKey();
+    if (gbMaxPlayers == 1) {
+        v0 = gamemenu_enable_single;
+        v1 = sgSingleMenu;
+    } else {
+        v0 = gamemenu_enable_multi;
+        v1 = sgMultiMenu;
+    }
+    gmenu_call_proc(v1, v0);
+    PressEscKey();
 }
 // 679660: using guessed type char gbMaxPlayers;
 
 void __cdecl gamemenu_enable_single()
 {
-	bool v0; // dl
+    bool v0; // dl
 
-	gmenu_enable(&sgSingleMenu[3], gbValidSaveFile);
-	v0 = 0;
-	if ( plr[myplr]._pmode != PM_DEATH && !deathflag )
-		v0 = 1;
-	gmenu_enable(sgSingleMenu, v0);
+    gmenu_enable(&sgSingleMenu[3], gbValidSaveFile);
+    v0 = 0;
+    if (plr[myplr]._pmode != PM_DEATH && !deathflag)
+        v0 = 1;
+    gmenu_enable(sgSingleMenu, v0);
 }
 
 void __cdecl gamemenu_enable_multi()
 {
-	gmenu_enable(&sgMultiMenu[2], deathflag);
+    gmenu_enable(&sgMultiMenu[2], deathflag);
 }
 
 void __cdecl gamemenu_off()
 {
-	gmenu_call_proc(0, 0);
+    gmenu_call_proc(0, 0);
 }
 
 void __cdecl gamemenu_handle_previous()
 {
-	if ( gmenu_exception() )
-		gamemenu_off();
-	else
-		gamemenu_previous();
+    if (gmenu_exception())
+        gamemenu_off();
+    else
+        gamemenu_previous();
 }
 
 void __cdecl gamemenu_new_game()
 {
-	int i; // eax
+    int i; // eax
 
-	for(i = 0; i < 4; i++)
-	{
-		plr[i]._pmode = PM_QUIT;
-		plr[i]._pInvincible = 1;
-	}
+    for (i = 0; i < 4; i++) {
+        plr[i]._pmode = PM_QUIT;
+        plr[i]._pInvincible = 1;
+    }
 
-	deathflag = FALSE;
-	drawpanflag = 255;
-	scrollrt_draw_game_screen(1);
-	gbRunGame = FALSE;
-	gamemenu_off();
+    deathflag = FALSE;
+    drawpanflag = 255;
+    scrollrt_draw_game_screen(1);
+    gbRunGame = FALSE;
+    gamemenu_off();
 }
 // 52571C: using guessed type int drawpanflag;
 
 void __cdecl gamemenu_quit_game()
 {
-	gamemenu_new_game();
-	gbRunGameResult = 0;
+    gamemenu_new_game();
+    gbRunGameResult = 0;
 }
 // 525698: using guessed type int gbRunGameResult;
 
 void __cdecl gamemenu_load_game()
 {
-	WNDPROC saveProc; // edi
+    WNDPROC saveProc; // edi
 
-	saveProc = SetWindowProc(DisableInputWndProc);
-	gamemenu_off();
-	SetCursor(0);
-	InitDiabloMsg(10);
-	drawpanflag = 255;
-	DrawAndBlit();
-	LoadGame(FALSE);
-	ClrDiabloMsg();
-	PaletteFadeOut(8);
-	deathflag = FALSE;
-	drawpanflag = 255;
-	DrawAndBlit();
-	PaletteFadeIn(8);
-	SetCursor(CURSOR_HAND);
-	interface_msg_pump();
-	SetWindowProc(saveProc);
+    saveProc = SetWindowProc(DisableInputWndProc);
+    gamemenu_off();
+    SetCursor(0);
+    InitDiabloMsg(10);
+    drawpanflag = 255;
+    DrawAndBlit();
+    LoadGame(FALSE);
+    ClrDiabloMsg();
+    PaletteFadeOut(8);
+    deathflag = FALSE;
+    drawpanflag = 255;
+    DrawAndBlit();
+    PaletteFadeIn(8);
+    SetCursor(CURSOR_HAND);
+    interface_msg_pump();
+    SetWindowProc(saveProc);
 }
 // 52571C: using guessed type int drawpanflag;
 
 void __cdecl gamemenu_save_game()
 {
-	WNDPROC saveProc; // edi
+    WNDPROC saveProc; // edi
 
-	if ( pcurs == CURSOR_HAND )
-	{
-		if ( plr[myplr]._pmode == PM_DEATH || deathflag )
-		{
-			gamemenu_off();
-		}
-		else
-		{
-			saveProc = SetWindowProc(DisableInputWndProc);
-			SetCursor(0);
-			gamemenu_off();
-			InitDiabloMsg(11);
-			drawpanflag = 255;
-			DrawAndBlit();
-			SaveGame();
-			ClrDiabloMsg();
-			drawpanflag = 255;
-			SetCursor(CURSOR_HAND);
-			interface_msg_pump();
-			SetWindowProc(saveProc);
-		}
-	}
+    if (pcurs == CURSOR_HAND) {
+        if (plr[myplr]._pmode == PM_DEATH || deathflag) {
+            gamemenu_off();
+        } else {
+            saveProc = SetWindowProc(DisableInputWndProc);
+            SetCursor(0);
+            gamemenu_off();
+            InitDiabloMsg(11);
+            drawpanflag = 255;
+            DrawAndBlit();
+            SaveGame();
+            ClrDiabloMsg();
+            drawpanflag = 255;
+            SetCursor(CURSOR_HAND);
+            interface_msg_pump();
+            SetWindowProc(saveProc);
+        }
+    }
 }
 // 52571C: using guessed type int drawpanflag;
 
 void __cdecl gamemenu_restart_town()
 {
-	NetSendCmd(TRUE, CMD_RETOWN);
+    NetSendCmd(TRUE, CMD_RETOWN);
 }
 
 void __cdecl gamemenu_options()
 {
-	gamemenu_get_music();
-	gamemenu_get_sound();
-	gamemenu_get_gamma();
-	gamemenu_get_color_cycling();
-	gmenu_call_proc(sgOptionMenu, 0);
+    gamemenu_get_music();
+    gamemenu_get_sound();
+    gamemenu_get_gamma();
+    gamemenu_get_color_cycling();
+    gmenu_call_proc(sgOptionMenu, 0);
 }
 
 void __cdecl gamemenu_get_music()
 {
-	gamemenu_sound_music_toggle(music_toggle_names, sgOptionMenu, sound_get_or_set_music_volume(1));
+    gamemenu_sound_music_toggle(music_toggle_names, sgOptionMenu, sound_get_or_set_music_volume(1));
 }
 
 void __fastcall gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int gamma)
 {
-	if ( gbSndInited )
-	{
-		menu_item->dwFlags |= 0xC0000000;
-		menu_item->pszStr = *names;
-		gmenu_slider_3(menu_item, 17);
-		gmenu_slider_1(menu_item, VOLUME_MIN, VOLUME_MAX, gamma);
-	}
-	else
-	{
-		menu_item->dwFlags &= 0x3F000000;
-		menu_item->pszStr = names[1];
-	}
+    if (gbSndInited) {
+        menu_item->dwFlags |= 0xC0000000;
+        menu_item->pszStr = *names;
+        gmenu_slider_3(menu_item, 17);
+        gmenu_slider_1(menu_item, VOLUME_MIN, VOLUME_MAX, gamma);
+    } else {
+        menu_item->dwFlags &= 0x3F000000;
+        menu_item->pszStr = names[1];
+    }
 }
 
 void __cdecl gamemenu_get_sound()
 {
-	gamemenu_sound_music_toggle(sound_toggle_names, &sgOptionMenu[1], sound_get_or_set_sound_volume(1));
+    gamemenu_sound_music_toggle(sound_toggle_names, &sgOptionMenu[1], sound_get_or_set_sound_volume(1));
 }
 
 void __cdecl gamemenu_get_color_cycling()
 {
-	sgOptionMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling()];
+    sgOptionMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling()];
 }
 
 void __cdecl gamemenu_get_gamma()
 {
-	gmenu_slider_3(&sgOptionMenu[2], 15);
-	gmenu_slider_1(&sgOptionMenu[2], 30, 100, UpdateGamma(0));
+    gmenu_slider_3(&sgOptionMenu[2], 15);
+    gmenu_slider_1(&sgOptionMenu[2], 30, 100, UpdateGamma(0));
 }
 
 void __fastcall gamemenu_music_volume(int a1)
 {
-	int v1; // esi
+    int v1; // esi
 
-	if ( a1 )
-	{
-		if ( gbMusicOn )
-		{
-			gbMusicOn = FALSE;
-			music_stop();
-			sound_get_or_set_music_volume(VOLUME_MIN);
-			goto LABEL_11;
-		}
-		gbMusicOn = TRUE;
-		sound_get_or_set_music_volume(VOLUME_MAX);
-LABEL_10:
-		music_start((unsigned char)leveltype);
-		goto LABEL_11;
-	}
-	v1 = gamemenu_slider_music_sound(sgOptionMenu);
-	sound_get_or_set_music_volume(v1);
-	if ( v1 != VOLUME_MIN )
-	{
-		if ( gbMusicOn )
-			goto LABEL_11;
-		gbMusicOn = TRUE;
-		goto LABEL_10;
-	}
-	if ( gbMusicOn )
-	{
-		gbMusicOn = FALSE;
-		music_stop();
-	}
+    if (a1) {
+        if (gbMusicOn) {
+            gbMusicOn = FALSE;
+            music_stop();
+            sound_get_or_set_music_volume(VOLUME_MIN);
+            goto LABEL_11;
+        }
+        gbMusicOn = TRUE;
+        sound_get_or_set_music_volume(VOLUME_MAX);
+    LABEL_10:
+        music_start((unsigned char)leveltype);
+        goto LABEL_11;
+    }
+    v1 = gamemenu_slider_music_sound(sgOptionMenu);
+    sound_get_or_set_music_volume(v1);
+    if (v1 != VOLUME_MIN) {
+        if (gbMusicOn)
+            goto LABEL_11;
+        gbMusicOn = TRUE;
+        goto LABEL_10;
+    }
+    if (gbMusicOn) {
+        gbMusicOn = FALSE;
+        music_stop();
+    }
 LABEL_11:
-	gamemenu_get_music();
+    gamemenu_get_music();
 }
 // 5BB1ED: using guessed type char leveltype;
 
 int __fastcall gamemenu_slider_music_sound(TMenuItem *menu_item)
 {
-	return gmenu_slider_get(menu_item, VOLUME_MIN, VOLUME_MAX);
+    return gmenu_slider_get(menu_item, VOLUME_MIN, VOLUME_MAX);
 }
 
 void __fastcall gamemenu_sound_volume(int a1)
 {
-	int v1; // ecx
-	int v2; // esi
+    int v1; // ecx
+    int v2; // esi
 
-	if ( a1 ) {
-		if ( gbSoundOn ) {
-			gbSoundOn = FALSE;
-			FreeMonsterSnd();
-			v1 = VOLUME_MIN;
-		} else {
-			gbSoundOn = TRUE;
-		}
-		sound_get_or_set_sound_volume(VOLUME_MAX);
-	} else {
-		v2 = gamemenu_slider_music_sound(&sgOptionMenu[1]);
-		sound_get_or_set_sound_volume(v2);
-		if ( v2 == VOLUME_MIN ) {
-			if ( gbSoundOn ) {
-				gbSoundOn = FALSE;
-				FreeMonsterSnd();
-			}
-		} else if ( !gbSoundOn ) {
-			gbSoundOn = TRUE;
-		}
-	}
-	PlaySFX(IS_TITLEMOV);
-	gamemenu_get_sound();
+    if (a1) {
+        if (gbSoundOn) {
+            gbSoundOn = FALSE;
+            FreeMonsterSnd();
+            v1 = VOLUME_MIN;
+        } else {
+            gbSoundOn = TRUE;
+        }
+        sound_get_or_set_sound_volume(VOLUME_MAX);
+    } else {
+        v2 = gamemenu_slider_music_sound(&sgOptionMenu[1]);
+        sound_get_or_set_sound_volume(v2);
+        if (v2 == VOLUME_MIN) {
+            if (gbSoundOn) {
+                gbSoundOn = FALSE;
+                FreeMonsterSnd();
+            }
+        } else if (!gbSoundOn) {
+            gbSoundOn = TRUE;
+        }
+    }
+    PlaySFX(IS_TITLEMOV);
+    gamemenu_get_sound();
 }
 
 void __fastcall gamemenu_gamma(int a1)
 {
-	int v1; // eax
-	int v2; // eax
+    int v1; // eax
+    int v2; // eax
 
-	if ( a1 )
-	{
-		v1 = -(UpdateGamma(0) != 30);
-		_LOBYTE(v1) = v1 & 0xBA;
-		v2 = v1 + 100;
-	}
-	else
-	{
-		v2 = gamemenu_slider_gamma();
-	}
-	UpdateGamma(v2);
-	gamemenu_get_gamma();
+    if (a1) {
+        v1 = -(UpdateGamma(0) != 30);
+        _LOBYTE(v1) = v1 & 0xBA;
+        v2 = v1 + 100;
+    } else {
+        v2 = gamemenu_slider_gamma();
+    }
+    UpdateGamma(v2);
+    gamemenu_get_gamma();
 }
 
 int __cdecl gamemenu_slider_gamma()
 {
-	return gmenu_slider_get(&sgOptionMenu[2], 30, 100);
+    return gmenu_slider_get(&sgOptionMenu[2], 30, 100);
 }
 
 void __cdecl gamemenu_color_cycling()
 {
-	palette_set_color_cycling(palette_get_colour_cycling() == 0);
-	sgOptionMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];
+    palette_set_color_cycling(palette_get_colour_cycling() == 0);
+    sgOptionMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];
 }

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -29,7 +29,7 @@ char block_lvid[2049];
 //char byte_5B78EB;
 char dung_map[MAXDUNX][MAXDUNY];
 char nTrapTable[2049];
-char leveltype; // weak
+BYTE leveltype;
 unsigned char currlevel; // idb
 char TransList[256];
 UCHAR nSolidTable[2049];
@@ -134,7 +134,6 @@ LABEL_13:
 	}
 	mem_free_dbg(v0);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __cdecl gendung_418D91()
 {
@@ -492,7 +491,6 @@ LABEL_66:
 }
 // 525728: using guessed type int light4flag;
 // 53CD4C: using guessed type int nlevel_frames;
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall gendung_4191BF(int frames)
 {
@@ -666,7 +664,6 @@ void __cdecl SetDungeonMicros()
 	}
 }
 // 52569C: using guessed type int zoomflag;
-// 5BB1ED: using guessed type char leveltype;
 // 5C2FF8: using guessed type int dword_5C2FF8;
 // 5C2FFC: using guessed type int dword_5C2FFC;
 // 5C3000: using guessed type int scr_pix_width;
@@ -1250,7 +1247,6 @@ LABEL_53:
 		}
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, int rndSize)
 {
@@ -1341,7 +1337,6 @@ void __fastcall DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int fr
 	while ( v5 < 40 );
 }
 // 5A5590: using guessed type char TransVal;
-// 5BB1ED: using guessed type char leveltype;
 
 void __cdecl DRLG_HoldThemeRooms()
 {
@@ -1435,5 +1430,4 @@ void __cdecl InitLevels()
 	}
 }
 // 52572C: using guessed type int leveldebug;
-// 5BB1ED: using guessed type char leveltype;
 // 5CF31D: using guessed type char setlevel;

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -29,7 +29,7 @@ extern char block_lvid[2049];
 //char byte_5B78EB;
 extern char dung_map[MAXDUNX][MAXDUNY];
 extern char nTrapTable[2049];
-extern char leveltype; // weak
+extern BYTE leveltype;
 extern unsigned char currlevel; // idb
 extern char TransList[256];
 extern UCHAR nSolidTable[2049];

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -117,7 +117,7 @@ void __cdecl gmenu_init_menu()
 // 634478: using guessed type char byte_634478;
 // 63448C: using guessed type int dword_63448C;
 
-bool __cdecl gmenu_exception()
+BOOL __cdecl gmenu_exception()
 {
 	return dword_634480 != 0;
 }

--- a/Source/gmenu.h
+++ b/Source/gmenu.h
@@ -19,7 +19,7 @@ void __cdecl gmenu_draw_pause();
 void __fastcall gmenu_print_text(int x, int y, char *pszStr);
 void __cdecl FreeGMenu();
 void __cdecl gmenu_init_menu();
-bool __cdecl gmenu_exception();
+BOOL __cdecl gmenu_exception();
 void __fastcall gmenu_call_proc(TMenuItem *pItem, void (__cdecl *gmFunc)());
 void __fastcall gmenu_up_down(int a1);
 void __cdecl gmenu_draw();

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -233,7 +233,6 @@ LABEL_41:
 		PrepDoEnding();
 	gbSomebodyWonGameKludge = 0;
 }
-// 5BB1ED: using guessed type char leveltype;
 // 5CF31C: using guessed type char setlvltype;
 // 5CF31D: using guessed type char setlevel;
 // 6761B8: using guessed type char gbSomebodyWonGameKludge;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2976,7 +2976,6 @@ LABEL_11:
 	}
 	return TRUE;
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall UseStaffCharge(int pnum)
 {

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -1363,7 +1363,6 @@ void __cdecl MakeLightTable()
 	while ( (signed int)v43 < (signed int)&dung_map_rgba[16384] );
 }
 // 525728: using guessed type int light4flag;
-// 5BB1ED: using guessed type char leveltype;
 
 #ifdef _DEBUG
 void __cdecl ToggleLighting()
@@ -1750,4 +1749,3 @@ void __cdecl lighting_color_cycling()
 	}
 }
 // 525728: using guessed type int light4flag;
-// 5BB1ED: using guessed type char leveltype;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -171,7 +171,6 @@ void __fastcall LoadGame(BOOL firstflag)
 	SetCursor(CURSOR_HAND);
 	gbProcessPlayers = TRUE;
 }
-// 5BB1ED: using guessed type char leveltype;
 // 5CF31D: using guessed type char setlevel;
 
 char __cdecl BLoad()
@@ -416,7 +415,6 @@ void __cdecl SaveGame()
 	pfile_rename_temp_to_perm();
 	pfile_write_hero();
 }
-// 5BB1ED: using guessed type char leveltype;
 // 5CF31D: using guessed type char setlevel;
 
 void __fastcall BSave(char v)
@@ -602,7 +600,6 @@ void __cdecl SaveLevel()
 	else
 		plr[myplr]._pSLvlVisited[setlvlnum] = 1;
 }
-// 5BB1ED: using guessed type char leveltype;
 // 5CF31D: using guessed type char setlevel;
 
 void __cdecl LoadLevel()
@@ -697,5 +694,4 @@ void __cdecl LoadLevel()
 
 	mem_free_dbg(LoadBuff);
 }
-// 5BB1ED: using guessed type char leveltype;
 // 642A18: using guessed type int dolighting;

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -2,109 +2,73 @@
 
 #include "../types.h"
 
-int mainmenu_cpp_init_value; // weak
+static float mainmenu_cpp_init_value = INFINITY;
 char chr_name_str[16];
-
-const int mainmenu_inf = 0x7F800000; // weak
 
 /* data */
 
-int menu_music_track_id = 5; // idb
-
-struct mainmenu_cpp_init
-{
-	mainmenu_cpp_init()
-	{
-		mainmenu_cpp_init_value = mainmenu_inf;
-	}
-} _mainmenu_cpp_init;
-// 47F074: using guessed type int mainmenu_inf;
-// 646CE0: using guessed type int mainmenu_cpp_init_value;
+int menu_music_track_id = 5;
 
 void __cdecl mainmenu_refresh_music()
 {
-	int v0; // eax
-
-	music_start(menu_music_track_id);
-	v0 = menu_music_track_id;
-	do
-	{
-		if ( ++v0 == 6 )
-			v0 = 0;
-	}
-	while ( !v0 || v0 == 1 );
-	menu_music_track_id = v0;
+    music_start(menu_music_track_id);
+    do {
+        menu_music_track_id++;
+        if (menu_music_track_id == 6)
+            menu_music_track_id = 0;
+    } while (!menu_music_track_id || menu_music_track_id == 1);
 }
 
-void __stdcall mainmenu_create_hero(char *a1, char *a2)
+void __stdcall mainmenu_create_hero(char *name_1, char *name_2)
 {
-	// char *v2; // [esp-14h] [ebp-14h]
-
-	if ( UiValidPlayerName(a1) ) /* v2 */
-		pfile_create_save_file(a1, a2);
+    if (UiValidPlayerName(name_1))
+        pfile_create_save_file(name_1, name_2);
 }
 
 int __stdcall mainmenu_select_hero_dialog(int u1, int u2, int u3, int u4, int mode, char *cname, int clen, char *cdesc, int cdlen, int *multi) /* fix args */
 {
-	int v10; // eax
-	int a6; // [esp+8h] [ebp-8h]
-	int a5; // [esp+Ch] [ebp-4h]
+    int a6 = 1;
+    int a5 = 0;
+    if (gbMaxPlayers == 1) {
+        if (!UiSelHeroSingDialog(
+                pfile_ui_set_hero_infos,
+                pfile_ui_save_create,
+                pfile_delete_save,
+                pfile_ui_set_class_stats,
+                &a5,
+                chr_name_str,
+                &gnDifficulty))
+            TermMsg("Unable to display SelHeroSing");
+        if (a5 == 2)
+            dword_5256E8 = TRUE;
+        else
+            dword_5256E8 = FALSE;
+    } else if (!UiSelHeroMultDialog(
+                   pfile_ui_set_hero_infos,
+                   pfile_ui_save_create,
+                   pfile_delete_save,
+                   pfile_ui_set_class_stats,
+                   &a5,
+                   &a6,
+                   chr_name_str)) {
+        TermMsg("Can't load multiplayer dialog");
+    }
+    if (a5 == 4) {
+        SErrSetLastError(1223);
+        return 0;
+    }
+    pfile_create_player_description(cdesc, cdlen);
+    if (multi) {
+        if (mode == 'BNET')
+            *multi = a6 || !plr[myplr].pBattleNet;
+        else
+            *multi = a6;
+    }
+    if (cname && clen)
+        SStrCopy(cname, chr_name_str, clen);
 
-	a6 = 1;
-	a5 = 0;
-	if ( gbMaxPlayers == 1 )
-	{
-		if ( !UiSelHeroSingDialog(
-				  pfile_ui_set_hero_infos,
-				  pfile_ui_save_create,
-				  pfile_delete_save,
-				  pfile_ui_set_class_stats,
-				  &a5,
-				  chr_name_str,
-				  &gnDifficulty) )
-			TermMsg("Unable to display SelHeroSing");
-		if ( a5 == 2 )
-		{
-			dword_5256E8 = 1;
-			goto LABEL_6;
-		}
-		dword_5256E8 = 0;
-	}
-	else if ( !UiSelHeroMultDialog(
-				   pfile_ui_set_hero_infos,
-				   pfile_ui_save_create,
-				   pfile_delete_save,
-				   pfile_ui_set_class_stats,
-				   &a5,
-				   &a6,
-				   chr_name_str) )
-	{
-		TermMsg("Can't load multiplayer dialog");
-	}
-	if ( a5 == 4 )
-	{
-		SErrSetLastError(1223);
-		return 0;
-	}
-LABEL_6:
-	pfile_create_player_description(cdesc, cdlen);
-	if ( multi )
-	{
-		if ( mode == 'BNET' )
-			v10 = a6 || !plr[myplr].pBattleNet;
-		else
-			v10 = a6;
-		*multi = v10;
-	}
-	if ( cname )
-	{
-		if ( clen )
-			SStrCopy(cname, chr_name_str, clen);
-	}
-	return 1;
+    return 1;
 }
-// 5256E8: using guessed type int dword_5256E8;
-// 679660: using guessed type char gbMaxPlayers;
 
 void __cdecl mainmenu_loop()
 {
@@ -150,38 +114,36 @@ LABEL_16:
 }
 // 634980: using guessed type int gbActive;
 
-int __cdecl mainmenu_single_player()
+BOOL __cdecl mainmenu_single_player()
 {
-	gbMaxPlayers = 1;
-	return mainmenu_init_menu(1);
+    gbMaxPlayers = 1;
+    return mainmenu_init_menu(1);
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-int __fastcall mainmenu_init_menu(int a1)
+BOOL __fastcall mainmenu_init_menu(int type)
 {
-	int v1; // esi
-	int v3; // esi
+    if (type == 4)
+        return 1;
 
-	v1 = a1;
-	if ( a1 == 4 )
-		return 1;
-	music_stop();
-	v3 = diablo_init_menu(v1 != 2, v1 != 3);
-	if ( v3 )
-		mainmenu_refresh_music();
-	return v3;
+    music_stop();
+
+    int success = diablo_init_menu(type != 2, type != 3);
+    if (success)
+        mainmenu_refresh_music();
+
+    return success;
 }
 
-int __cdecl mainmenu_multi_player()
+BOOL __cdecl mainmenu_multi_player()
 {
-	gbMaxPlayers = MAX_PLRS;
-	return mainmenu_init_menu(3);
+    gbMaxPlayers = MAX_PLRS;
+    return mainmenu_init_menu(3);
 }
-// 679660: using guessed type char gbMaxPlayers;
 
 void __cdecl mainmenu_play_intro()
 {
-	music_stop();
-	play_movie("gendata\\diablo1.smk", 1);
-	mainmenu_refresh_music();
+    music_stop();
+    play_movie("gendata\\diablo1.smk", 1);
+    mainmenu_refresh_music();
 }

--- a/Source/mainmenu.h
+++ b/Source/mainmenu.h
@@ -2,17 +2,16 @@
 #ifndef __MAINMENU_H__
 #define __MAINMENU_H__
 
-extern int mainmenu_cpp_init_value; // weak
 extern char chr_name_str[16];
 
 void __cdecl mainmenu_cpp_init();
 void __cdecl mainmenu_refresh_music();
-void __stdcall mainmenu_create_hero(char *, char *);
+void __stdcall mainmenu_create_hero(char *name_1, char *name_2);
 int __stdcall mainmenu_select_hero_dialog(int u1, int u2, int u3, int u4, int mode, char *cname, int clen, char *cdesc, int cdlen, int *multi);
 void __cdecl mainmenu_loop();
-int __cdecl mainmenu_single_player();
-int __fastcall mainmenu_init_menu(int a1);
-int __cdecl mainmenu_multi_player();
+BOOL __cdecl mainmenu_single_player();
+BOOL __fastcall mainmenu_init_menu(int a1);
+BOOL __cdecl mainmenu_multi_player();
 void __cdecl mainmenu_play_intro();
 
 /* rdata */

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3017,20 +3017,19 @@ LABEL_14:
 	{
 		if ( setlevel )
 		{
-			_LOWORD(v21) = (unsigned char)leveltype;
+			_LOWORD(v21) = leveltype;
 			v22 = v21;
 			_LOWORD(v21) = setlvlnum;
 			NetSendCmdLocParam3(TRUE, CMD_ACTIVATEPORTAL, v9, v11, v21, v22, 1);
 		}
 		else
 		{
-			_LOWORD(v20) = (unsigned char)leveltype;
+			_LOWORD(v20) = leveltype;
 			_LOWORD(v21) = currlevel;
 			NetSendCmdLocParam3(TRUE, CMD_ACTIVATEPORTAL, v9, v11, v21, v20, 0);
 		}
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 5CF31D: using guessed type char setlevel;
 
 void __fastcall AddFlash(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
@@ -6232,7 +6231,6 @@ void __fastcall MI_Teleport(int i)
 		missile[v1]._miDelFlag = 1;
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall MI_Stone(int i)
 {

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -982,7 +982,6 @@ void __cdecl SetupLocalCoords()
 	plr[myplr].destAction = ACTION_NONE;
 }
 // 52572C: using guessed type int leveldebug;
-// 5BB1ED: using guessed type char leveltype;
 // 5CF31D: using guessed type char setlevel;
 // 679660: using guessed type char gbMaxPlayers;
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -457,7 +457,6 @@ bool __fastcall RndLocOk(int xp, int yp)
 	}
 	return result;
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall InitRndLocObj(int min, int max, int objtype)
 {
@@ -1141,7 +1140,6 @@ void __cdecl AddChestTraps()
 	}
 	while ( v0 < 112 );
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall LoadMapObjects(unsigned char *pMap, int startx, int starty, int x1, int y1, int w, int h, int leveridx)
 {
@@ -1592,12 +1590,11 @@ void __cdecl InitObjects()
 		InitRndLocObj(1, 5, 7);
 		if ( leveltype != 4 )
 			AddObjTraps();
-		if ( (unsigned char)leveltype > 1u )
+		if ( leveltype > 1u )
 			AddChestTraps();
 		InitObjFlag = 0;
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 // 679660: using guessed type char gbMaxPlayers;
@@ -1707,7 +1704,6 @@ void __fastcall SetMapObjects(unsigned char *pMap, int startx, int starty)
 	}
 	InitObjFlag = 0;
 }
-// 5BB1ED: using guessed type char leveltype;
 // 67D7C0: using guessed type int InitObjFlag;
 // 67D7C4: using guessed type int numobjfiles;
 // 4427C5: using guessed type int var_10C[56];
@@ -2820,10 +2816,10 @@ void __fastcall Obj_BCrossDamage(int i)
 	{
 		v3 = plr[v1]._pFireResist;
 		if ( v3 > 0 )
-			damage[(unsigned char)leveltype-1] -= v3 * damage[(unsigned char)leveltype-1] / 100;
+			damage[leveltype-1] -= v3 * damage[leveltype-1] / 100;
 		if ( plr[v1].WorldX == object[v8]._ox && plr[v1].WorldY == object[v8]._oy - 1 )
 		{
-			v4 = damage[(unsigned char)leveltype-1];
+			v4 = damage[leveltype-1];
 			plr[v1]._pHitPoints -= v4;
 			plr[v1]._pHPBase -= v4;
 			if ( plr[v1]._pHitPoints >> 6 <= 0 )
@@ -2844,7 +2840,6 @@ void __fastcall Obj_BCrossDamage(int i)
 		}
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __cdecl ProcessObjects()
 {
@@ -3021,7 +3016,6 @@ void __fastcall ObjSetMicro(int dx, int dy, int pn)
 		while ( v6 < 10 );
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall objects_set_door_piece(int x, int y)
 {
@@ -3838,7 +3832,6 @@ void __fastcall ObjChangeMap(int x1, int y1, int x2, int y2)
 		AddL2Objs(2 * v6 + 16, v9, v8, y_end); /* v10 */
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall ObjChangeMapResync(int x1, int y1, int x2, int y2)
 {
@@ -3876,7 +3869,6 @@ void __fastcall ObjChangeMapResync(int x1, int y1, int x2, int y2)
 	if ( leveltype == DTYPE_CATACOMBS )
 		ObjL2Special(2 * v6 + 16, 2 * v5 + 16, 2 * x2 + 17, 2 * v4 + 17);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall OperateL1Door(int pnum, int i, unsigned char sendflag)
 {
@@ -5050,7 +5042,7 @@ LABEL_47:
 					-1,
 					arglist,
 					0,
-					2 * (unsigned char)leveltype);
+					2 * leveltype);
 				if ( arglist != myplr )
 					return;
 				_LOBYTE(v7) = EMSG_SHRINE_MAGICAL;
@@ -5247,7 +5239,7 @@ LABEL_47:
 					-1,
 					arglist,
 					0,
-					2 * (unsigned char)leveltype);
+					2 * leveltype);
 				if ( arglist != myplr )
 					return;
 				_LOBYTE(v7) = EMSG_SHRINE_CRYPTIC;
@@ -5385,7 +5377,7 @@ LABEL_47:
 					-1,
 					arglist,
 					0,
-					2 * (unsigned char)leveltype);
+					2 * leveltype);
 				if ( arglist != myplr )
 					return;
 				_LOBYTE(v7) = EMSG_SHRINE_HOLY;
@@ -5435,7 +5427,7 @@ LABEL_47:
 				{
 					if ( !plr[v106].InvGrid[sfx_idd] )
 					{
-						v107 = 5 * (unsigned char)leveltype + random(160, 10 * (unsigned char)leveltype);
+						v107 = 5 * leveltype + random(160, 10 * leveltype);
 						v108 = plr[v106]._pNumInv;
 						v109 = v106 * 21720 + 368 * v108;
 						qmemcpy((char *)plr[0].InvList + v109, &golditem, 0x170u);
@@ -5657,7 +5649,6 @@ LABEL_280:
 }
 // 4B84DC: using guessed type int dropGoldFlag;
 // 52571C: using guessed type int drawpanflag;
-// 5BB1ED: using guessed type char leveltype;
 // 676190: using guessed type int deltaload;
 
 void __fastcall OperateSkelBook(int pnum, int i, unsigned char sendmsg)
@@ -5987,7 +5978,7 @@ LABEL_38:
 					-1,
 					v4,
 					0,
-					2 * (unsigned char)leveltype);
+					2 * leveltype);
 				v5 = 1;
 				if ( v4 == myplr )
 					NetSendCmdParam1(FALSE, CMD_OPERATEOBJ, v2);
@@ -6055,7 +6046,6 @@ LABEL_38:
 	return v5;
 }
 // 52571C: using guessed type int drawpanflag;
-// 5BB1ED: using guessed type char leveltype;
 // 676190: using guessed type int deltaload;
 
 void __fastcall OperateWeaponRack(int pnum, int i, unsigned char sendmsg)
@@ -6114,7 +6104,7 @@ LABEL_12:
 	{
 		v11 = object[v4]._ox;
 		v12 = object[v4]._oy;
-		if ( (unsigned char)leveltype <= 1u )
+		if ( leveltype <= 1u )
 			CreateTypeItem(v11, v12, 0, v9, 0, sendmsg, 0);
 		else
 			CreateTypeItem(v11, v12, 1u, v9, 0, sendmsg, 0);
@@ -6122,7 +6112,6 @@ LABEL_12:
 			NetSendCmdParam1(FALSE, CMD_OPERATEOBJ, v3);
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 676190: using guessed type int deltaload;
 
 void __fastcall OperateStoryBook(int pnum, int i)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4033,7 +4033,7 @@ LABEL_17:
 					quests[QTYPE_BONE]._qactive = 3;
 					if ( !deltaload )
 						PlaySfxLoc(IS_QUESTDN, object[i]._ox, object[i]._oy);
-					InitDiabloMsg(43);
+					InitDiabloMsg(EMSG_BONECHAMB);
 					AddMissile(
 						plr[myplr].WorldX,
 						plr[myplr].WorldY,
@@ -4868,7 +4868,7 @@ void __fastcall OperateShrine(int pnum, int i, int sType)
 						ModifyPlrStr(arglist, 6);
 					}
 					CheckStats(arglist);
-					_LOBYTE(v7) = 12;
+					_LOBYTE(v7) = EMSG_SHRINE_MYSTERIOUS;
 					goto LABEL_221;
 				}
 				return;
@@ -4959,7 +4959,7 @@ void __fastcall OperateShrine(int pnum, int i, int sType)
 				if ( v25 <= 0 )
 					*(_DWORD *)v7 = 1;
 LABEL_47:
-				_LOBYTE(v7) = 13;
+				_LOBYTE(v7) = EMSG_SHRINE_HIDDEN;
 				goto LABEL_221;
 			case SHRINE_GLOOMY:
 				if ( v5 )
@@ -5034,7 +5034,7 @@ LABEL_47:
 					}
 					while ( v36 < plr[v34]._pNumInv );
 				}
-				_LOBYTE(v7) = 15;
+				_LOBYTE(v7) = EMSG_SHRINE_WEIRD;
 				goto LABEL_221;
 			case SHRINE_MAGICAL:
 			case SHRINE_MAGICAL2:
@@ -5053,7 +5053,7 @@ LABEL_47:
 					2 * (unsigned char)leveltype);
 				if ( arglist != myplr )
 					return;
-				_LOBYTE(v7) = 16;
+				_LOBYTE(v7) = EMSG_SHRINE_MAGICAL;
 				goto LABEL_221;
 			case SHRINE_STONE:
 				if ( v5 )
@@ -5094,7 +5094,7 @@ LABEL_47:
 					--v44;
 				}
 				while ( v44 );
-				v7 = 17;
+				v7 = EMSG_SHRINE_STONE;
 				goto LABEL_221;
 			case SHRINE_RELIGIOUS:
 				if ( v5 )
@@ -5132,7 +5132,7 @@ LABEL_47:
 					--v51;
 				}
 				while ( v51 );
-				v7 = 18;
+				v7 = EMSG_SHRINE_RELIGIOUS;
 				goto LABEL_221;
 			case SHRINE_ENCHANTED:
 				if ( v5 || arglist != myplr )
@@ -5175,7 +5175,7 @@ LABEL_47:
 					else
 						*v61 -= 2;
 				}
-				_LOBYTE(v7) = 19;
+				_LOBYTE(v7) = EMSG_SHRINE_ENCHANTED;
 				goto LABEL_221;
 			case SHRINE_THAUMATURGIC:
 				for ( j = 0; j < nobjects; ++j )
@@ -5195,7 +5195,7 @@ LABEL_47:
 					return;
 				if ( arglist != myplr )
 					goto LABEL_280;
-				_LOBYTE(v7) = 20;
+				_LOBYTE(v7) = EMSG_SHRINE_THAUMATURGIC;
 				goto LABEL_221;
 			case SHRINE_FASCINATING:
 				if ( v5 || arglist != myplr )
@@ -5231,7 +5231,7 @@ LABEL_47:
 					*(int *)((char *)&plr[0]._pMaxManaBase + v7) = 0;
 					*(int *)((char *)&plr[0]._pMaxMana + v7) = v73;
 				}
-				_LOBYTE(v7) = 21;
+				_LOBYTE(v7) = EMSG_SHRINE_FASCINATING;
 				goto LABEL_221;
 			case SHRINE_CRYPTIC:
 				if ( v5 )
@@ -5250,7 +5250,7 @@ LABEL_47:
 					2 * (unsigned char)leveltype);
 				if ( arglist != myplr )
 					return;
-				_LOBYTE(v7) = 22;
+				_LOBYTE(v7) = EMSG_SHRINE_CRYPTIC;
 				plr[v77]._pMana = plr[v77]._pMaxMana;
 				plr[v77]._pManaBase = plr[v77]._pMaxManaBase;
 				goto LABEL_221;
@@ -5328,14 +5328,14 @@ LABEL_47:
 					sfx_idc = v82;
 				}
 				while ( !v56 );
-				_LOBYTE(v7) = 24;
+				_LOBYTE(v7) = EMSG_SHRINE_ELDRITCH;
 				goto LABEL_221;
 			case SHRINE_EERIE:
 				if ( v5 || arglist != myplr )
 					return;
 				ModifyPlrMag(arglist, 2);
 				CheckStats(arglist);
-				_LOBYTE(v7) = 25;
+				_LOBYTE(v7) = EMSG_SHRINE_EERIE;
 				goto LABEL_221;
 			case SHRINE_DIVINE:
 				if ( v5 || arglist != myplr )
@@ -5358,7 +5358,7 @@ LABEL_47:
 				plr[v87]._pHitPoints = plr[arglist]._pMaxHP;
 				v7 = plr[arglist]._pMaxHPBase;
 				plr[v87]._pHPBase = v7;
-				_LOBYTE(v7) = 26;
+				_LOBYTE(v7) = EMSG_SHRINE_DIVINE;
 				goto LABEL_221;
 			case SHRINE_HOLY:
 				if ( v5 )
@@ -5388,7 +5388,7 @@ LABEL_47:
 					2 * (unsigned char)leveltype);
 				if ( arglist != myplr )
 					return;
-				_LOBYTE(v7) = 27;
+				_LOBYTE(v7) = EMSG_SHRINE_HOLY;
 				goto LABEL_221;
 			case SHRINE_SACRED:
 				if ( v5 || arglist != myplr )
@@ -5424,7 +5424,7 @@ LABEL_47:
 					*(int *)((char *)&plr[0]._pMaxManaBase + v7) = 0;
 					*(int *)((char *)&plr[0]._pMaxMana + v7) = v102;
 				}
-				_LOBYTE(v7) = 28;
+				_LOBYTE(v7) = EMSG_SHRINE_SACRED;
 				goto LABEL_221;
 			case SHRINE_SPIRITUAL:
 				if ( v5 || arglist != myplr )
@@ -5449,18 +5449,17 @@ LABEL_47:
 					++sfx_idd;
 				}
 				while ( sfx_idd < 40 );
-				_LOBYTE(v7) = 29;
+				_LOBYTE(v7) = EMSG_SHRINE_SPIRITUAL;
 				goto LABEL_221;
 			case SHRINE_SPOOKY:
 				if ( v5 )
 					return;
 				if ( arglist == myplr )
 				{
-					_LOBYTE(v7) = 30;
+					_LOBYTE(v7) = EMSG_SHRINE_SPOOKY1;
 					goto LABEL_221;
 				}
-				_LOBYTE(v7) = 31;
-				InitDiabloMsg(v7);
+				InitDiabloMsg(EMSG_SHRINE_SPOOKY2);
 				v110 = myplr;
 				plr[v110]._pHitPoints = plr[myplr]._pMaxHP;
 				plr[v110]._pHPBase = plr[v110]._pMaxHPBase;
@@ -5474,7 +5473,7 @@ LABEL_47:
 				CheckStats(arglist);
 				if ( arglist != myplr )
 					goto LABEL_280;
-				_LOBYTE(v7) = 32;
+				_LOBYTE(v7) = EMSG_SHRINE_ABANDONED;
 				goto LABEL_221;
 			case SHRINE_CREEPY:
 				if ( v5 || arglist != myplr )
@@ -5483,7 +5482,7 @@ LABEL_47:
 				CheckStats(arglist);
 				if ( arglist != myplr )
 					goto LABEL_280;
-				_LOBYTE(v7) = 33;
+				_LOBYTE(v7) = EMSG_SHRINE_CREEPY;
 				goto LABEL_221;
 			case SHRINE_QUIET:
 				if ( v5 || arglist != myplr )
@@ -5492,7 +5491,7 @@ LABEL_47:
 				CheckStats(arglist);
 				if ( arglist != myplr )
 					goto LABEL_280;
-				_LOBYTE(v7) = 34;
+				_LOBYTE(v7) = EMSG_SHRINE_QUIET;
 				goto LABEL_221;
 			case SHRINE_SECLUDED:
 				if ( v5 )
@@ -5514,7 +5513,7 @@ LABEL_47:
 					++v7;
 				}
 				while ( v7 < 40 );
-				_LOBYTE(v7) = 35;
+				_LOBYTE(v7) = EMSG_SHRINE_SECLUDED;
 				goto LABEL_221;
 			case SHRINE_ORNATE:
 				if ( v5 || arglist != myplr )
@@ -5550,7 +5549,7 @@ LABEL_47:
 					*(int *)((char *)&plr[0]._pMaxManaBase + v7) = 0;
 					*(int *)((char *)&plr[0]._pMaxMana + v7) = v121;
 				}
-				_LOBYTE(v7) = 36;
+				_LOBYTE(v7) = EMSG_SHRINE_ORNATE;
 				goto LABEL_221;
 			case SHRINE_GLIMMERING:
 				if ( v5 || arglist != myplr )
@@ -5589,18 +5588,17 @@ LABEL_47:
 					--v131;
 				}
 				while ( v131 );
-				v7 = 37;
+				v7 = EMSG_SHRINE_GLIMMERING;
 				goto LABEL_221;
 			case SHRINE_TAINTED:
 				if ( v5 )
 					return;
 				if ( arglist == myplr )
 				{
-					_LOBYTE(v7) = 38;
+					_LOBYTE(v7) = EMSG_SHRINE_TAINTED1;
 					goto LABEL_221;
 				}
-				_LOBYTE(v7) = 39;
-				InitDiabloMsg(v7);
+				InitDiabloMsg(EMSG_SHRINE_TAINTED2);
 				v133 = random(155, 4);
 				v134 = 1;
 				v135 = 2 * (v133 == 1) - 1;

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -13,7 +13,7 @@ const int palette_inf = 0x7F800000; // weak
 /* data */
 
 int gamma_correction = 100; // idb
-int color_cycling_enabled = 1; // idb
+BOOL color_cycling_enabled = TRUE;
 bool sgbFadedIn = 1;
 
 struct palette_cpp_init
@@ -29,7 +29,7 @@ struct palette_cpp_init
 void __cdecl SaveGamma()
 {
 	SRegSaveValue("Diablo", "Gamma Correction", 0, gamma_correction);
-	SRegSaveValue("Diablo", "Color Cycling", 0, color_cycling_enabled);
+	SRegSaveValue("Diablo", "Color Cycling", FALSE, color_cycling_enabled);
 }
 
 void __cdecl palette_init()
@@ -69,7 +69,7 @@ void __cdecl LoadGamma()
 	if ( SRegLoadValue("Diablo", "Color Cycling", 0, &value) )
 		v3 = value;
 	else
-		v3 = 1;
+		v3 = TRUE;
 	color_cycling_enabled = v3;
 }
 

--- a/Source/palette.h
+++ b/Source/palette.h
@@ -37,7 +37,7 @@ extern const int palette_inf; // weak
 /* data */
 
 extern int gamma_correction; // idb
-extern int color_cycling_enabled; // idb
+extern BOOL color_cycling_enabled;
 extern bool sgbFadedIn;
 
 #endif /* __PALETTE_H__ */

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -232,7 +232,6 @@ void __fastcall LoadPlrGFX(int pnum, player_graphic gfxflag)
         p->_pGFXLoad |= i;
     }
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall InitPlayerGFX(int pnum)
 {
@@ -491,7 +490,6 @@ void __fastcall SetPlrAnims(int pnum)
         }
     }
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall ClearPlrRVars(PlayerStruct *p)
 {
@@ -1035,7 +1033,6 @@ void __fastcall PlrDoTrans(int x, int y)
         }
     }
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall SetPlayerOld(int pnum)
 {
@@ -1404,7 +1401,6 @@ void __fastcall StartWalk3(int pnum, int xvel, int yvel, int xoff, int yoff, int
     }
 }
 // 52569C: using guessed type int zoomflag;
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall StartAttack(int pnum, int d)
 {
@@ -1518,7 +1514,6 @@ void __fastcall StartSpell(int pnum, int d, int cx, int cy)
     plr[pnum]._pVar4 = GetSpellLevel(pnum, plr[pnum]._pSpell);
     plr[pnum]._pVar8 = 1;
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall FixPlrWalkTags(int pnum)
 {
@@ -1991,8 +1986,6 @@ void __fastcall StartNewLvl(int pnum, int fom, int lvl)
         }
     }
 }
-// 5BB1ED: using guessed type char leveltype;
-
 void __fastcall RestartTownLvl(int pnum)
 {
     InitLevelChange(pnum);
@@ -2092,7 +2085,6 @@ BOOL __fastcall PM_DoWalk(int pnum)
     PM_ChangeOffset(pnum);
     return FALSE;
 }
-// 5BB1ED: using guessed type char leveltype;
 
 BOOL __fastcall PM_DoWalk2(int pnum)
 {
@@ -2141,7 +2133,6 @@ BOOL __fastcall PM_DoWalk2(int pnum)
     PM_ChangeOffset(pnum);
     return FALSE;
 }
-// 5BB1ED: using guessed type char leveltype;
 
 BOOL __fastcall PM_DoWalk3(int pnum)
 {
@@ -2195,7 +2186,6 @@ BOOL __fastcall PM_DoWalk3(int pnum)
     PM_ChangeOffset(pnum);
     return FALSE;
 }
-// 5BB1ED: using guessed type char leveltype;
 
 BOOL __fastcall WeaponDur(int pnum, int durrnd)
 {
@@ -2806,7 +2796,6 @@ BOOL __fastcall PM_DoSpell(int pnum)
     return FALSE;
 }
 // 52571C: using guessed type int drawpanflag;
-// 5BB1ED: using guessed type char leveltype;
 
 BOOL __fastcall PM_DoGotHit(int pnum)
 {
@@ -3636,7 +3625,6 @@ void __fastcall CheckPlrSpell()
     }
 }
 // 4B8CC2: using guessed type char pcursplr;
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall SyncPlrAnim(int pnum)
 {

--- a/Source/portal.cpp
+++ b/Source/portal.cpp
@@ -153,7 +153,6 @@ void __cdecl GetPortalLevel()
 		}
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 5CF31D: using guessed type char setlevel;
 
 void __cdecl GetPortalLvlPos()

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -898,7 +898,6 @@ LABEL_23:
 		}
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 69BEF8: using guessed type int light_table_index;
 // 69CF14: using guessed type int level_cel_block;
 // 69CF20: using guessed type char arch_draw_type;
@@ -2958,7 +2957,7 @@ void __cdecl EnableFrameCount()
 }
 #endif
 
-void __fastcall scrollrt_draw_game_screen(bool draw_cursor)
+void __fastcall scrollrt_draw_game_screen(BOOL draw_cursor)
 {
 	int dwHgt; // edi
 
@@ -3389,4 +3388,3 @@ void __cdecl DrawAndBlit()
 }
 // 4B8960: using guessed type int talkflag;
 // 52571C: using guessed type int drawpanflag;
-// 5BB1ED: using guessed type char leveltype;

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -51,7 +51,7 @@ void __cdecl ClearScreenBuffer();
 void __cdecl ScrollView();
 void __cdecl EnableFrameCount();
 #endif
-void __fastcall scrollrt_draw_game_screen(bool draw_cursor);
+void __fastcall scrollrt_draw_game_screen(BOOL draw_cursor);
 void __cdecl scrollrt_draw_cursor_back_buffer();
 void __cdecl scrollrt_draw_cursor_item();
 void __fastcall DrawMain(int dwHgt, int draw_desc, int draw_hp, int draw_mana, int draw_sbar, int draw_btn);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2322,7 +2322,6 @@ LABEL_18:
 		}
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 646D00: using guessed type char qtextflag;
 // 69F110: using guessed type int stextlhold;
 // 6A8A24: using guessed type int stextvhold;
@@ -4127,7 +4126,6 @@ void __cdecl STextEnter()
 		}
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 646D00: using guessed type char qtextflag;
 // 69F110: using guessed type int stextlhold;
 // 6A8A24: using guessed type int stextvhold;
@@ -4218,7 +4216,6 @@ void __cdecl CheckStoreBtn()
 		}
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 646D00: using guessed type char qtextflag;
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;

--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -198,7 +198,6 @@ bool __fastcall TFit_SkelRoom(int t)
 	themeVar1 = i;
 	return TFit_Obj5(t);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 bool __fastcall TFit_GoatShrine(int t)
 {
@@ -278,7 +277,6 @@ bool __fastcall TFit_Obj3(int t)
 	}
 	return 0;
 }
-// 5BB1ED: using guessed type char leveltype;
 
 bool __fastcall CheckThemeReqs(int t)
 {
@@ -361,7 +359,6 @@ LABEL_16:
 	}
 	return 0;
 }
-// 5BB1ED: using guessed type char leveltype;
 // 6AAA58: using guessed type int mFountainFlag;
 // 6AAA5C: using guessed type int cauldronFlag;
 // 6AAA60: using guessed type int tFountainFlag;
@@ -534,7 +531,6 @@ LABEL_16:
 	}
 	return 0;
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __cdecl InitThemes()
 {
@@ -653,7 +649,6 @@ LABEL_23:
 		}
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 6AAA3C: using guessed type int armorFlag;
 // 6AAA50: using guessed type int weaponFlag;
 // 6AAA54: using guessed type int treasureFlag;
@@ -706,7 +701,6 @@ void __cdecl HoldThemeRooms()
 		}
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall PlaceThemeMonsts(int t, int f)
 {
@@ -778,7 +772,6 @@ void __fastcall Theme_Barrel(int t)
 
 	PlaceThemeMonsts(t, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_Shrine(int t)
 {
@@ -803,7 +796,6 @@ void __fastcall Theme_Shrine(int t)
 	}
 	PlaceThemeMonsts(t, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_MonstPit(int t)
 {
@@ -839,7 +831,6 @@ void __fastcall Theme_MonstPit(int t)
 	ItemNoFlippy();
 	PlaceThemeMonsts(t, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_SkelRoom(int t)
 {
@@ -895,7 +886,6 @@ void __fastcall Theme_SkelRoom(int t)
 	if ( !dObject[xp][yp + 3] )
 		AddObject(OBJ_SKELBOOK, xp, yp + 2);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_Treasure(int t)
 {
@@ -938,7 +928,6 @@ void __fastcall Theme_Treasure(int t)
 	}
 	PlaceThemeMonsts(t, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_Library(int t)
 {
@@ -1015,7 +1004,6 @@ void __fastcall Theme_Library(int t)
 	if ( !QuestStatus(QTYPE_ZHAR) || ta != zharlib )
 		PlaceThemeMonsts(ta, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 // 6AAA64: using guessed type int zharlib;
 
 void __fastcall Theme_Torture(int t)
@@ -1068,7 +1056,6 @@ void __fastcall Theme_Torture(int t)
 	while ( (signed int)v8 < (signed int)&dPiece[1][111] );
 	PlaceThemeMonsts(v1, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_BloodFountain(int t)
 {
@@ -1082,7 +1069,6 @@ void __fastcall Theme_BloodFountain(int t)
 	AddObject(OBJ_BLOODFTN, themex, themey);
 	PlaceThemeMonsts(t, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_Decap(int t)
 {
@@ -1134,7 +1120,6 @@ void __fastcall Theme_Decap(int t)
 	while ( (signed int)v8 < (signed int)&dPiece[1][111] );
 	PlaceThemeMonsts(v1, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_PurifyingFountain(int t)
 {
@@ -1148,7 +1133,6 @@ void __fastcall Theme_PurifyingFountain(int t)
 	AddObject(OBJ_PURIFYINGFTN, themex, themey);
 	PlaceThemeMonsts(t, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_ArmorStand(int t)
 {
@@ -1206,7 +1190,6 @@ void __fastcall Theme_ArmorStand(int t)
 	PlaceThemeMonsts(ta, monstrnd[leveltype-1]);
 	armorFlag = 0;
 }
-// 5BB1ED: using guessed type char leveltype;
 // 6AAA3C: using guessed type int armorFlag;
 
 void __fastcall Theme_GoatShrine(int t)
@@ -1266,7 +1249,6 @@ void __fastcall Theme_Cauldron(int t)
 	AddObject(OBJ_CAULDRON, themex, themey);
 	PlaceThemeMonsts(t, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_MurkyFountain(int t)
 {
@@ -1280,7 +1262,6 @@ void __fastcall Theme_MurkyFountain(int t)
 	AddObject(OBJ_MURKYFTN, themex, themey);
 	PlaceThemeMonsts(t, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_TearFountain(int t)
 {
@@ -1294,7 +1275,6 @@ void __fastcall Theme_TearFountain(int t)
 	AddObject(OBJ_TEARFTN, themex, themey);
 	PlaceThemeMonsts(t, monstrnd[leveltype-1]);
 }
-// 5BB1ED: using guessed type char leveltype;
 
 void __fastcall Theme_BrnCross(int t)
 {
@@ -1347,7 +1327,6 @@ void __fastcall Theme_BrnCross(int t)
 	PlaceThemeMonsts(ta, monstrnd[leveltype-1]);
 	bCrossFlag = 1;
 }
-// 5BB1ED: using guessed type char leveltype;
 // 6AAC10: using guessed type int bCrossFlag;
 
 void __fastcall Theme_WeaponRack(int t)
@@ -1406,7 +1385,6 @@ void __fastcall Theme_WeaponRack(int t)
 	PlaceThemeMonsts(ta, monstrnd[leveltype-1]);
 	weaponFlag = 0;
 }
-// 5BB1ED: using guessed type char leveltype;
 // 6AAA50: using guessed type int weaponFlag;
 
 void __cdecl UpdateL4Trans()
@@ -1497,5 +1475,4 @@ void __cdecl CreateThemeRooms()
 			UpdateL4Trans();
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 67D7C0: using guessed type int InitObjFlag;

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -1252,7 +1252,6 @@ LABEL_24:
 		goto LABEL_14;
 	}
 }
-// 5BB1ED: using guessed type char leveltype;
 // 5CF31D: using guessed type char setlevel;
 
 void __cdecl CheckTriggers()

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -1332,21 +1332,21 @@ LABEL_34:
 		v5 = 1;
 		x = plr[myplr].WorldX;
 		_LOBYTE(y) = v3 + 1;
-		_LOBYTE(error_id) = 40;
+		_LOBYTE(error_id) = EMSG_REQUIRES_LVL_8;
 	}
 	if ( v0[1] == 9 && plr[v1]._pLevel < 13 )
 	{
 		v5 = 1;
 		_LOBYTE(x) = v2 + 1;
 		y = plr[v1].WorldY;
-		_LOBYTE(error_id) = 41;
+		_LOBYTE(error_id) = EMSG_REQUIRES_LVL_13;
 	}
 	if ( v0[1] == 13 && plr[v1]._pLevel < 17 )
 	{
 		x = plr[myplr].WorldX;
 		v5 = 1;
 		_LOBYTE(y) = v3 + 1;
-		_LOBYTE(error_id) = 42;
+		_LOBYTE(error_id) = EMSG_REQUIRES_LVL_17;
 	}
 	if ( !v5 )
 	{

--- a/enums.h
+++ b/enums.h
@@ -1784,6 +1784,53 @@ enum dungeon_message {
     DMSG_DIABLO    = 1 << 4,
 };
 
+enum diablo_message {
+    EMSG_NONE                   = 0,
+    EMSG_NO_AUTOMAP_IN_TOWN     = 1,
+    EMSG_NO_MULTIPLAYER_IN_DEMO = 2,
+    EMSG_DIRECT_SOUND_FAILED    = 3,
+    EMSG_NOT_IN_SHAREWARE       = 4,
+    EMSG_NO_SPACE_TO_SAVE       = 5,
+    EMSG_NO_PAUSE_IN_TOWN       = 6,
+    EMSG_COPY_TO_HDD            = 7,
+    EMSG_DESYNC                 = 8,
+    EMSG_NO_PAUSE_IN_MP         = 9,
+    EMSG_LOADING                = 10,
+    EMSG_SAVING                 = 11,
+    EMSG_SHRINE_MYSTERIOUS      = 12,
+    EMSG_SHRINE_HIDDEN          = 13,
+    EMSG_SHRINE_GLOOMY          = 14,
+    EMSG_SHRINE_WEIRD           = 15,
+    EMSG_SHRINE_MAGICAL         = 16,
+    EMSG_SHRINE_STONE           = 17,
+    EMSG_SHRINE_RELIGIOUS       = 18,
+    EMSG_SHRINE_ENCHANTED       = 19,
+    EMSG_SHRINE_THAUMATURGIC    = 20,
+    EMSG_SHRINE_FASCINATING     = 21,
+    EMSG_SHRINE_CRYPTIC         = 22,
+    EMSG_SHRINE_UNUSED          = 23,
+    EMSG_SHRINE_ELDRITCH        = 24,
+    EMSG_SHRINE_EERIE           = 25,
+    EMSG_SHRINE_DIVINE          = 26,
+    EMSG_SHRINE_HOLY            = 27,
+    EMSG_SHRINE_SACRED          = 28,
+    EMSG_SHRINE_SPIRITUAL       = 29,
+    EMSG_SHRINE_SPOOKY1         = 30,
+    EMSG_SHRINE_SPOOKY2         = 31,
+    EMSG_SHRINE_ABANDONED       = 32,
+    EMSG_SHRINE_CREEPY          = 33,
+    EMSG_SHRINE_QUIET           = 34,
+    EMSG_SHRINE_SECLUDED        = 35,
+    EMSG_SHRINE_ORNATE          = 36,
+    EMSG_SHRINE_GLIMMERING      = 37,
+    EMSG_SHRINE_TAINTED1        = 38,
+    EMSG_SHRINE_TAINTED2        = 39,
+    EMSG_REQUIRES_LVL_8         = 40,
+    EMSG_REQUIRES_LVL_13        = 41,
+    EMSG_REQUIRES_LVL_17        = 42,
+    EMSG_BONECHAMB              = 43,
+};
+
 enum magic_type {
     STYPE_FIRE      = 0x0,
     STYPE_LIGHTNING = 0x1,
@@ -1876,12 +1923,12 @@ enum MON_MODE {
 };
 
 enum MON_ANIM {
-    MA_STAND     = 0,
-    MA_WALK      = 1,
-    MA_ATTACK    = 2,
-    MA_GOTHIT    = 3,
-    MA_DEATH     = 4,
-    MA_SPECIAL   = 5,
+    MA_STAND   = 0,
+    MA_WALK    = 1,
+    MA_ATTACK  = 2,
+    MA_GOTHIT  = 3,
+    MA_DEATH   = 4,
+    MA_SPECIAL = 5,
 };
 
 enum PLR_MODE {


### PR DESCRIPTION
This makes all functions in gamemenu.cpp bin exact, except for gamemenu_enable_single, gamemenu_get_music, gamemenu_get_sound, gamemenu_get_gamma and gamemenu_color_cycling. As such the only changes to them are auto formatting (in order for the PRs to only contain bin exact changes)