### PR TITLE
Cleanup gmenu_presskeys

### DIFF
--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -289,7 +289,7 @@ int __fastcall gmenu_get_lfont(TMenuItem *pItem)
 	return i - 2;
 }
 
-int __fastcall gmenu_presskeys(int a1)
+BOOL __fastcall gmenu_presskeys(int a1)
 {
 	if (!dword_634480)
 		return 0;
@@ -305,7 +305,7 @@ int __fastcall gmenu_presskeys(int a1)
 		gmenu_call_proc(0, 0);
 		break;
 	case VK_SPACE:
-		return 0;
+		return FALSE;
 	case VK_LEFT:
 		gmenu_left_right(0);
 		break;
@@ -319,7 +319,7 @@ int __fastcall gmenu_presskeys(int a1)
 		gmenu_up_down(1);
 		break;
 	}
-	return 1;
+	return TRUE;
 }
 
 void __fastcall gmenu_left_right(int a1)

--- a/Source/gmenu.h
+++ b/Source/gmenu.h
@@ -26,7 +26,7 @@ void __cdecl gmenu_draw();
 void __fastcall gmenu_draw_menu_item(TMenuItem *pItem, int a2);
 void __fastcall gmenu_clear_buffer(int x, int y, int width, int height);
 int __fastcall gmenu_get_lfont(TMenuItem *pItem);
-int __fastcall gmenu_presskeys(int a1);
+BOOL __fastcall gmenu_presskeys(int a1);
 void __fastcall gmenu_left_right(int a1);
 int __fastcall gmenu_on_mouse_move(LPARAM lParam);
 BOOLEAN __fastcall gmenu_valid_mouse_pos(int *plOffset);


### PR DESCRIPTION
gmenu_presskeys is now binary exact:
![image](https://user-images.githubusercontent.com/46401660/50729837-fe16d880-1140-11e9-95b2-a527f2735248.png)

The Devilution asm code on the right was built with VC++ 6.0 SP5/PP. 
