### PR TITLE
Remove unused init

### DIFF
--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -2,9 +2,6 @@
 
 #include "../types.h"
 
-// +Infinity after initialization of appfat.cpp.
-static float appfat_cpp_init_value = INFINITY;
-
 char sz_error_buf[256];
 int terminating;       // weak
 int cleanup_thread_id; // weak

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -34,7 +34,6 @@ extern int sgnTimeoutCurs;
 extern char sgbMouseDown;     // weak
 extern int color_cycle_timer; // weak
 
-void __cdecl diablo_cpp_init();
 void __cdecl FreeGameMem();
 BOOL __fastcall StartGame(BOOL bNewGame, BOOL bSinglePlayer);
 void __fastcall run_game_loop(unsigned int uMsg);

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -2,7 +2,6 @@
 
 #include "../types.h"
 
-static float dthread_cpp_init_value = INFINITY;
 static CRITICAL_SECTION sgMemCrit; // idb
 unsigned int glpDThreadId;         // idb
 TMegaPkt *sgpInfoHead;             /* may not be right struct */

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -7,7 +7,6 @@ extern TMegaPkt *sgpInfoHead;     /* may not be right struct */
 extern char byte_52A508;          // weak
 extern HANDLE sghWorkToDoEvent;   // idb
 
-void __cdecl dthread_cpp_init_1();
 void __cdecl dthread_cpp_init_2();
 void __cdecl dthread_init_mutex();
 void __cdecl dthread_cleanup_mutex_atexit();

--- a/Source/dx.h
+++ b/Source/dx.h
@@ -13,7 +13,6 @@ extern char gbBackBuf;    // weak
 extern char gbEmulate;    // weak
 extern HMODULE ghDiabMod; // idb
 
-void __cdecl dx_cpp_init_1();
 void __cdecl dx_cpp_init_2();
 void __cdecl dx_init_mutex();
 void __cdecl dx_cleanup_mutex_atexit();

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -7,7 +7,6 @@ extern int sfxdnum;
 extern void *sfx_stream;
 extern TSFX *sfx_data_cur;
 
-void __cdecl effects_cpp_init();
 BOOL __fastcall effect_is_playing(int nSFX);
 void __cdecl sfx_stop();
 void __fastcall InitMonsterSND(int monst);

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -2,7 +2,6 @@
 
 #include "../types.h"
 
-static float engine_cpp_init_value = INFINITY;
 char gbPixelCol;           // automap pixel color 8-bit (palette entry)
 int dword_52B970;          // BOOLEAN flip - if y < x
 int orgseed;               // weak

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -13,7 +13,6 @@ extern int sglGameSeed;  // weak
 extern int SeedCount;    // weak
 extern int dword_52B99C; // bool valid - if x/y are in bounds
 
-void __cdecl engine_cpp_init_1();
 void __fastcall CelDrawDatOnly(char *pDecodeTo, char *pRLEBytes, int dwRLESize, int dwRLEWdt);
 void __fastcall CelDecodeOnly(int screen_x, int screen_y, void *pCelBuff, int frame, int frame_width);
 void __fastcall CelDecDatOnly(char *pBuff, char *pCelBuff, int frame, int frame_width);

--- a/Source/init.h
+++ b/Source/init.h
@@ -14,7 +14,6 @@ extern void *patch_rt_mpq;
 extern int killed_mom_parent; // weak
 extern BOOLEAN screensaver_enabled_prev;
 
-void __cdecl init_cpp_init();
 void __fastcall init_cleanup(BOOLEAN show_cursor);
 void __cdecl init_run_office_from_start_menu();
 void __fastcall init_run_office(char *dir);

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -6,7 +6,6 @@ extern void *sgpBackCel;
 extern int sgdwProgress;
 extern int progress_id; // idb
 
-void __cdecl interfac_cpp_init();
 void __cdecl interface_msg_pump();
 BOOL __cdecl IncProgress();
 void __cdecl DrawCutscene();

--- a/Source/logging.cpp
+++ b/Source/logging.cpp
@@ -2,7 +2,6 @@
 
 #include "../types.h"
 
-static float log_cpp_init_value = INFINITY;
 static CRITICAL_SECTION sgMemCrit;
 CHAR FileName[260]; // idb
 char log_buffer[388];

--- a/Source/logging.h
+++ b/Source/logging.h
@@ -7,7 +7,6 @@ extern char log_buffer[388];
 extern LPCVOID lpAddress;           // idb
 extern DWORD nNumberOfBytesToWrite; // idb
 
-void __cdecl log_cpp_init_1();
 void __cdecl log_cpp_init_2();
 void __cdecl log_init_mutex();
 void __cdecl j_log_cleanup_mutex();

--- a/Source/mainmenu.h
+++ b/Source/mainmenu.h
@@ -4,7 +4,6 @@
 
 extern char gszHero[16];
 
-void __cdecl mainmenu_cpp_init();
 void __cdecl mainmenu_refresh_music();
 void __stdcall mainmenu_create_hero(char *name_1, char *name_2);
 int __stdcall mainmenu_select_hero_dialog(

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -5,7 +5,6 @@
 // Tracks which missile files are already loaded
 int MissileFileFlag;
 
-static float monster_cpp_init_value = INFINITY;
 int monstkills[MAXMONSTERS];
 int monstactive[MAXMONSTERS];
 int nummonsters;

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -15,7 +15,6 @@ extern int monstimgtot; // weak
 extern int uniquetrans;
 extern int nummtypes;
 
-void __cdecl monster_cpp_init();
 void __fastcall InitMonsterTRN(int monst, BOOL special);
 void __cdecl InitLevelMonsters();
 int __fastcall AddMonsterType(int type, int placeflag);

--- a/Source/movie.h
+++ b/Source/movie.h
@@ -5,7 +5,6 @@
 extern BYTE movie_playing;
 extern BOOL loop_movie;
 
-void __cdecl movie_cpp_init();
 void __fastcall play_movie(char *pszMovie, BOOL user_can_close);
 LRESULT __stdcall MovieWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -2,7 +2,6 @@
 
 #include "../types.h"
 
-static float mpqapi_cpp_init_value = INFINITY;
 int sgdwMpqOffset; // idb
 char mpq_buf[4096];
 _HASHENTRY *sgpHashTbl;

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -9,7 +9,6 @@ extern BOOLEAN save_archive_modified; // weak
 extern _BLOCKENTRY *sgpBlockTbl;
 extern BOOLEAN save_archive_open; // weak
 
-void __cdecl mpqapi_cpp_init();
 BOOLEAN __fastcall mpqapi_set_hidden(char *pszArchive, BOOLEAN hidden);
 void __fastcall mpqapi_store_creation_time(const char *pszArchive, int dwChar);
 BOOLEAN __fastcall mpqapi_reg_load_modification_time(char *dst, int size);

--- a/Source/msgcmd.cpp
+++ b/Source/msgcmd.cpp
@@ -4,7 +4,6 @@
 
 /* TODO: decompile and fix, commands are NOT deleted properly */
 
-static float msgcmd_cpp_init_value = INFINITY;
 ChatCmd sgChat_Cmd;
 int sgdwMsgCmdTimer;
 

--- a/Source/msgcmd.h
+++ b/Source/msgcmd.h
@@ -5,7 +5,6 @@
 extern ChatCmd sgChat_Cmd;
 extern int sgdwMsgCmdTimer;
 
-void __cdecl msgcmd_cpp_init_1();
 void __cdecl msgcmd_cpp_init_2();
 void __cdecl msgcmd_init_event();
 void __cdecl msgcmd_cleanup_chatcmd_atexit();

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -27,7 +27,6 @@ extern BYTE gbDeltaSender; // weak
 extern int sgbNetInited;   // weak
 extern int player_state[MAX_PLRS];
 
-void __cdecl multi_cpp_init();
 void __fastcall multi_msg_add(BYTE *a1, unsigned char a2);
 void __fastcall NetSendLoPri(BYTE *pbMsg, BYTE bLen);
 void __fastcall multi_copy_packet(TBuffer *a1, void *packet, BYTE size);

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -2,7 +2,6 @@
 
 #include "../types.h"
 
-static float nthread_cpp_init_value = INFINITY;
 char byte_679704; // weak
 int gdwMsgLenTbl[4];
 static CRITICAL_SECTION sgMemCrit;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -608,7 +608,6 @@ void __cdecl ClrAllObjects()
 }
 // 679768: using guessed type int trapid;
 // 67976C: using guessed type int trapdir;
-// 67D7C8: using guessed type int hero_cpp_init_value;
 
 void __cdecl AddTortures()
 {

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -2,7 +2,6 @@
 #ifndef __PACK_H__
 #define __PACK_H__
 
-void __cdecl pack_cpp_init();
 void __fastcall PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield);
 void __fastcall PackItem(PkItemStruct *id, ItemStruct *is);
 void __fastcall VerifyGoldSeeds(PlayerStruct *pPlayer);

--- a/Source/palette.h
+++ b/Source/palette.h
@@ -7,7 +7,6 @@ extern PALETTEENTRY system_palette[256];
 extern PALETTEENTRY orig_palette[256];
 extern UINT gdwPalEntries;
 
-void __cdecl palette_cpp_init();
 void __cdecl SaveGamma();
 void __cdecl palette_init();
 void __cdecl LoadGamma();

--- a/Source/player.h
+++ b/Source/player.h
@@ -18,7 +18,6 @@ extern int plr_sframe_size; // idb
 extern int deathdelay;      // weak
 extern int plr_dframe_size; // idb
 
-void __cdecl player_cpp_init();
 void __fastcall SetPlayerGPtrs(UCHAR *pData, UCHAR **pAnim); /* unsigned char *+** */
 void __fastcall LoadPlrGFX(int pnum, player_graphic gfxflag);
 void __fastcall InitPlayerGFX(int pnum);

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -22,7 +22,6 @@ extern char sgSaveBack[8192];
 extern int draw_monster_num; // weak
 extern int sgdwCursHgtOld;   // idb
 
-void __cdecl scrollrt_cpp_init();
 void __cdecl ClearCursor();
 void __fastcall DrawMissile(int x, int y, int sx, int sy, int a5, int a6, int del_flag);
 void __fastcall DrawClippedMissile(int x, int y, int sx, int sy, int a5, int a6, int a7);

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -11,7 +11,6 @@ extern HMODULE hDsound_dll;
 extern void *sgpMusicTrack;
 extern IDirectSoundBuffer *sglpDSB;
 
-void __cdecl sound_cpp_init();
 void __fastcall snd_update(BOOL bStopAll);
 void __fastcall snd_stop_snd(TSnd *pSnd);
 BOOL __fastcall snd_playing(TSnd *pSnd);

--- a/defs.h
+++ b/defs.h
@@ -211,17 +211,3 @@ char __OFSUB__(T x, U y)
 #endif
 
 #endif /* IDA_GARBAGE */
-
-#ifndef INFINITY
-#ifdef __cplusplus
-#include <limits>
-#define INFINITY std::numeric_limits<float>::infinity()
-#else
-typedef union {
-   unsigned int u;
-   float f;
-} inf;
-static inf float_init = {0x7F800000};
-#define INFINITY float_init.f
-#endif
-#endif


### PR DESCRIPTION
Removes some left over bits, as well as INFINITY (not in active use, and conflicts with moving to the C compiler). The current understanding is that INFINITY was pulled in by a mutex helper, so in the long run this should be the way to implement it in any case.