### PR TITLE
Compile as c

### DIFF
--- a/MakefileVC
+++ b/MakefileVC
@@ -56,6 +56,9 @@ debug: Diablo.exe
 DIABLO_SRC=$(sort $(filter-out Source/_asm.cpp Source/_render.cpp Source/render.cpp, $(wildcard Source/*.cpp)))
 DIABLO_SRC += Source/render.cpp
 OBJS=$(DIABLO_SRC:.cpp=.obj)
+# hardcoded list of src files, because only some of them are ready to be compiled as C instead of C++
+# once all files compile as C we should use the /TC flag abd DIABLO_SRC instead
+DIABLO_SRC_FIXED = Source/appfat.cpp Source/automap.cpp Source/capture.cpp /TcSource/codec.cpp Source/control.cpp Source/cursor.cpp /TcSource/dead.cpp Source/debug.cpp Source/diablo.cpp Source/doom.cpp Source/drlg_l1.cpp Source/drlg_l2.cpp Source/drlg_l3.cpp Source/drlg_l4.cpp Source/dthread.cpp Source/dx.cpp Source/effects.cpp Source/encrypt.cpp Source/engine.cpp Source/error.cpp Source/fault.cpp Source/gamemenu.cpp Source/gendung.cpp Source/gmenu.cpp /TcSource/help.cpp Source/init.cpp Source/interfac.cpp Source/inv.cpp Source/items.cpp Source/lighting.cpp Source/loadsave.cpp Source/logging.cpp Source/mainmenu.cpp Source/minitext.cpp Source/missiles.cpp Source/monster.cpp Source/movie.cpp Source/mpqapi.cpp Source/msg.cpp Source/msgcmd.cpp Source/multi.cpp Source/nthread.cpp Source/objects.cpp Source/pack.cpp Source/palette.cpp /TcSource/path.cpp Source/pfile.cpp Source/player.cpp /TcSource/plrmsg.cpp /TcSource/portal.cpp Source/quests.cpp /TcSource/restrict.cpp Source/scrollrt.cpp Source/setmaps.cpp /TcSource/sha.cpp Source/sound.cpp Source/spells.cpp Source/stores.cpp Source/sync.cpp /TcSource/textdat.cpp Source/themes.cpp Source/tmsg.cpp Source/town.cpp Source/towners.cpp Source/track.cpp Source/trigs.cpp Source/wave.cpp Source/render.cpp
 
 PKWARE_SRC=$(sort $(wildcard 3rdParty/PKWare/*.cpp))
 PKWARE_OBJS=$(PKWARE_SRC:.cpp=.obj)
@@ -77,7 +80,7 @@ DiabloUI/diabloui.lib: $(DIABLOUI_OBJS) 3rdParty/Storm/Source/storm.lib
 
 # compiles all main source files with once compiler call
 main_files:
-	$(CL) $(CFLAGS) /FoSource/ $(DIABLO_SRC)
+	$(CL) $(CFLAGS) /FoSource/ $(DIABLO_SRC_FIXED)
 
 %.obj: %.cpp
 	$(CL) $(CFLAGS) /Fo$@ $<

--- a/MakefileVC
+++ b/MakefileVC
@@ -67,7 +67,7 @@ DIABLOUI_SRC=DiabloUI/diabloui.cpp
 DIABLOUI_OBJS=$(DIABLOUI_SRC:.cpp=.obj)
 
 Diablo.exe: main_files $(PKWARE_OBJS) diablo.res DiabloUI/diabloui.lib 3rdParty/Storm/Source/storm.lib
-	$(VC_LINK) /OUT:$@ $(LINKFLAGS) $(OBJS) $(PKWARE_OBJS) diablo.res advapi32.lib gdi32.lib shell32.lib user32.lib version.lib DiabloUI/diabloui.lib 3rdParty/Storm/Source/storm.lib
+	$(VC_LINK) /OUT:$@ $(LINKFLAGS) $(OBJS) $(PKWARE_OBJS) diablo.res DiabloUI/diabloui.lib 3rdParty/Storm/Source/storm.lib user32.lib gdi32.lib advapi32.lib shell32.lib version.lib
 
 DiabloUI/diabloui.lib: $(DIABLOUI_OBJS) 3rdParty/Storm/Source/storm.lib
 	$(CL) $^ /link /LINK50COMPAT /nologo /dll /subsystem:windows /machine:I386 /LIBPATH:$(VC6_LIB_DIR) DiabloUI/diabloui.res advapi32.lib gdi32.lib shell32.lib user32.lib version.lib 3rdParty/Storm/Source/storm.lib /def:"DiabloUI/diabloui.def" /out:DiabloUI/diabloui.dll

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -43,6 +43,4 @@ void __fastcall pfile_update(BOOL force_save);
 
 /* rdata */
 
-extern const int pfile_inf; // weak
-
 #endif /* __PFILE_H__ */

--- a/Source/sha.h
+++ b/Source/sha.h
@@ -10,7 +10,6 @@
 #define SHA1HashSize 20
 
 //sha
-extern SHA1Context sgSHA1[3];
 
 void __cdecl SHA1Clear();
 void __fastcall SHA1Result(int n, char Message_Digest[SHA1HashSize]);

--- a/defs.h
+++ b/defs.h
@@ -211,6 +211,15 @@ char __OFSUB__(T x, U y)
 #endif /* IDA_GARBAGE */
 
 #ifndef INFINITY
+#ifdef __cplusplus
 #include <limits>
 #define INFINITY std::numeric_limits<float>::infinity()
+#else
+typedef union {
+   unsigned int u;
+   float f;
+} inf;
+static inf float_init = {0x7F800000};
+#define INFINITY float_init.f
+#endif
 #endif

--- a/types.h
+++ b/types.h
@@ -122,7 +122,11 @@ extern "C" {
 #include "Source/pack.h"
 #include "Source/palette.h"
 #include "Source/path.h"
+#ifdef __cplusplus
+}
 #include "Source/pfile.h"
+extern "C" {
+#endif
 #include "Source/player.h"
 #include "Source/plrmsg.h"
 #include "Source/portal.h"

--- a/types.h
+++ b/types.h
@@ -40,8 +40,8 @@
 #include "enums.h"
 #include "structs.h"
 
-#include "3rdParty/Storm/Source/storm.h"
 #include "DiabloUI/diabloui.h"
+#include "3rdParty/Storm/Source/storm.h"
 #include "3rdParty/PKWare/pkware.h"
 
 // If defined, use copy protection [Default -> Defined]

--- a/types.h
+++ b/types.h
@@ -61,12 +61,19 @@
 #define ASM_XLAT(eax, ebx) eax = (eax & 0xFFFFFF00) + LOBYTE(ebx[LOBYTE(eax)])
 
 // header files
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "Source/appfat.h"
 #include "Source/automap.h"
 #include "Source/capture.h"
 #include "Source/codec.h"
 #include "Source/control.h"
+#ifdef __cplusplus
+}
 #include "Source/cursor.h"
+extern "C" {
+#endif
 #include "Source/dead.h"
 #include "Source/debug.h"
 #include "Source/diablo.h"
@@ -79,7 +86,11 @@
 #include "Source/dx.h"
 #include "Source/effects.h"
 #include "Source/encrypt.h"
+#ifdef __cplusplus
+}
 #include "Source/engine.h"
+extern "C" {
+#endif
 #include "Source/error.h"
 #include "Source/fault.h"
 #include "Source/gamemenu.h"
@@ -103,7 +114,11 @@
 #include "Source/msgcmd.h"
 #include "Source/multi.h"
 #include "Source/nthread.h"
+#ifdef __cplusplus
+}
 #include "Source/objects.h"
+extern "C" {
+#endif
 #include "Source/pack.h"
 #include "Source/palette.h"
 #include "Source/path.h"
@@ -129,5 +144,8 @@
 #include "Source/trigs.h"
 #include "Source/wave.h"
 #include "Source/render.h" // linked last, likely .s/.asm
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
This makes the following files compile as C instead of C++
codec.cpp, dead.cpp, help.cpp, path.cpp, plrmsg.cpp, portal.cpp, restrict.cpp, sha.cpp, textdat.cpp

There are still 4 header files that aren't full C compatible and so are omitted using #idfed in types.h when the compiler is in C mode.

I couldn't think of a good way to add /Tc in front of the specific files in DIABLO_SRC so I ended up just having a fixed list for now.