### PR TITLE
Correct name diablo_init_menu

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -107,41 +107,37 @@ void __cdecl FreeGameMem()
 	FreeTownerGFX();
 }
 
-int __fastcall diablo_init_menu(int a1, int bSinglePlayer)
+BOOL __fastcall StartGame(BOOL bNewGame, BOOL bSinglePlayer)
 {
-	int v2;            // esi
-	int v3;            // edi
-	int v4;            // ecx
-	int pfExitProgram; // [esp+Ch] [ebp-4h]
+	BOOL fExitProgram; // [esp+Ch] [ebp-4h]
+	unsigned int uMsg; // ecx
 
-	v2 = bSinglePlayer;
-	v3 = a1;
 	byte_678640 = 1;
 	while (1) {
-		pfExitProgram = 0;
+		fExitProgram = 0;
 		dword_5256E8 = FALSE;
-		if (!NetInit(v2, &pfExitProgram))
+		if (!NetInit(bSinglePlayer, &fExitProgram))
 			break;
 		byte_678640 = 0;
-		if ((v3 || !gbValidSaveFile)
+		if ((bNewGame || !gbValidSaveFile)
 		        && (InitLevels(), InitQuests(), InitPortals(), InitDungMsgs(myplr), !gbValidSaveFile)
-		    || (v4 = WM_DIABLOADGAME, !dword_5256E8)) {
-			v4 = WM_DIABNEWGAME;
+		    || (uMsg = WM_DIABLOADGAME, !dword_5256E8)) {
+			uMsg = WM_DIABNEWGAME;
 		}
-		run_game_loop(v4);
+		run_game_loop(uMsg);
 		NetClose();
 		pfile_create_player_description(0, 0);
 		if (!gbRunGameResult)
 			goto LABEL_11;
 	}
-	gbRunGameResult = pfExitProgram == 0;
+	gbRunGameResult = fExitProgram == 0;
 LABEL_11:
 	SNetDestroy();
 	return gbRunGameResult;
 }
 // 678640: using guessed type char byte_678640;
 
-void __fastcall run_game_loop(int uMsg)
+void __fastcall run_game_loop(unsigned int uMsg)
 {
 	//int v3; // eax
 	bool v5; // zf
@@ -215,7 +211,7 @@ void __fastcall run_game_loop(int uMsg)
 // 52571C: using guessed type int drawpanflag;
 // 679660: using guessed type char gbMaxPlayers;
 
-void __fastcall start_game(int uMsg)
+void __fastcall start_game(unsigned int uMsg)
 {
 	cineflag = FALSE;
 	zoomflag = 1;

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -37,9 +37,9 @@ extern int color_cycle_timer; // weak
 
 void __cdecl diablo_cpp_init();
 void __cdecl FreeGameMem();
-int __fastcall diablo_init_menu(int a1, int bSinglePlayer);
-void __fastcall run_game_loop(int uMsg);
-void __fastcall start_game(int uMsg);
+BOOL __fastcall StartGame(BOOL bNewGame, BOOL bSinglePlayer);
+void __fastcall run_game_loop(unsigned int uMsg);
+void __fastcall start_game(unsigned int uMsg);
 void __cdecl free_game();
 BOOL __cdecl diablo_get_not_running();
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow);

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -77,7 +77,7 @@ void __fastcall DrawProgress(int screen_x, int screen_y, int progress_id)
 	} while (v4);
 }
 
-void __fastcall ShowProgress(int uMsg)
+void __fastcall ShowProgress(unsigned int uMsg)
 {
 	WNDPROC saveProc; // edi
 	BOOL v3;          // cl
@@ -240,7 +240,7 @@ void __cdecl FreeInterface()
 	mem_free_dbg(v0);
 }
 
-void __fastcall InitCutscene(int uMsg)
+void __fastcall InitCutscene(unsigned int uMsg)
 {
 	int v1;            // eax
 	int v2;            // eax

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -12,9 +12,9 @@ void __cdecl interface_msg_pump();
 BOOL __cdecl IncProgress();
 void __cdecl DrawCutscene();
 void __fastcall DrawProgress(int screen_x, int screen_y, int progress_id);
-void __fastcall ShowProgress(int uMsg);
+void __fastcall ShowProgress(unsigned int uMsg);
 void __cdecl FreeInterface();
-void __fastcall InitCutscene(int uMsg);
+void __fastcall InitCutscene(unsigned int uMsg);
 
 /* rdata */
 

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -130,11 +130,11 @@ BOOL __cdecl mainmenu_single_player()
 BOOL __fastcall mainmenu_init_menu(int type)
 {
 	if (type == 4)
-		return 1;
+		return TRUE;
 
 	music_stop();
 
-	int success = diablo_init_menu(type != 2, type != 3);
+	BOOL success = StartGame(type != 2, type != 3);
 	if (success)
 		mainmenu_refresh_music();
 


### PR DESCRIPTION
The correct function signature is `StartGame` and was taken from the PSX. Also corrected the local variable names.