### PR TITLE
fix collisions of SetCursor and DeleteObject

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -2598,7 +2598,7 @@ void __fastcall control_set_gold_curs(int pnum)
 		v3 = &plr[v1].HoldItem._iCurs;
 		plr[v1].HoldItem._iCurs = ICURS_GOLD_LARGE;
 	}
-	SetCursor(*v3 + 12);
+	SetCursor_(*v3 + 12);
 }
 
 void __cdecl DrawTalkPan()

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -416,7 +416,7 @@ void __fastcall SetICursor(int i)
 // 4B8CB4: using guessed type int icursH;
 // 4B8CBC: using guessed type int icursW;
 
-void __fastcall SetCursor(int i)
+void __fastcall SetCursor_(int i)
 {
 	int v1; // eax
 
@@ -430,12 +430,12 @@ void __fastcall SetCursor(int i)
 
 void __fastcall NewCursor(int i)
 {
-	SetCursor(i);
+	SetCursor_(i);
 }
 
 void __cdecl InitLevelCursor()
 {
-	SetCursor(CURSOR_HAND);
+	SetCursor_(CURSOR_HAND);
 	cursmx = ViewX;
 	cursmy = ViewY;
 	dword_4B8CCC = -1;

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -22,7 +22,7 @@ extern int pcurs;        // idb
 void __cdecl InitCursor();
 void __cdecl FreeCursor();
 void __fastcall SetICursor(int i);
-void __fastcall SetCursor(int i);
+void __fastcall SetCursor_(int i);
 void __fastcall NewCursor(int i);
 void __cdecl InitLevelCursor();
 void __cdecl CheckTown();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -192,7 +192,7 @@ void __fastcall run_game_loop(unsigned int uMsg)
 		pfile_write_hero();
 	pfile_flush_W();
 	PaletteFadeOut(8);
-	SetCursor(CURSOR_NONE);
+	SetCursor_(CURSOR_NONE);
 	ClearScreenBuffer();
 	drawpanflag = 255;
 	scrollrt_draw_game_screen(1);
@@ -816,7 +816,7 @@ BOOL __fastcall LeftMouseDown(int wParam)
 			return 0;
 		NetSendCmdPItem(TRUE, CMD_PUTITEM, cursmx, cursmy);
 	LABEL_48:
-		SetCursor(CURSOR_HAND);
+		SetCursor_(CURSOR_HAND);
 		return 0;
 	}
 	if (plr[myplr]._pStatPts && !spselflag)
@@ -920,7 +920,7 @@ BOOLEAN __cdecl TryIconCurs()
 			return 1;
 		}
 	LABEL_26:
-		SetCursor(CURSOR_HAND);
+		SetCursor_(CURSOR_HAND);
 		return 1;
 	case CURSOR_REPAIR:
 		if (pcursinvitem != -1) {
@@ -994,7 +994,7 @@ void __cdecl RightMouseDown()
 					if (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem))
 						CheckPlrSpell();
 				} else if (pcurs > 1 && pcurs < 12) {
-					SetCursor(CURSOR_HAND);
+					SetCursor_(CURSOR_HAND);
 				}
 			}
 		}
@@ -1675,7 +1675,7 @@ void __fastcall LoadGameLevel(BOOL firstflag, int lvldir)
 		glSeedTbl[currlevel] = setseed;
 
 	music_stop();
-	SetCursor(CURSOR_HAND);
+	SetCursor_(CURSOR_HAND);
 	SetRndSeed(glSeedTbl[currlevel]);
 	IncProgress();
 	MakeLightTable();
@@ -1958,12 +1958,12 @@ void __fastcall timeout_cursor(BOOL bTimeout)
 			ClearPanel();
 			AddPanelString("-- Network timeout --", 1);
 			AddPanelString("-- Waiting for players --", 1);
-			SetCursor(CURSOR_HOURGLASS);
+			SetCursor_(CURSOR_HOURGLASS);
 			drawpanflag = 255;
 		}
 		scrollrt_draw_game_screen(1);
 	} else if (sgnTimeoutCurs) {
-		SetCursor(sgnTimeoutCurs);
+		SetCursor_(sgnTimeoutCurs);
 		sgnTimeoutCurs = 0;
 		ClearPanel();
 		drawpanflag = 255;

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -110,7 +110,7 @@ void __cdecl gamemenu_load_game()
 {
 	WNDPROC saveProc = SetWindowProc(DisableInputWndProc);
 	gamemenu_off();
-	SetCursor(CURSOR_NONE);
+	SetCursor_(CURSOR_NONE);
 	InitDiabloMsg(EMSG_LOADING);
 	drawpanflag = 255;
 	DrawAndBlit();
@@ -121,7 +121,7 @@ void __cdecl gamemenu_load_game()
 	drawpanflag = 255;
 	DrawAndBlit();
 	PaletteFadeIn(8);
-	SetCursor(CURSOR_HAND);
+	SetCursor_(CURSOR_HAND);
 	interface_msg_pump();
 	SetWindowProc(saveProc);
 }
@@ -134,7 +134,7 @@ void __cdecl gamemenu_save_game()
 			gamemenu_off();
 		} else {
 			WNDPROC saveProc = SetWindowProc(DisableInputWndProc);
-			SetCursor(CURSOR_NONE);
+			SetCursor_(CURSOR_NONE);
 			gamemenu_off();
 			InitDiabloMsg(EMSG_SAVING);
 			drawpanflag = 255;
@@ -142,7 +142,7 @@ void __cdecl gamemenu_save_game()
 			SaveGame();
 			ClrDiabloMsg();
 			drawpanflag = 255;
-			SetCursor(CURSOR_HAND);
+			SetCursor_(CURSOR_HAND);
 			interface_msg_pump();
 			SetWindowProc(saveProc);
 		}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1035,7 +1035,7 @@ LABEL_18:
 				qmemcpy(&plr[v3].HoldItem, v27, sizeof(plr[v3].HoldItem));
 				v29 = plr[v3].HoldItem._iCurs + 12;
 				if (v28 == myplr)
-					SetCursor(v29);
+					SetCursor_(v29);
 				else
 					SetICursor(v29);
 				v67 = 0;
@@ -1050,7 +1050,7 @@ LABEL_18:
 				qmemcpy(&plr[v3].HoldItem, &tempitem, sizeof(plr[v3].HoldItem));
 				v33 = plr[v3].HoldItem._iCurs + 12;
 				if (v32 == myplr)
-					SetCursor(v33);
+					SetCursor_(v33);
 				else
 					SetICursor(v33);
 				if (!v67)
@@ -1286,7 +1286,7 @@ LABEL_18:
 				if (v60 == myplr) {
 					if (cursor_ida == 1)
 						SetCursorPos(MouseX + (cursW >> 1), MouseY + (cursH >> 1));
-					SetCursor(cursor_ida);
+					SetCursor_(cursor_ida);
 				}
 				return;
 			default:
@@ -1551,7 +1551,7 @@ void __fastcall CheckInvCut(int pnum, int mx, int my)
 
 		if (pnum == myplr) {
 			PlaySFX(IS_IGRAB);
-			SetCursor(plr[pnum].HoldItem._iCurs + CURSOR_FIRSTITEM);
+			SetCursor_(plr[pnum].HoldItem._iCurs + CURSOR_FIRSTITEM);
 			SetCursorPos(mx - (cursW >> 1), MouseY - (cursH >> 1));
 		}
 	}
@@ -1809,7 +1809,7 @@ void __fastcall InvGetItem(int pnum, int ii)
 		}
 		v5 = plr[pnuma].HoldItem._iCurs;
 		pcursitem = -1;
-		SetCursor(v5 + 12);
+		SetCursor_(v5 + 12);
 	}
 }
 // 4B84DC: using guessed type int dropGoldFlag;
@@ -2286,7 +2286,7 @@ int __fastcall InvPutItem(int pnum, int x, int y)
 	item[v17]._ix = xa;
 	RespawnItem(v15, 1);
 	++numitems;
-	SetCursor(CURSOR_HAND);
+	SetCursor_(CURSOR_HAND);
 	return yc;
 }
 
@@ -2770,7 +2770,7 @@ void __cdecl DoTelekinesis()
 		NetSendCmdGItem(TRUE, CMD_REQUESTAGITEM, myplr, myplr, pcursitem);
 	if (pcursmonst != -1 && !M_Talker(pcursmonst) && !monster[pcursmonst].mtalkmsg)
 		NetSendCmdParam1(TRUE, CMD_KNOCKBACK, pcursmonst);
-	SetCursor(CURSOR_HAND);
+	SetCursor_(CURSOR_HAND);
 }
 // 4B8CC0: using guessed type char pcursitem;
 // 4B8CC1: using guessed type char pcursobj;
@@ -2815,6 +2815,6 @@ int __cdecl DropItemBeforeTrig()
 	if (!TryInvPut())
 		return 0;
 	NetSendCmdPItem(TRUE, CMD_PUTITEM, cursmx, cursmy);
-	SetCursor(CURSOR_HAND);
+	SetCursor_(CURSOR_HAND);
 	return 1;
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3322,7 +3322,7 @@ void __fastcall CheckIdentify(int pnum, int cii)
 	CalcPlrInv(pnum, 1);
 
 	if (pnum == myplr)
-		SetCursor(CURSOR_HAND);
+		SetCursor_(CURSOR_HAND);
 }
 
 void __fastcall DoRepair(int pnum, int cii)
@@ -3338,7 +3338,7 @@ void __fastcall DoRepair(int pnum, int cii)
 	CalcPlrInv(pnum, 1);
 
 	if (pnum == myplr)
-		SetCursor(CURSOR_HAND);
+		SetCursor_(CURSOR_HAND);
 }
 
 void __fastcall RepairItem(ItemStruct *i, int lvl)
@@ -3386,7 +3386,7 @@ void __fastcall DoRecharge(int pnum, int cii)
 	}
 
 	if (pnum == myplr)
-		SetCursor(CURSOR_HAND);
+		SetCursor_(CURSOR_HAND);
 }
 
 void __fastcall RechargeItem(ItemStruct *i, int r)

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -170,7 +170,7 @@ void __fastcall LoadGame(BOOL firstflag)
 	ProcessVisionList();
 	missiles_process_charge();
 	ResetPal();
-	SetCursor(CURSOR_HAND);
+	SetCursor_(CURSOR_HAND);
 	gbProcessPlayers = TRUE;
 }
 // 5CF31D: using guessed type char setlevel;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3177,7 +3177,7 @@ void __fastcall AddHealOther(int mi, int sx, int sy, int dx, int dy, int midir, 
 	missile[mi]._miDelFlag = 1;
 	UseMana(id, 34);
 	if (id == myplr)
-		SetCursor(CURSOR_HEALOTHER);
+		SetCursor_(CURSOR_HEALOTHER);
 }
 
 void __fastcall AddElement(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
@@ -3235,7 +3235,7 @@ void __fastcall AddIdentify(int mi, int sx, int sy, int dx, int dy, int midir, i
 			sbookflag = 0;
 		if (!invflag)
 			invflag = 1;
-		SetCursor(CURSOR_IDENTIFY);
+		SetCursor_(CURSOR_IDENTIFY);
 	}
 }
 // 4B8968: using guessed type int sbookflag;
@@ -3411,7 +3411,7 @@ void __fastcall AddRepair(int mi, int sx, int sy, int dx, int dy, int midir, int
 			sbookflag = 0;
 		if (!invflag)
 			invflag = 1;
-		SetCursor(CURSOR_REPAIR);
+		SetCursor_(CURSOR_REPAIR);
 	}
 }
 // 4B8968: using guessed type int sbookflag;
@@ -3425,7 +3425,7 @@ void __fastcall AddRecharge(int mi, int sx, int sy, int dx, int dy, int midir, i
 			sbookflag = 0;
 		if (!invflag)
 			invflag = 1;
-		SetCursor(CURSOR_RECHARGE);
+		SetCursor_(CURSOR_RECHARGE);
 	}
 }
 // 4B8968: using guessed type int sbookflag;
@@ -3435,7 +3435,7 @@ void __fastcall AddDisarm(int mi, int sx, int sy, int dx, int dy, int midir, int
 	missile[mi]._miDelFlag = 1;
 	UseMana(id, 28);
 	if (id == myplr)
-		SetCursor(CURSOR_DISARM);
+		SetCursor_(CURSOR_DISARM);
 }
 
 void __fastcall AddApoca(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
@@ -3625,7 +3625,7 @@ void __fastcall AddResurrect(int mi, int sx, int sy, int dx, int dy, int midir, 
 	v9 = mi;
 	UseMana(id, 32);
 	if (id == myplr)
-		SetCursor(CURSOR_RESURRECT);
+		SetCursor_(CURSOR_RESURRECT);
 	missile[v9]._miDelFlag = 1;
 }
 
@@ -3650,7 +3650,7 @@ void __fastcall AddTelekinesis(int mi, int sx, int sy, int dx, int dy, int midir
 	missile[mi]._miDelFlag = 1;
 	UseMana(id, 33);
 	if (id == myplr)
-		SetCursor(CURSOR_TELEKINESIS);
+		SetCursor_(CURSOR_TELEKINESIS);
 }
 
 void __fastcall AddBoneSpirit(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4173,7 +4173,7 @@ void __fastcall TryDisarm(int pnum, int i)
 	v3 = i;
 	v12 = i;
 	if (pnum == myplr)
-		SetCursor(CURSOR_HAND);
+		SetCursor_(CURSOR_HAND);
 	v4 = v3;
 	if (object[v4]._oTrapFlag) {
 		v5 = 2 * plr[v2]._pDexterity - 5 * currlevel;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1522,7 +1522,7 @@ void __fastcall SetMapObjects(unsigned char *pMap, int startx, int starty)
 // 67D7C4: using guessed type int numobjfiles;
 // 4427C5: using guessed type int var_10C[56];
 
-void __fastcall DeleteObject(int oi, int i)
+void __fastcall DeleteObject_(int oi, int i)
 {
 	int v2;     // eax
 	BOOLEAN v3; // zf
@@ -2683,7 +2683,7 @@ LABEL_45:
 	v6 = 0;
 	while (v6 < nobjects) {
 		if (object[objectactive[v6]]._oDelFlag) {
-			DeleteObject(objectactive[v6], v6);
+			DeleteObject_(objectactive[v6], v6);
 			v6 = 0;
 		} else {
 			++v6;

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -42,7 +42,7 @@ void __cdecl AddL4Goodies();
 void __cdecl AddLazStand();
 void __cdecl InitObjects();
 void __fastcall SetMapObjects(unsigned char *pMap, int startx, int starty);
-void __fastcall DeleteObject(int oi, int i);
+void __fastcall DeleteObject_(int oi, int i);
 void __fastcall SetupObject(int i, int x, int y, int ot);
 void __fastcall SetObjMapRange(int i, int x1, int y1, int x2, int y2, int v);
 void __fastcall SetBookMsg(int i, int msg);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1726,7 +1726,7 @@ void __fastcall StartPlayerKill(int pnum, int earflag)
 
 			if (pcurs >= CURSOR_FIRSTITEM) {
 				PlrDeadItem(pnum, &plr[pnum].HoldItem, 0, 0);
-				SetCursor(CURSOR_HAND);
+				SetCursor_(CURSOR_HAND);
 			}
 
 			if (!diablolevel) {

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2475,7 +2475,7 @@ void __cdecl S_SBuyEnter()
 		idx = stextsval + ((stextsel - stextup) >> 2);
 		if (plr[myplr]._pGold >= smithitem[idx]._iIvalue) {
 			qmemcpy(&plr[v0].HoldItem, &smithitem[idx], sizeof(plr[v0].HoldItem));
-			SetCursor(plr[v0].HoldItem._iCurs + 12);
+			SetCursor_(plr[v0].HoldItem._iCurs + 12);
 			done = 0;
 			i = 0;
 			do {
@@ -2491,7 +2491,7 @@ void __cdecl S_SBuyEnter()
 			v4 = STORE_NOROOM;
 		LABEL_11:
 			StartStore(v4);
-			SetCursor(CURSOR_HAND);
+			SetCursor_(CURSOR_HAND);
 		} else {
 			StartStore(STORE_NOMONEY);
 		}
@@ -2579,7 +2579,7 @@ void __cdecl S_SPBuyEnter()
 		v7 = myplr;
 		if (plr[myplr]._pGold >= premiumitem[v6]._iIvalue) {
 			qmemcpy(&plr[v7].HoldItem, &premiumitem[v6], sizeof(plr[v7].HoldItem));
-			SetCursor(plr[v7].HoldItem._iCurs + 12);
+			SetCursor_(plr[v7].HoldItem._iCurs + 12);
 			v8 = 0;
 			v9 = 0;
 			do {
@@ -2595,7 +2595,7 @@ void __cdecl S_SPBuyEnter()
 			v10 = STORE_NOROOM;
 		LABEL_16:
 			StartStore(v10);
-			SetCursor(CURSOR_HAND);
+			SetCursor_(CURSOR_HAND);
 		} else {
 			StartStore(STORE_NOMONEY);
 		}
@@ -2619,9 +2619,9 @@ BOOLEAN __fastcall StoreGoldFit(int idx)
 	if (cost % 5000)
 		sz++;
 
-	SetCursor(storehold[idx]._iCurs + 12);
+	SetCursor_(storehold[idx]._iCurs + 12);
 	numsqrs = cursW / 28 * (cursH / 28);
-	SetCursor(CURSOR_HAND);
+	SetCursor_(CURSOR_HAND);
 
 	if (numsqrs >= sz)
 		return 1;
@@ -2928,7 +2928,7 @@ void __cdecl S_WBuyEnter()
 
 		if (plr[myplr]._pGold >= witchitem[idx]._iIvalue) {
 			qmemcpy(&plr[myplr].HoldItem, &witchitem[idx], sizeof(ItemStruct));
-			SetCursor(plr[myplr].HoldItem._iCurs + 12);
+			SetCursor_(plr[myplr].HoldItem._iCurs + 12);
 			done = 0;
 
 			for (i = 0; i < 40; i++) {
@@ -2942,7 +2942,7 @@ void __cdecl S_WBuyEnter()
 			else
 				StartStore(STORE_NOROOM);
 
-			SetCursor(CURSOR_HAND);
+			SetCursor_(CURSOR_HAND);
 		} else {
 			StartStore(STORE_NOMONEY);
 		}
@@ -3164,7 +3164,7 @@ void __cdecl S_BBuyEnter()
 		if (plr[myplr]._pGold >= boyitem._iIvalue + (boyitem._iIvalue >> 1)) {
 			qmemcpy(&plr[v1].HoldItem, &boyitem, sizeof(plr[v1].HoldItem));
 			plr[v1].HoldItem._iIvalue += plr[v1].HoldItem._iIvalue >> 1;
-			SetCursor(plr[v1].HoldItem._iCurs + 12);
+			SetCursor_(plr[v1].HoldItem._iCurs + 12);
 			v3 = 0;
 			v4 = 0;
 			do {
@@ -3180,7 +3180,7 @@ void __cdecl S_BBuyEnter()
 			_LOBYTE(v2) = STORE_NOROOM;
 		LABEL_10:
 			StartStore(v2);
-			SetCursor(CURSOR_HAND);
+			SetCursor_(CURSOR_HAND);
 		} else {
 			_LOBYTE(v0) = STORE_NOMONEY;
 			StartStore(v0);
@@ -3345,7 +3345,7 @@ void __cdecl S_HBuyEnter()
 		idx = stextsval + ((stextsel - stextup) >> 2);
 		if (plr[myplr]._pGold >= healitem[idx]._iIvalue) {
 			qmemcpy(&plr[v0].HoldItem, &healitem[idx], sizeof(plr[v0].HoldItem));
-			SetCursor(plr[v0].HoldItem._iCurs + 12);
+			SetCursor_(plr[v0].HoldItem._iCurs + 12);
 			done = 0;
 			i = 0;
 			do {
@@ -3361,7 +3361,7 @@ void __cdecl S_HBuyEnter()
 			v4 = STORE_NOROOM;
 		LABEL_11:
 			StartStore(v4);
-			SetCursor(CURSOR_HAND);
+			SetCursor_(CURSOR_HAND);
 		} else {
 			StartStore(STORE_NOMONEY);
 		}

--- a/types.h
+++ b/types.h
@@ -69,11 +69,7 @@ extern "C" {
 #include "Source/capture.h"
 #include "Source/codec.h"
 #include "Source/control.h"
-#ifdef __cplusplus
-}
 #include "Source/cursor.h"
-extern "C" {
-#endif
 #include "Source/dead.h"
 #include "Source/debug.h"
 #include "Source/diablo.h"
@@ -114,11 +110,7 @@ extern "C" {
 #include "Source/msgcmd.h"
 #include "Source/multi.h"
 #include "Source/nthread.h"
-#ifdef __cplusplus
-}
 #include "Source/objects.h"
-extern "C" {
-#endif
 #include "Source/pack.h"
 #include "Source/palette.h"
 #include "Source/path.h"


### PR DESCRIPTION
These collisions happen since windows.h define both SetCursor and DeleteObject. And in C, we don't have overloading, so only one function can be defined.