### PR TITLE
Fix angular trans tiles

### DIFF
--- a/Source/_asm.cpp
+++ b/Source/_asm.cpp
@@ -6,7 +6,7 @@ static inline void asm_trans_light_square_0_2(unsigned char w, BYTE *tbl, BYTE *
 static inline void asm_trans_light_cel_1_3(unsigned char w, BYTE *tbl, BYTE *&dst, BYTE *&src);
 static inline void asm_trans_light_edge_1_3(unsigned char w, BYTE *tbl, BYTE *&dst, BYTE *&src);
 static inline void asm_trans_light_square_1_3(unsigned char w, BYTE *tbl, BYTE *&dst, BYTE *&src);
-static inline void asm_trans_light_mask(unsigned char w, BYTE *tbl, BYTE *&dst, BYTE *&src, unsigned int mask);
+static inline unsigned int asm_trans_light_mask(unsigned char w, BYTE *tbl, BYTE *&dst, BYTE *&src, unsigned int mask);
 
 static inline void asm_cel_light_edge(unsigned char w, BYTE *tbl, BYTE *&dst, BYTE *&src)
 {
@@ -110,10 +110,12 @@ static inline void asm_trans_light_square_1_3(unsigned char w, BYTE *tbl, BYTE *
     }
 }
 
-static inline void asm_trans_light_mask(unsigned char w, BYTE *tbl, BYTE *&dst, BYTE *&src, unsigned int mask)
+static inline unsigned int asm_trans_light_mask(unsigned char w, BYTE *tbl, BYTE *&dst, BYTE *&src, unsigned int mask)
 {
     for (; w; --w, src++, dst++, mask *= 2) {
         if (mask & 0x80000000)
             dst[0] = tbl[src[0]];
     }
+
+	return mask;
 }

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -1712,7 +1712,7 @@ LABEL_129:
 							yy_32 -= width;
 							if ( dst < gpBufEnd )
 								return;
-							asm_trans_light_mask(width, tbl, dst, src, gdwCurrentMask);
+							gdwCurrentMask = asm_trans_light_mask(width, tbl, dst, src, gdwCurrentMask);
 						}
 						while ( yy_32 );
 LABEL_50:
@@ -4895,7 +4895,7 @@ LABEL_252:
 								yy_32 -= width;
 								if ( dst < gpBufEnd )
 								{
-									asm_trans_light_mask(width, tbl, dst, src, gdwCurrentMask);
+									gdwCurrentMask = asm_trans_light_mask(width, tbl, dst, src, gdwCurrentMask);
 								}
 								else
 								{


### PR DESCRIPTION
This issue is caused by the fact these inlined functions are currently in C instead of asm, so the mask value is passed directly instead of by-reference. CEL type 1 stores the mask value in a global variable, and thus the function needs to pass the mask by reference. Changing it to work this way while in C++ seems to crash VC6, so I've created a temporary fix. This bug ONLY affects type 1 (custom-specified width).

This should fix itself when things are converted to proper assembly. Fixes #437 

EDIT: also, someone needs to change the project back to use tabs again. Replacing them with spaces is so-not-cool P_P