### PR TITLE
Correct signature of SFileGetFileArchive

### DIFF
--- a/3rdParty/Storm/Source/storm.cpp
+++ b/3rdParty/Storm/Source/storm.cpp
@@ -73,7 +73,7 @@ BOOL STORMAPI SFileDdaInitialize(HANDLE directsound) rBool;
 BOOL STORMAPI SFileDdaSetVolume(HANDLE directsound, signed int bigvolume, signed int volume) rBool;
 BOOL STORMAPI SFileDestroy() rBool;
 
-BOOL STORMAPI SFileGetFileArchive(HANDLE hFile, HANDLE archive) rBool;
+BOOL STORMAPI SFileGetFileArchive(HANDLE hFile, HANDLE *archive) rBool;
 LONG STORMAPI SFileGetFileSize(HANDLE hFile, LPDWORD lpFileSizeHigh) rInt;
 BOOL STORMAPI SFileOpenArchive(const char *szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE *phMpq) rBool;
 BOOL STORMAPI SFileOpenFile(const char *filename, HANDLE *phFile) rBool;

--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -479,7 +479,7 @@ BOOL STORMAPI SFileDdaInitialize(HANDLE directsound);
 BOOL STORMAPI SFileDdaSetVolume(HANDLE directsound, signed int bigvolume, signed int volume);
 BOOL STORMAPI SFileDestroy();
 
-BOOL STORMAPI SFileGetFileArchive(HANDLE hFile, HANDLE archive);
+BOOL STORMAPI SFileGetFileArchive(HANDLE hFile, HANDLE *archive);
 LONG STORMAPI SFileGetFileSize(HANDLE hFile, LPDWORD lpFileSizeHigh);
 BOOL STORMAPI SFileOpenArchive(const char *szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE *phMpq);
 


### PR DESCRIPTION
Looking at this functions usage (bin exact) it's signature appears incorrect (and is causing an issue for LLVM):
https://github.com/diasurgical/devilution/blob/master/Source/wave.cpp#L28