### PR TITLE
RFC: DRLG_L1Pass3 *work in progress*

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1579,31 +1579,31 @@ void __cdecl LoadLvlGFX()
 	switch (leveltype) {
 	case DTYPE_TOWN:
 		pDungeonCels = LoadFileInMem("Levels\\TownData\\Town.CEL", 0);
-		pMegaTiles = LoadFileInMem("Levels\\TownData\\Town.TIL", 0);
+		pMegaTiles = (WORD *)LoadFileInMem("Levels\\TownData\\Town.TIL", 0);
 		pLevelPieces = LoadFileInMem("Levels\\TownData\\Town.MIN", 0);
 		level_special_cel = LoadFileInMem("Levels\\TownData\\TownS.CEL", 0);
 		break;
 	case DTYPE_CATHEDRAL:
 		pDungeonCels = LoadFileInMem("Levels\\L1Data\\L1.CEL", 0);
-		pMegaTiles = LoadFileInMem("Levels\\L1Data\\L1.TIL", 0);
+		pMegaTiles = (WORD *)LoadFileInMem("Levels\\L1Data\\L1.TIL", 0);
 		pLevelPieces = LoadFileInMem("Levels\\L1Data\\L1.MIN", 0);
 		level_special_cel = LoadFileInMem("Levels\\L1Data\\L1S.CEL", 0);
 		break;
 	case DTYPE_CATACOMBS:
 		pDungeonCels = LoadFileInMem("Levels\\L2Data\\L2.CEL", 0);
-		pMegaTiles = LoadFileInMem("Levels\\L2Data\\L2.TIL", 0);
+		pMegaTiles = (WORD *)LoadFileInMem("Levels\\L2Data\\L2.TIL", 0);
 		pLevelPieces = LoadFileInMem("Levels\\L2Data\\L2.MIN", 0);
 		level_special_cel = LoadFileInMem("Levels\\L2Data\\L2S.CEL", 0);
 		break;
 	case DTYPE_CAVES:
 		pDungeonCels = LoadFileInMem("Levels\\L3Data\\L3.CEL", 0);
-		pMegaTiles = LoadFileInMem("Levels\\L3Data\\L3.TIL", 0);
+		pMegaTiles = (WORD *)LoadFileInMem("Levels\\L3Data\\L3.TIL", 0);
 		pLevelPieces = LoadFileInMem("Levels\\L3Data\\L3.MIN", 0);
 		level_special_cel = LoadFileInMem("Levels\\L1Data\\L1S.CEL", 0);
 		break;
 	case DTYPE_HELL:
 		pDungeonCels = LoadFileInMem("Levels\\L4Data\\L4.CEL", 0);
-		pMegaTiles = LoadFileInMem("Levels\\L4Data\\L4.TIL", 0);
+		pMegaTiles = (WORD *)LoadFileInMem("Levels\\L4Data\\L4.TIL", 0);
 		pLevelPieces = LoadFileInMem("Levels\\L4Data\\L4.MIN", 0);
 		level_special_cel = LoadFileInMem("Levels\\L2Data\\L2S.CEL", 0);
 		break;

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -232,7 +232,7 @@ void __cdecl DRLG_L1Pass3()
 	long v1, v2, v3, v4, lv;
 
 	// Initialize the entire dungeon piece ID map with dirt.
-	const DIRT = 22;
+	const int DIRT = 22;
 	lv = pMegaTiles[(DIRT-1)*4+0];
 	v1 = pMegaTiles[(DIRT-1)*4+0];
 	v2 = pMegaTiles[(DIRT-1)*4+1];

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -228,77 +228,43 @@ void __cdecl DRLG_L1Floor()
 
 void __cdecl DRLG_L1Pass3()
 {
-	int v0;             // eax
-	int *v1;            // edx
-	int *v2;            // eax
-	signed int v3;      // ecx
-	signed int v4;      // ebx
-	int *v5;            // ecx
-	unsigned char *v6;  // edx
-	unsigned short *v7; // esi
-	unsigned short v8;  // ax
-	int v9;             // eax
-	int v10;            // ST24_4
-	int v11;            // ST20_4
-	int v12;            // ST1C_4
-	signed int v13;     // [esp+Ch] [ebp-1Ch]
-	int *v14;           // [esp+10h] [ebp-18h]
-	int v15;            // [esp+14h] [ebp-14h]
-	int v16;            // [esp+18h] [ebp-10h]
-	int v17;            // [esp+1Ch] [ebp-Ch]
-	int v18;            // [esp+20h] [ebp-8h]
+	int i, j, xx, yy;
+	long v1, v2, v3, v4, lv;
 
-	v0 = *((unsigned short *)pMegaTiles + 84) + 1;
-	v18 = *((unsigned short *)pMegaTiles + 84) + 1;
-	_LOWORD(v0) = *((_WORD *)pMegaTiles + 85);
-	v17 = ++v0;
-	_LOWORD(v0) = *((_WORD *)pMegaTiles + 86);
-	v16 = ++v0;
-	_LOWORD(v0) = *((_WORD *)pMegaTiles + 87);
-	v15 = v0 + 1;
-	v1 = dPiece[1];
-	do {
-		v2 = v1;
-		v3 = 56;
-		do {
-			*(v2 - 112) = v18;
-			*v2 = v17;
-			*(v2 - 111) = v16;
-			v2[1] = v15;
-			v2 += 224;
-			--v3;
-		} while (v3);
-		v1 += 2;
-	} while ((signed int)v1 < (signed int)dPiece[2]);
-	v4 = 0;
-	v14 = &dPiece[17][16]; /* check */
-	do {
-		v5 = v14;
-		v6 = (unsigned char *)dungeon + v4;
-		v13 = 40;
-		do {
-			v7 = (unsigned short *)((char *)pMegaTiles + 8 * (*v6 - 1));
-			v8 = *v7;
-			++v7;
-			v9 = v8 + 1;
-			v10 = v9;
-			_LOWORD(v9) = *v7;
-			++v7;
-			v11 = ++v9;
-			_LOWORD(v9) = *v7;
-			v12 = ++v9;
-			_LOWORD(v9) = v7[1];
-			v6 += 40;
-			*(v5 - 112) = v10;
-			*v5 = v11;
-			*(v5 - 111) = v12;
-			v5[1] = v9 + 1;
-			v5 += 224;
-			--v13;
-		} while (v13);
-		v14 += 2;
-		++v4;
-	} while (v4 < 40);
+	// Initialize the entire dungeon piece ID map with dirt.
+	const DIRT = 22;
+	lv = pMegaTiles[(DIRT-1)*4+0];
+	v1 = pMegaTiles[(DIRT-1)*4+0];
+	v2 = pMegaTiles[(DIRT-1)*4+1];
+	v3 = pMegaTiles[(DIRT-1)*4+2];
+	v4 = pMegaTiles[(DIRT-1)*4+3];
+	for (j = 0; j < 112; j += 2) {
+		for (i = 0; i < 112; i += 2) {
+			dPiece[i][j] = v1 + 1;
+			dPiece[i+1][j] = v2 + 1;
+			dPiece[i][j+1] = v3 + 1;
+			dPiece[i+1][j+1] = v4 + 1;
+		}
+	}
+	// Initialize the visible tiles of the dungeon piece ID map based on the tile
+	// ID map. The visible tiles are located at (16, 16) <= coordinate < (96,
+	// 96).
+	j = 16;
+	for (yy = 0; yy < 40; yy++) {
+		i = 16;
+		for (xx = 0; xx < 40; xx++) {
+			v1 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 0] + 1;
+			v2 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 1] + 1;
+			v3 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 2] + 1;
+			v4 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 3] + 1;
+			dPiece[i][j] = v1 + 1;
+			dPiece[i+1][j] = v2 + 1;
+			dPiece[i][j+1] = v3 + 1;
+			dPiece[i+1][j+1] = v4 + 1;
+			i += 2;
+		}
+		j += 2;
+	}
 }
 
 void __cdecl DRLG_InitL1Vals()

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -253,10 +253,10 @@ void __cdecl DRLG_L1Pass3()
 	for (yy = 0; yy < 40; yy++) {
 		i = 16;
 		for (xx = 0; xx < 40; xx++) {
-			v1 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 0] + 1;
-			v2 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 1] + 1;
-			v3 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 2] + 1;
-			v4 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 3] + 1;
+			v1 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 0];
+			v2 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 1];
+			v3 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 2];
+			v4 = pMegaTiles[(dungeon[xx][yy]-1)*4 + 3];
 			dPiece[i][j] = v1 + 1;
 			dPiece[i+1][j] = v2 + 1;
 			dPiece[i][j+1] = v3 + 1;

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -22,7 +22,7 @@ int dPiece[MAXDUNX][MAXDUNY];
 char dTransVal[MAXDUNX][MAXDUNY];
 int setloadflag_2; // weak
 int tile_defs[2048];
-void *pMegaTiles;
+WORD *pMegaTiles;
 void *pLevelPieces;
 int gnDifficulty; // idb
 char block_lvid[2049];

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -22,7 +22,7 @@ extern int dPiece[MAXDUNX][MAXDUNY];
 extern char dTransVal[MAXDUNX][MAXDUNY];
 extern int setloadflag_2; // weak
 extern int tile_defs[2048];
-extern void *pMegaTiles;
+extern WORD *pMegaTiles;
 extern void *pLevelPieces;
 extern int gnDifficulty; // idb
 extern char block_lvid[2049];


### PR DESCRIPTION
**DO NOT MERGE**

*This is a request for comments.*

I think the functionality should be exact. However the assembly seems quite different. I can't seem to understand how the original used `sub esp, 0x1C` for local variables. The closest I've managed to get is `sub esp, 0x10`, as seen in this PR.

I've tried a few different approaches, but can't seem to "get it". Any suggestions are warmly welcome. Note, I based this off @nomdenom's beta version.https://github.com/nomdenom/devil-beta/blob/9e9dc5eff5d9b80b466b5a6e51e71a6b6a793c57/Source/drlg_l1.cpp#L114 and the Go version https://github.com/sanctuary/djavul/blob/cb7fec7a95a067a7a9003c26b93ef25f907d5822/d1/l1/l1.go#L115.

![2019-02-05-111406_1384x1414_scrot](https://user-images.githubusercontent.com/1414531/52249571-2dcf2100-2937-11e9-8a1d-563732c72feb.png)
