### PR TITLE
Fix CreateMagicItem and cheat cmd

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4890,18 +4890,46 @@ void __fastcall CreateSpellBook(int x, int y, int ispell, bool sendmsg, int delt
 	}
 }
 
-void __fastcall CreateMagicItem(int x, int y, int imisc, int icurs, int sendmsg, int delta)
+void __fastcall CreateMagicArmor(int x, int y, int imisc, int icurs, int sendmsg, int delta)
 {
 	int ii;    // esi
 	int idx;   // ebx
-	bool done; // [esp+Ch] [ebp-4h]
+	BOOL done; // [esp+Ch] [ebp-4h]
 
 	done = 0;
 	if (numitems < MAXITEMS) {
 		ii = itemavail[0];
-		GetSuperItemSpace(x, y, itemavail[0]);
-		itemactive[numitems] = ii;
+		GetSuperItemSpace(x, y, ii);
 		itemavail[0] = itemavail[MAXITEMS - numitems - 1];
+		itemactive[numitems] = ii;
+		idx = RndTypeItems(imisc, 0);
+		do {
+			SetupAllItems(ii, idx, GetRndSeed(), 2 * currlevel, 1, 1, 0, delta);
+			if (item[ii]._iCurs == icurs)
+				done = 1;
+			else
+				idx = RndTypeItems(imisc, 0);
+		} while (!done);
+		if (sendmsg)
+			NetSendCmdDItem(FALSE, ii);
+		if (delta)
+			DeltaAddItem(ii);
+		++numitems;
+	}
+}
+
+void __fastcall CreateMagicWeapon(int x, int y, int imisc, int icurs, int sendmsg, int delta)
+{
+	int ii;    // esi
+	int idx;   // ebx
+	BOOL done; // [esp+Ch] [ebp-4h]
+
+	done = 0;
+	if (numitems < MAXITEMS) {
+		ii = itemavail[0];
+		GetSuperItemSpace(x, y, ii);
+		itemavail[0] = itemavail[MAXITEMS - numitems - 1];
+		itemactive[numitems] = ii;
 		idx = RndTypeItems(imisc, 0);
 		do {
 			SetupAllItems(ii, idx, GetRndSeed(), 2 * currlevel, 1, 1, 0, delta);

--- a/Source/items.h
+++ b/Source/items.h
@@ -119,7 +119,8 @@ void __fastcall RecreateTownItem(int ii, int idx, unsigned short icreateinfo, in
 void __cdecl RecalcStoreStats();
 int __cdecl ItemNoFlippy();
 void __fastcall CreateSpellBook(int x, int y, int ispell, bool sendmsg, int delta);
-void __fastcall CreateMagicItem(int x, int y, int imisc, int icurs, int sendmsg, int delta);
+void __fastcall CreateMagicArmor(int x, int y, int imisc, int icurs, int sendmsg, int delta);
+void __fastcall CreateMagicWeapon(int x, int y, int imisc, int icurs, int sendmsg, int delta);
 BOOL __fastcall GetItemRecord(int dwSeed, WORD CI, int indx);
 void __fastcall NextItemRecord(int i);
 void __fastcall SetItemRecord(int dwSeed, WORD CI, int indx);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1315,17 +1315,10 @@ int __fastcall ParseCmd(int pnum, TCmd *pCmd)
 		return On_NEWLVL((struct TCmdParam2 *)v3, pnum);
 	case CMD_WARP:
 		return On_WARP((struct TCmdParam1 *)v3, pnum);
-#ifdef _DEBUG
 	case CMD_CHEAT_EXPERIENCE:
 		return On_CHEAT_EXPERIENCE(v3, pnum);
 	case CMD_CHEAT_SPELL_LEVEL:
 		return On_CHEAT_SPELL_LEVEL(v3, pnum);
-#else
-	case CMD_CHEAT_EXPERIENCE:
-		return On_DEBUG(v3);
-	case CMD_CHEAT_SPELL_LEVEL:
-		return On_DEBUG(v3);
-#endif
 	case CMD_DEBUG:
 		return On_DEBUG(v3);
 	case CMD_SYNCDATA:
@@ -2751,29 +2744,29 @@ int __fastcall On_ENDSHIELD(struct TCmd *pCmd, int pnum)
 	return sizeof(*pCmd);
 }
 
-#ifdef _DEBUG
 int __fastcall On_CHEAT_EXPERIENCE(struct TCmd *pCmd, int pnum)
 {
+#ifdef _DEBUG
 	if (gbBufferMsgs == 1)
 		msg_send_packet(pnum, pCmd, sizeof(*pCmd));
 	else if (plr[pnum]._pLevel < MAXCHARLEVEL - 1) {
 		plr[pnum]._pExperience = plr[pnum]._pNextExper;
 		NextPlrLevel(pnum);
 	}
-
+#endif
 	return sizeof(*pCmd);
 }
 
 int __fastcall On_CHEAT_SPELL_LEVEL(struct TCmd *pCmd, int pnum)
 {
+#ifdef _DEBUG
 	if (gbBufferMsgs == 1)
 		msg_send_packet(pnum, pCmd, sizeof(*pCmd));
 	else
 		plr[pnum]._pSplLvl[plr[pnum]._pRSpell]++;
-
+#endif
 	return sizeof(*pCmd);
 }
-#endif
 
 int __cdecl On_DEBUG(struct TCmd *pCmd)
 {

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -134,10 +134,8 @@ int __fastcall On_STRING(struct TCmdString *pCmd, int pnum);
 int __fastcall On_STRING2(int pnum, struct TCmdString *pCmd);
 int __fastcall On_SYNCQUEST(struct TCmdQuest *pCmd, int pnum);
 int __fastcall On_ENDSHIELD(struct TCmd *pCmd, int pnum);
-#ifdef _DEBUG
 int __fastcall On_CHEAT_EXPERIENCE(struct TCmd *pCmd, int pnum);
 int __fastcall On_CHEAT_SPELL_LEVEL(struct TCmd *pCmd, int pnum);
-#endif
 int __cdecl On_DEBUG(struct TCmd *pCmd);
 int __fastcall On_NOVA(struct TCmdLoc *pCmd, int pnum);
 int __fastcall On_SETSHIELD(struct TCmd *pCmd, int pnum);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3939,10 +3939,10 @@ void __fastcall OperateSlainHero(int pnum, int i, unsigned char sendmsg)
 		object[v5]._oSelFlag = 0;
 		if (v6) {
 			if (plr[pnum]._pClass == PC_WARRIOR) {
-				CreateMagicItem(object[v5]._ox, object[v5]._oy, 9, ICURS_BREAST_PLATE, 0, 1);
+				CreateMagicArmor(object[v5]._ox, object[v5]._oy, 9, ICURS_BREAST_PLATE, 0, 1);
 				v8 = PS_WARR9;
 			} else if (plr[pnum]._pClass == PC_ROGUE) {
-				CreateMagicItem(object[v5]._ox, object[v5]._oy, 3, ICURS_LONG_WAR_BOW, 0, 1);
+				CreateMagicWeapon(object[v5]._ox, object[v5]._oy, 3, ICURS_LONG_WAR_BOW, 0, 1);
 				v8 = PS_ROGUE9;
 			} else if (plr[pnum]._pClass == PC_SORCERER) {
 				CreateSpellBook(object[v5]._ox, object[v5]._oy, 3, 0, 1);


### PR DESCRIPTION
This fixes two instances of single-call functions that were inlined. In particular, VC6 will usually removed duplicate functions if they are all called within the same function and nowhere else.

The PSX lists both `CreateMagicArmor/Weapon`, but they're identical and get merged into one.

The debug network commands, exp cheat, spell cheat, and debug, all get optimized to a single `return 1` function since the code is ommited from release builds thus creating single-use dupes.

Thankfully we have access to older patches which can help us pin point these down. There are a few other missing functions as well, such as `LeftMouseDown` being two functions, and `ParseCmd` using a separate function for its' default case.