### PR TITLE
Fix M_DoFadeout

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2802,10 +2802,13 @@ BOOL __fastcall M_DoFadeout(int i)
 		return FALSE;
 	}
 
-	if (monster[i].MType->mtype < MT_INCIN || monster[i].MType->mtype > MT_HELLBURN)
-		monster[i]._mFlags &= ~MFLAG_LOCK_ANIMATION | MFLAG_HIDDEN;
-	else
+	int mt = monster[i].MType->mtype;
+	if (mt < MT_INCIN || mt > MT_HELLBURN) {
 		monster[i]._mFlags &= ~MFLAG_LOCK_ANIMATION;
+		monster[i]._mFlags |= MFLAG_HIDDEN;
+	} else {
+		monster[i]._mFlags &= ~MFLAG_LOCK_ANIMATION;
+	}
 
 	M_StartStand(i, monster[i]._mdir);
 


### PR DESCRIPTION
This fixes a bug where monsters capable of hiding will instead loop there special animation, also it restores M_DoFadein's bin exact status.

The issue was introduced in e340ce22419a1ac783ac12ad4d7d458681964774
Bin exact was broken in ef74b2cbaf496c931843da63282f9783e6198ab4