### PR TITLE
Cleaning Engine CEL functions

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1067,19 +1067,19 @@ void __cdecl DrawCtrlPan()
 	do {
 		v2 = *v1;
 		if (panbtn[v0])
-			CelDecodeOnly(v2 + 64, v1[1] + 178, pPanelButtons, v0 + 1, 71);
+			CelDecodeOnly(v2 + 64, v1[1] + 178, (BYTE *)pPanelButtons, v0 + 1, 71);
 		else
 			DrawPanelBox(v2, v1[1] - 336, 71, 20, v2 + 64, v1[1] + 160);
 		++v0;
 		v1 += 5;
 	} while (v0 < 6);
 	if (numpanbtns == 8) {
-		CelDecodeOnly(151, 634, pMultiBtns, panbtn[6] + 1, 33);
+		CelDecodeOnly(151, 634, (BYTE *)pMultiBtns, panbtn[6] + 1, 33);
 		if (FriendlyMode)
 			v3 = panbtn[7] + 3;
 		else
 			v3 = panbtn[7] + 5;
-		CelDecodeOnly(591, 634, pMultiBtns, v3, 33);
+		CelDecodeOnly(591, 634, (BYTE *)pMultiBtns, v3, 33);
 	}
 }
 // 484368: using guessed type int FriendlyMode;
@@ -1723,7 +1723,7 @@ void __cdecl DrawChr()
 	int v30;     // [esp+54h] [ebp-8h]
 	char a5[4];  // [esp+58h] [ebp-4h]
 
-	CelDecodeOnly(64, 511, pChrPanel, 1, 320);
+	CelDecodeOnly(64, 511, (BYTE *)pChrPanel, 1, 320);
 	ADD_PlrStringXY(20, 32, 151, plr[myplr]._pName, 0);
 	if (plr[myplr]._pClass == PC_WARRIOR) {
 		ADD_PlrStringXY(168, 32, 299, "Warrior", 0);
@@ -1886,13 +1886,13 @@ void __cdecl DrawChr()
 		ADD_PlrStringXY(95, 266, 126, a4, 2);
 		v22 = plr[myplr]._pClass;
 		if (plr[myplr]._pBaseStr < MaxStats[v22][ATTRIB_STR])
-			CelDecodeOnly(201, 319, pChrButtons, chrbtn[0] + 2, 41);
+			CelDecodeOnly(201, 319, (BYTE *)pChrButtons, chrbtn[0] + 2, 41);
 		if (plr[myplr]._pBaseMag < MaxStats[v22][ATTRIB_MAG])
-			CelDecodeOnly(201, 347, pChrButtons, chrbtn[1] + 4, 41);
+			CelDecodeOnly(201, 347, (BYTE *)pChrButtons, chrbtn[1] + 4, 41);
 		if (plr[myplr]._pBaseDex < MaxStats[v22][ATTRIB_DEX])
-			CelDecodeOnly(201, 376, pChrButtons, chrbtn[2] + 6, 41);
+			CelDecodeOnly(201, 376, (BYTE *)pChrButtons, chrbtn[2] + 6, 41);
 		if (plr[myplr]._pBaseVit < MaxStats[v22][ATTRIB_VIT])
-			CelDecodeOnly(201, 404, pChrButtons, chrbtn[3] + 8, 41);
+			CelDecodeOnly(201, 404, (BYTE *)pChrButtons, chrbtn[3] + 8, 41);
 	}
 	v23 = plr[myplr]._pMaxHP;
 	a5[0] = v23 > plr[myplr]._pMaxHPBase;
@@ -2028,7 +2028,7 @@ void __cdecl DrawLevelUpIcon()
 	if (!stextflag) {
 		v0 = (lvlbtndown != 0) + 2;
 		ADD_PlrStringXY(0, 303, 120, "Level Up", 0);
-		CelDecodeOnly(104, 495, pChrButtons, v0, 41);
+		CelDecodeOnly(104, 495, (BYTE *)pChrButtons, v0, 41);
 	}
 }
 // 4B851C: using guessed type int lvlbtndown;
@@ -2196,7 +2196,7 @@ int __fastcall DrawDurIcon4Item(ItemStruct *pItem, int x, int c)
 LABEL_18:
 	if (v5 > 2)
 		v7 += 8;
-	CelDecodeOnly(v4, 495, pDurIcons, v7, 32);
+	CelDecodeOnly(v4, 495, (BYTE *)pDurIcons, v7, 32);
 	return v4 - 40;
 }
 
@@ -2288,8 +2288,8 @@ void __cdecl DrawSpellBook()
 	int v11;       // [esp+18h] [ebp-10h]
 	int v12;       // [esp+1Ch] [ebp-Ch]
 
-	CelDecodeOnly(384, 511, pSpellBkCel, 1, 320);
-	CelDecodeOnly(76 * sbooktab + 391, 508, pSBkBtnCel, sbooktab + 1, 76);
+	CelDecodeOnly(384, 511, (BYTE *)pSpellBkCel, 1, 320);
+	CelDecodeOnly(76 * sbooktab + 391, 508, (BYTE *)pSBkBtnCel, sbooktab + 1, 76);
 	v9 = 1;
 	v8 = 214;
 	v0 = plr[myplr]._pISpells | plr[myplr]._pMemSpells | plr[myplr]._pAblSpells;
@@ -2431,7 +2431,7 @@ void __fastcall DrawGoldSplit(int amount)
 
 	screen_x = 0;
 	v1 = amount;
-	CelDecodeOnly(415, 338, pGBoxBuff, 1, 261);
+	CelDecodeOnly(415, 338, (BYTE *)pGBoxBuff, 1, 261);
 	sprintf(tempstr, "You have %u gold", initialDropGoldValue);
 	ADD_PlrStringXY(366, 87, 600, tempstr, 3);
 	v2 = get_pieces_str(initialDropGoldValue);
@@ -2450,7 +2450,7 @@ void __fastcall DrawGoldSplit(int amount)
 		}
 		screen_xa = screen_x + 452;
 	}
-	CelDecodeOnly(screen_xa, 300, pCelBuff, frame_4B8800, 12);
+	CelDecodeOnly(screen_xa, 300, (BYTE *)pCelBuff, frame_4B8800, 12);
 	frame_4B8800 = (frame_4B8800 & 7) + 1;
 }
 
@@ -2598,7 +2598,7 @@ void __cdecl DrawTalkPan()
 		} while (v4 < 39);
 		*v3 = 0;
 	LABEL_10:
-		CelDecDatOnly((char *)gpBuffer + a4, (char *)pCelBuff, frame, 12);
+		CelDecDatOnly((BYTE *)gpBuffer + a4, (BYTE *)pCelBuff, frame, 12);
 		v5 = 0;
 		a1 = plr[0]._pName;
 		v10 = 0;
@@ -2626,7 +2626,7 @@ void __cdecl DrawTalkPan()
 			if (talkbtndown[v5])
 				v7 = (v5 != 0) + 5;
 		}
-		CelDecodeOnly(236, 18 * v5 + 596, pTalkBtns, v7, 61);
+		CelDecodeOnly(236, 18 * v5 + 596, (BYTE *)pTalkBtns, v7, 61);
 		goto LABEL_18;
 	}
 }

--- a/Source/doom.cpp
+++ b/Source/doom.cpp
@@ -95,5 +95,5 @@ void __cdecl doom_draw()
 		}
 	}
 
-	CelDecodeOnly(64, 511, pDoomCel, 1, 640);
+	CelDecodeOnly(64, 511, (BYTE *)pDoomCel, 1, 640);
 }

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -340,7 +340,7 @@ void __fastcall CelDecDatLightOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSi
 
 	src = pRLEBytes;
 	dst = pDecodeTo;
-	tbl = &pLightTbl[light_table_index * 256];
+	tbl = (BYTE *)&pLightTbl[light_table_index * 256];
 	w = nWidth;
 
 	for(; src != &pRLEBytes[nDataSize]; dst -= 768 + w) {
@@ -504,7 +504,7 @@ void __fastcall CelDecDatLightTrans(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataS
 
 	src = pRLEBytes;
 	dst = pDecodeTo;
-	tbl = &pLightTbl[light_table_index * 256];
+	tbl = (BYTE *)&pLightTbl[light_table_index * 256];
 	w = nWidth;
 	shift = (BYTE)dst & 1;
 
@@ -1063,7 +1063,7 @@ void __fastcall Cel2DecDatLightOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataS
 
 	src = pRLEBytes;
 	dst = pDecodeTo;
-	tbl = &pLightTbl[light_table_index * 256];
+	tbl = (BYTE *)&pLightTbl[light_table_index * 256];
 	w = nWidth;
 
 	for(; src != &pRLEBytes[nDataSize]; dst -= 768 + w) {
@@ -1242,7 +1242,7 @@ void __fastcall Cel2DecDatLightTrans(BYTE *pDecodeTo, BYTE *pRLEBytes, int nData
 
 	src = pRLEBytes;
 	dst = pDecodeTo;
-	tbl = &pLightTbl[light_table_index * 256];
+	tbl = (BYTE *)&pLightTbl[light_table_index * 256];
 	w = nWidth;
 	shift = (BYTE)dst & 1;
 

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -14,337 +14,584 @@ int dword_52B99C; // BOOLEAN valid - if x/y are in bounds
 const int rand_increment = 1;           // unused
 const int rand_multiplier = 0x015A4E35; // unused
 
-void __fastcall CelDrawDatOnly(char *pDecodeTo, char *pRLEBytes, int dwRLESize, int dwRLEWdt)
+void __fastcall CelDrawDatOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth)
 {
-	char *v4;         // esi
-	char *v5;         // edi
-	int v6;           // edx
-	unsigned int v7;  // eax
-	unsigned int v8;  // ecx
-	char v9;          // cf
-	unsigned int v10; // ecx
-	char *v11;        // [esp+4h] [ebp-8h]
+	int w;
 
-	v11 = pRLEBytes;
-	if (pDecodeTo && pRLEBytes) {
-		v4 = pRLEBytes;
-		v5 = pDecodeTo;
-		do {
-			v6 = dwRLEWdt;
-			do {
-				while (1) {
-					v7 = (unsigned char)*v4++;
-					if ((v7 & 0x80u) == 0)
-						break;
-					_LOBYTE(v7) = -(char)v7;
-					v5 += v7;
-					v6 -= v7;
-					if (!v6)
-						goto LABEL_14;
-				}
-				v6 -= v7;
-				v8 = v7 >> 1;
-				if (v7 & 1) {
-					*v5++ = *v4++;
-					if (!v8)
-						continue;
-				}
-				v9 = v8 & 1;
-				v10 = v7 >> 2;
-				if (v9) {
-					*(_WORD *)v5 = *(_WORD *)v4;
-					v4 += 2;
-					v5 += 2;
-					if (!v10)
-						continue;
-				}
-				qmemcpy(v5, v4, 4 * v10);
-				v4 += 4 * v10;
-				v5 += 4 * v10;
-			} while (v6);
-		LABEL_14:
-			v5 += -dwRLEWdt - 768;
-		} while (&v11[dwRLESize] != v4);
+	/// ASSERT: assert(pDecodeTo != NULL);
+	if(!pDecodeTo)
+		return;
+	/// ASSERT: assert(pRLEBytes != NULL);
+	if(!pRLEBytes)
+		return;
+
+#if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
+	__asm {
+		mov		esi, pRLEBytes
+		mov		edi, pDecodeTo
+		mov		eax, 768
+		add		eax, nWidth
+		mov		w, eax
+		mov		ebx, nDataSize
+		add		ebx, esi
+	label1:
+		mov		edx, nWidth
+	label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		label6
+		sub		edx, eax
+		mov		ecx, eax
+		shr		ecx, 1
+		jnb		label3
+		movsb
+		jecxz	label5
+	label3:
+		shr		ecx, 1
+		jnb		label4
+		movsw
+		jecxz	label5
+	label4:
+		rep movsd
+	label5:
+		or		edx, edx
+		jz		label7
+		jmp		label2
+	label6:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		label2
+	label7:
+		sub		edi, w
+		cmp		ebx, esi
+		jnz		label1
 	}
-}
+#else
+	int i;
+	BYTE width;
+	BYTE *src, *dst;
 
-void __fastcall CelDecodeOnly(int screen_x, int screen_y, void *pCelBuff, int frame, int frame_width)
-{
-	if (gpBuffer) {
-		if (pCelBuff)
-			CelDrawDatOnly(
-			    (char *)gpBuffer + screen_y_times_768[screen_y] + screen_x,
-			    (char *)pCelBuff + *((_DWORD *)pCelBuff + frame),
-			    *((_DWORD *)pCelBuff + frame + 1) - *((_DWORD *)pCelBuff + frame),
-			    frame_width);
-	}
-}
+	src = pRLEBytes;
+	dst = pDecodeTo;
+	w = nWidth;
 
-void __fastcall CelDecDatOnly(char *pBuff, char *pCelBuff, int frame, int frame_width)
-{
-	if (pCelBuff) {
-		if (pBuff)
-			CelDrawDatOnly(
-			    pBuff,
-			    &pCelBuff[*(_DWORD *)&pCelBuff[4 * frame]],
-			    *(_DWORD *)&pCelBuff[4 * frame + 4] - *(_DWORD *)&pCelBuff[4 * frame],
-			    frame_width);
-	}
-}
-
-void __fastcall CelDrawHdrOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int always_0, int direction)
-{
-	int v7;   // edx
-	char *v8; // eax
-	int v9;   // edi
-	int v10;  // ecx
-	int v11;  // [esp+Ch] [ebp-8h]
-	int v12;  // [esp+10h] [ebp-4h]
-
-	v12 = screen_y;
-	v11 = screen_x;
-	if (gpBuffer) {
-		if (pCelBuff) {
-			v7 = *(_DWORD *)&pCelBuff[4 * frame];
-			v8 = &pCelBuff[v7];
-			v9 = *(unsigned short *)&pCelBuff[v7 + always_0];
-			if (*(_WORD *)&pCelBuff[v7 + always_0]) {
-				if (direction != 8 && *(_WORD *)&v8[direction])
-					v10 = *(unsigned short *)&v8[direction] - v9;
-				else
-					v10 = *(_DWORD *)&pCelBuff[4 * frame + 4] - v7 - v9;
-				CelDrawDatOnly(
-				    (char *)gpBuffer + screen_y_times_768[v12 - 16 * always_0] + v11,
-				    &v8[v9],
-				    v10,
-				    frame_width);
+	for(; src != &pRLEBytes[nDataSize]; dst -= 768 + w) {
+		for(i = w; i;) {
+			width = *src++;
+			if(!(width & 0x80)) {
+				i -= width;
+				if(width & 1) {
+					dst[0] = src[0];
+					src++;
+					dst++;
+				}
+				width >>= 1;
+				if(width & 1) {
+					dst[0] = src[0];
+					dst[1] = src[1];
+					src += 2;
+					dst += 2;
+				}
+				width >>= 1;
+				for(; width; width--) {
+					dst[0] = src[0];
+					dst[1] = src[1];
+					dst[2] = src[2];
+					dst[3] = src[3];
+					src += 4;
+					dst += 4;
+				}
+			} else {
+				width = -(char)width;
+				dst += width;
+				i -= width;
 			}
 		}
 	}
+#endif
 }
 
-void __fastcall CelDecodeHdrOnly(char *pBuff, char *pCelBuff, int frame, int frame_width, int always_0, int direction)
+void __fastcall CelDecodeOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
 {
-	int v6;   // esi
-	char *v7; // eax
-	int v8;   // ebx
-	int v9;   // edx
-	int v10;  // edx
+	BYTE *tmp;
+	DWORD *pFrameTable;
 
-	if (pCelBuff) {
-		if (pBuff) {
-			v6 = *(_DWORD *)&pCelBuff[4 * frame];
-			v7 = &pCelBuff[v6];
-			v8 = *(unsigned short *)&pCelBuff[v6 + always_0];
-			if (*(_WORD *)&pCelBuff[v6 + always_0]) {
-				v9 = *(_DWORD *)&pCelBuff[4 * frame + 4] - v6;
-				if (direction != 8 && *(_WORD *)&v7[direction])
-					v10 = *(unsigned short *)&v7[direction] - v8;
-				else
-					v10 = v9 - v8;
-				CelDrawDatOnly(pBuff, &v7[v8], v10, frame_width);
+	/// ASSERT: assert(gpBuffer);
+	if(!gpBuffer)
+		return;
+	/// ASSERT: assert(pCelBuff != NULL);
+	if(!pCelBuff)
+		return;
+
+	tmp = (BYTE *)gpBuffer;
+	pFrameTable = (DWORD *)pCelBuff;
+
+	CelDrawDatOnly(
+		&tmp[sx + screen_y_times_768[sy]],
+		&pCelBuff[pFrameTable[nCel]],
+		pFrameTable[nCel + 1] - pFrameTable[nCel],
+		nWidth);
+}
+
+void __fastcall CelDecDatOnly(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth)
+{
+	DWORD *pFrameTable;
+
+	/// ASSERT: assert(pCelBuff != NULL);
+	if(!pCelBuff)
+		return;
+	/// ASSERT: assert(pBuff != NULL);
+	if(!pBuff)
+		return;
+
+	pFrameTable = (DWORD *)pCelBuff;
+
+	CelDrawDatOnly(
+		pBuff,
+		&pCelBuff[pFrameTable[nCel]],
+		pFrameTable[nCel + 1] - pFrameTable[nCel],
+		nWidth);
+}
+
+void __fastcall CelDrawHdrOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
+{
+	int v1, v2, nDataSize;
+	BYTE *pRLEBytes, *tmp;
+	DWORD *pFrameTable;
+
+	/// ASSERT: assert(gpBuffer);
+	if(!gpBuffer)
+		return;
+	/// ASSERT: assert(pCelBuff != NULL);
+	if(!pCelBuff)
+		return;
+
+	pFrameTable = (DWORD *)pCelBuff;
+	pRLEBytes = &pCelBuff[pFrameTable[nCel]];
+	v1 = *(WORD *)&pRLEBytes[always_0];
+
+	if(!v1)
+		return;
+
+	nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
+
+	if(dir == 8)
+		v2 = 0;
+	else
+		v2 = *(WORD *)&pRLEBytes[dir];
+	if(v2)
+		nDataSize = v2 - v1;
+	else
+		nDataSize -= v1;
+
+	tmp = (BYTE *)gpBuffer;
+	CelDrawDatOnly(
+		&tmp[sx + screen_y_times_768[sy - 16 * always_0]],
+		&pRLEBytes[v1],
+		nDataSize,
+		nWidth);
+}
+
+void __fastcall CelDecodeHdrOnly(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
+{
+	int v1, v2, nDataSize;
+	BYTE *pRLEBytes;
+	DWORD *pFrameTable;
+
+	/// ASSERT: assert(pCelBuff != NULL);
+	if(!pCelBuff)
+		return;
+	/// ASSERT: assert(pBuff != NULL);
+	if(!pBuff)
+		return;
+
+	pFrameTable = (DWORD *)pCelBuff;
+	pRLEBytes = &pCelBuff[pFrameTable[nCel]];
+	v1 = *(WORD *)&pRLEBytes[always_0];
+
+	if(!v1)
+		return;
+
+	nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
+
+	if(dir == 8)
+		v2 = 0;
+	else
+		v2 = *(WORD *)&pRLEBytes[dir];
+	if(v2)
+		nDataSize = v2 - v1;
+	else
+		nDataSize -= v1;
+
+	CelDrawDatOnly(pBuff, &pRLEBytes[v1], nDataSize, nWidth);
+}
+
+void __fastcall CelDecDatLightOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth)
+{
+	int w;
+	BYTE *tbl;
+
+	/// ASSERT: assert(pDecodeTo != NULL);
+	if(!pDecodeTo)
+		return;
+	/// ASSERT: assert(pRLEBytes != NULL);
+	if(!pRLEBytes)
+		return;
+
+#if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
+	__asm {
+		mov		eax, light_table_index
+		shl		eax, 8
+		add		eax, pLightTbl
+		mov		tbl, eax
+		mov		esi, pRLEBytes
+		mov		edi, pDecodeTo
+		mov		eax, 768
+		add		eax, nWidth
+		mov		w, eax
+		mov		ebx, nDataSize
+		add		ebx, esi
+	label1:
+		mov		edx, nWidth
+	label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		label3
+		push	ebx
+		mov		ebx, tbl
+		sub		edx, eax
+		mov		ecx, eax
+		push	edx
+		call	CelDecDatLightEntry
+		pop		edx
+		pop		ebx
+		or		edx, edx
+		jnz		label2
+		jmp		label4
+	label3:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		label2
+	label4:
+		sub		edi, w
+		cmp		ebx, esi
+		jnz		label1
+		jmp		labexit
+	}
+
+	/* Assembly Macro */
+	__asm {
+	CelDecDatLightEntry:
+		shr		cl, 1
+		jnb		label5
+		mov		dl, [esi]
+		mov		dl, [ebx+edx]
+		mov		[edi], dl
+		add		esi, 1
+		add		edi, 1
+	label5:
+		shr		cl, 1
+		jnb		label6
+		mov		dl, [esi]
+		mov		ch, [ebx+edx]
+		mov		[edi], ch
+		mov		dl, [esi+1]
+		mov		ch, [ebx+edx]
+		mov		[edi+1], ch
+		add		esi, 2
+		add		edi, 2
+	label6:
+		test	cl, cl
+		jz		labret
+	label7:
+		mov		eax, [esi]
+		add		esi, 4
+		mov		dl, al
+		mov		ch, [ebx+edx]
+		mov		dl, ah
+		ror		eax, 10h
+		mov		[edi], ch
+		mov		ch, [ebx+edx]
+		mov		dl, al
+		mov		[edi+1], ch
+		mov		ch, [ebx+edx]
+		mov		dl, ah
+		mov		[edi+2], ch
+		mov		ch, [ebx+edx]
+		mov		[edi+3], ch
+		add		edi, 4
+		dec		cl
+		jnz		label7
+	labret:
+		retn
+	}
+
+	__asm {
+	labexit:
+	}
+#else
+	int i;
+	BYTE width;
+	BYTE *src, *dst;
+
+	src = pRLEBytes;
+	dst = pDecodeTo;
+	tbl = &pLightTbl[light_table_index * 256];
+	w = nWidth;
+
+	for(; src != &pRLEBytes[nDataSize]; dst -= 768 + w) {
+		for(i = w; i;) {
+			width = *src++;
+			if(!(width & 0x80)) {
+				i -= width;
+				if(width & 1) {
+					dst[0] = tbl[src[0]];
+					src++;
+					dst++;
+				}
+				width >>= 1;
+				if(width & 1) {
+					dst[0] = tbl[src[0]];
+					dst[1] = tbl[src[1]];
+					src += 2;
+					dst += 2;
+				}
+				width >>= 1;
+				for(; width; width--) {
+					dst[0] = tbl[src[0]];
+					dst[1] = tbl[src[1]];
+					dst[2] = tbl[src[2]];
+					dst[3] = tbl[src[3]];
+					src += 4;
+					dst += 4;
+				}
+			} else {
+				width = -(char)width;
+				dst += width;
+				i -= width;
 			}
 		}
 	}
-}
-
-void __fastcall CelDecDatLightOnly(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width)
-{
-	char *v4; // esi
-	char *v5; // edi
-	char *v6; // ebx
-	int v7;   // edx
-	int v8;   // eax
-	int v9;   // ST00_4
-	char *a3; // [esp+Ch] [ebp-10h]
-
-	if (pDecodeTo && pRLEBytes) {
-		a3 = &pLightTbl[256 * light_table_index];
-		v4 = pRLEBytes;
-		v5 = pDecodeTo;
-		v6 = &pRLEBytes[frame_content_size];
-		do {
-			v7 = frame_width;
-			do {
-				while (1) {
-					v8 = (unsigned char)*v4++;
-					if ((v8 & 0x80u) != 0) /* check sign */
-						break;
-					v9 = v7 - v8;
-					CelDecDatLightEntry(v8, a3, &v5, &v4);
-					v7 = v9;
-					if (!v9)
-						goto LABEL_9;
-				}
-				_LOBYTE(v8) = -(char)v8;
-				v5 += v8;
-				v7 -= v8;
-			} while (v7);
-		LABEL_9:
-			v5 += -frame_width - 768;
-		} while (v6 != v4);
-	}
+#endif
 }
 // 69BEF8: using guessed type int light_table_index;
 
-void __fastcall CelDecDatLightEntry(unsigned char n, char *LightIndex, char **pDecodeTo, char **pRLEBytes)
+void __fastcall CelDecDatLightTrans(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth)
 {
-	int i;
+	int w;
+	BOOL shift;
+	BYTE *tbl;
 
-	for (i = 0; i < n; i++) {
-		**pDecodeTo = LightIndex[**pRLEBytes];
-		(*pRLEBytes)++;
-		(*pDecodeTo)++;
+	/// ASSERT: assert(pDecodeTo != NULL);
+	if(!pDecodeTo)
+		return;
+	/// ASSERT: assert(pRLEBytes != NULL);
+	if(!pRLEBytes)
+		return;
+
+#if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
+	__asm {
+		mov		eax, light_table_index
+		shl		eax, 8
+		add		eax, pLightTbl
+		mov		tbl, eax
+		mov		esi, pRLEBytes
+		mov		edi, pDecodeTo
+		mov		eax, 768
+		add		eax, nWidth
+		mov		w, eax
+		mov		ebx, nDataSize
+		add		ebx, esi
+		mov		eax, edi
+		and		eax, 1
+		mov		shift, eax
+	label1:
+		mov		edx, nWidth
+	label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		label9
+		push	ebx
+		mov		ebx, tbl
+		sub		edx, eax
+		mov		ecx, eax
+		mov		eax, edi
+		and		eax, 1
+		cmp		eax, shift
+		jnz		label5
+		shr		ecx, 1
+		jnb		label3
+		inc		esi
+		inc		edi
+		jecxz	label8
+		jmp		label6
+	label3:
+		shr		ecx, 1
+		jnb		label4
+		inc		esi
+		inc		edi
+		lodsb
+		xlat
+		stosb
+		jecxz	label8
+	label4:
+		lodsd
+		inc		edi
+		ror		eax, 8
+		xlat
+		stosb
+		ror		eax, 10h
+		inc		edi
+		xlat
+		stosb
+		loop	label4
+		jmp		label8
+	label5:
+		shr		ecx, 1
+		jnb		label6
+		lodsb
+		xlat
+		stosb
+		jecxz	label8
+		jmp		label3
+	label6:
+		shr		ecx, 1
+		jnb		label7
+		lodsb
+		xlat
+		stosb
+		inc		esi
+		inc		edi
+		jecxz	label8
+	label7:
+		lodsd
+		xlat
+		stosb
+		inc		edi
+		ror		eax, 10h
+		xlat
+		stosb
+		inc		edi
+		loop	label7
+	label8:
+		pop		ebx
+		or		edx, edx
+		jz		label10
+		jmp		label2
+	label9:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		label2
+	label10:
+		sub		edi, w
+		mov		eax, shift
+		inc		eax
+		and		eax, 1
+		mov		shift, eax
+		cmp		ebx, esi
+		jnz		label1
 	}
-}
+#else
+	int i;
+	BYTE width;
+	BYTE *src, *dst;
 
-void __fastcall CelDecDatLightTrans(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width)
-{
-	char *v4;         // esi
-	int v5;           // edi
-	char *v6;         // ebx
-	int v7;           // edx
-	unsigned int v8;  // eax
-	unsigned int v10; // ecx
-	char v11;         // cf
-	unsigned int v12; // ecx
-	char *v13;        // esi
-	_BYTE *v14;       // edi
-	_BYTE *v18;       // edi
-	unsigned int v21; // ecx
-	_BYTE *v25;       // edi
-	char *v26;        // [esp-4h] [ebp-24h]
-	char *v27;        // [esp+Ch] [ebp-14h]
-	int v28;          // [esp+14h] [ebp-Ch]
-	int _EAX;
-	char *_EBX;
+	src = pRLEBytes;
+	dst = pDecodeTo;
+	tbl = &pLightTbl[light_table_index * 256];
+	w = nWidth;
+	shift = (BYTE)dst & 1;
 
-	if (pDecodeTo && pRLEBytes) {
-		v27 = &pLightTbl[256 * light_table_index];
-		v4 = pRLEBytes;
-		v5 = (int)pDecodeTo;
-		v6 = &pRLEBytes[frame_content_size];
-		v28 = (unsigned char)pDecodeTo & 1;
-		do {
-			v7 = frame_width;
-			do {
-				while (1) {
-					v8 = (unsigned char)*v4++;
-					if ((v8 & 0x80u) != 0)
-						break;
-					v26 = v6;
-					_EBX = v27;
-					v7 -= v8;
-					if ((v5 & 1) == v28) {
-						v10 = v8 >> 1;
-						if (!(v8 & 1))
-							goto LABEL_10;
-						++v4;
-						++v5;
-						if (v10) {
-						LABEL_17:
-							v11 = v10 & 1;
-							v21 = v10 >> 1;
-							if (!v11)
-								goto LABEL_26;
-							_EAX = *v4;
-							ASM_XLAT(_EAX, _EBX);
-							*(_BYTE *)v5 = _EAX;
-							v4 += 2;
-							v5 += 2;
-							if (v21) {
-							LABEL_26:
-								do {
-									_EAX = *(_DWORD *)v4;
-									v4 += 4;
-									ASM_XLAT(_EAX, _EBX);
-									*(_BYTE *)v5 = _EAX;
-									v25 = (_BYTE *)(v5 + 2);
-									_EAX = _rotr(_EAX, 16);
-									ASM_XLAT(_EAX, _EBX);
-									*v25 = _EAX;
-									v5 = (int)(v25 + 2);
-									--v21;
-								} while (v21);
-							}
-							goto LABEL_20;
-						}
+	for(; src != &pRLEBytes[nDataSize]; dst -= 768 + w, shift = (shift + 1) & 1) {
+		for(i = w; i;) {
+			width = *src++;
+			if(!(width & 0x80)) {
+				i -= width;
+				if(((BYTE)dst & 1) == shift) {
+					if(!(width & 1)) {
+						goto L_ODD;
 					} else {
-						v10 = v8 >> 1;
-						if (!(v8 & 1))
-							goto LABEL_17;
-						_EAX = *v4++;
-						ASM_XLAT(_EAX, _EBX);
-						*(_BYTE *)v5++ = _EAX;
-						if (v10) {
-						LABEL_10:
-							v11 = v10 & 1;
-							v12 = v10 >> 1;
-							if (!v11)
-								goto LABEL_27;
-							v13 = v4 + 1;
-							v14 = (_BYTE *)(v5 + 1);
-							_EAX = *v13;
-							v4 = v13 + 1;
-							ASM_XLAT(_EAX, _EBX);
-							*v14 = _EAX;
-							v5 = (int)(v14 + 1);
-							if (v12) {
-							LABEL_27:
-								do {
-									_EAX = *(_DWORD *)v4;
-									v4 += 4;
-									v18 = (_BYTE *)(v5 + 1);
-									_EAX = _rotr(_EAX, 8);
-									ASM_XLAT(_EAX, _EBX);
-									*v18 = _EAX;
-									_EAX = _rotr(_EAX, 16);
-									v18 += 2;
-									ASM_XLAT(_EAX, _EBX);
-									*v18 = _EAX;
-									v5 = (int)(v18 + 1);
-									--v12;
-								} while (v12);
-							}
-							goto LABEL_20;
+						src++;
+						dst++;
+L_EVEN:
+						width >>= 1;
+						if(width & 1) {
+							dst[0] = tbl[src[0]];
+							src += 2;
+							dst += 2;
+						}
+						width >>= 1;
+						for(; width; width--) {
+							dst[0] = tbl[src[0]];
+							dst[2] = tbl[src[2]];
+							src += 4;
+							dst += 4;
 						}
 					}
-				LABEL_20:
-					v6 = v26;
-					if (!v7)
-						goto LABEL_23;
+				} else {
+					if(!(width & 1)) {
+						goto L_EVEN;
+					} else {
+						dst[0] = tbl[src[0]];
+						src++;
+						dst++;
+L_ODD:
+						width >>= 1;
+						if(width & 1) {
+							dst[1] = tbl[src[1]];
+							src += 2;
+							dst += 2;
+						}
+						width >>= 1;
+						for(; width; width--) {
+							dst[1] = tbl[src[1]];
+							dst[3] = tbl[src[3]];
+							src += 4;
+							dst += 4;
+						}
+					}
 				}
-				_LOBYTE(v8) = -(char)v8;
-				v5 += v8;
-				v7 -= v8;
-			} while (v7);
-		LABEL_23:
-			v5 -= frame_width + 768;
-			v28 = ((_BYTE)v28 + 1) & 1;
-		} while (v6 != v4);
+			} else {
+				width = -(char)width;
+				dst += width;
+				i -= width;
+			}
+		}
 	}
+#endif
 }
 // 69BEF8: using guessed type int light_table_index;
 
-void __fastcall CelDecodeLightOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width)
+void __fastcall CelDecodeLightOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
 {
-	int v5;   // ebx
-	int v6;   // esi
-	char *v7; // edx
-	char *v8; // ecx
-	int v9;   // [esp-8h] [ebp-14h]
+	int nDataSize;
+	BYTE *pDecodeTo, *pRLEBytes, *tmp;
+	DWORD *pFrameTable;
 
-	v5 = screen_y;
-	if (gpBuffer && pCelBuff) {
-		v6 = *(_DWORD *)&pCelBuff[4 * frame];
-		v7 = &pCelBuff[v6];
-		v8 = (char *)gpBuffer + screen_y_times_768[v5] + screen_x;
-		v9 = *(_DWORD *)&pCelBuff[4 * frame + 4] - v6;
-		if (light_table_index)
-			CelDecDatLightOnly(v8, v7, v9, frame_width);
-		else
-			CelDrawDatOnly(v8, v7, v9, frame_width);
-	}
+	/// ASSERT: assert(gpBuffer);
+	if(!gpBuffer)
+		return;
+	/// ASSERT: assert(pCelBuff != NULL);
+	if(!pCelBuff)
+		return;
+
+	tmp = (BYTE *)gpBuffer;
+	pFrameTable = (DWORD *)pCelBuff;
+
+	nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
+	pRLEBytes = &pCelBuff[pFrameTable[nCel]];
+	pDecodeTo = &tmp[sx + screen_y_times_768[sy]];
+
+	if(light_table_index)
+		CelDecDatLightOnly(pDecodeTo, pRLEBytes, nDataSize, nWidth);
+	else
+		CelDrawDatOnly(pDecodeTo, pRLEBytes, nDataSize, nWidth);
 }
 // 69BEF8: using guessed type int light_table_index;
 
@@ -378,9 +625,9 @@ void __fastcall CelDecodeHdrLightOnly(int screen_x, int screen_y, char *pCelBuff
 				v13 = &v10[(_DWORD)cel_buf];
 				v14 = (char *)gpBuffer + screen_y_times_768[v7 - 16 * always_0] + v15;
 				if (light_table_index)
-					CelDecDatLightOnly(v14, v13, v12, frame_width);
+					CelDecDatLightOnly((BYTE *)v14, (BYTE *)v13, v12, frame_width);
 				else
-					CelDrawDatOnly(v14, v13, v12, frame_width);
+					CelDrawDatOnly((BYTE *)v14, (BYTE *)v13, v12, frame_width);
 			}
 		}
 	}
@@ -411,11 +658,11 @@ void __fastcall CelDecodeHdrLightTrans(char *pBuff, char *pCelBuff, int frame, i
 					v11 = v10 - v9;
 				v12 = &v8[v9];
 				if (cel_transparency_active) {
-					CelDecDatLightTrans(pBuff, v12, v11, frame_width);
+					CelDecDatLightTrans((BYTE *)pBuff, (BYTE *)v12, v11, frame_width);
 				} else if (light_table_index) {
-					CelDecDatLightOnly(pBuff, v12, v11, frame_width);
+					CelDecDatLightOnly((BYTE *)pBuff, (BYTE *)v12, v11, frame_width);
 				} else {
-					CelDrawDatOnly(pBuff, v12, v11, frame_width);
+					CelDrawDatOnly((BYTE *)pBuff, (BYTE *)v12, v11, frame_width);
 				}
 			}
 		}
@@ -508,305 +755,559 @@ void __fastcall CelDrawHdrLightRed(int screen_x, int screen_y, char *pCelBuff, i
 }
 // 525728: using guessed type int light4flag;
 
-void __fastcall Cel2DecDatOnly(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width)
+void __fastcall Cel2DecDatOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth)
 {
-	char *v4;         // esi
-	char *v5;         // edi
-	int v6;           // edx
-	unsigned int v7;  // eax
-	unsigned int v8;  // ecx
-	char v9;          // cf
-	unsigned int v10; // ecx
-	char *v11;        // [esp+4h] [ebp-8h]
+	int w;
 
-	v11 = pRLEBytes;
-	if (pDecodeTo && pRLEBytes && gpBuffer) {
-		v4 = pRLEBytes;
-		v5 = pDecodeTo;
-		do {
-			v6 = frame_width;
-			do {
-				while (1) {
-					v7 = (unsigned char)*v4++;
-					if ((v7 & 0x80u) == 0)
-						break;
-					_LOBYTE(v7) = -(char)v7;
-					v5 += v7;
-					v6 -= v7;
-					if (!v6)
-						goto LABEL_17;
-				}
-				v6 -= v7;
-				if (v5 < (char *)gpBufEnd) {
-					v8 = v7 >> 1;
-					if (!(v7 & 1) || (*v5 = *v4, ++v4, ++v5, v8)) {
-						v9 = v8 & 1;
-						v10 = v7 >> 2;
-						if (!v9 || (*(_WORD *)v5 = *(_WORD *)v4, v4 += 2, v5 += 2, v10)) {
-							qmemcpy(v5, v4, 4 * v10);
-							v4 += 4 * v10;
-							v5 += 4 * v10;
-						}
+	/// ASSERT: assert(pDecodeTo != NULL);
+	if(!pDecodeTo)
+		return;
+	/// ASSERT: assert(pRLEBytes != NULL);
+	if(!pRLEBytes)
+		return;
+	/// ASSERT: assert(gpBuffer);
+	if(!gpBuffer)
+		return;
+
+#if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
+	__asm {
+		mov		esi, pRLEBytes
+		mov		edi, pDecodeTo
+		mov		eax, 768
+		add		eax, nWidth
+		mov		w, eax
+		mov		ebx, nDataSize
+		add		ebx, esi
+	label1:
+		mov		edx, nWidth
+	label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		label7
+		sub		edx, eax
+		cmp		edi, gpBufEnd
+		jb		label3
+		add		esi, eax
+		add		edi, eax
+		jmp		label6
+	label3:
+		mov		ecx, eax
+		shr		ecx, 1
+		jnb		label4
+		movsb
+		jecxz	label6
+	label4:
+		shr		ecx, 1
+		jnb		label5
+		movsw
+		jecxz	label6
+	label5:
+		rep movsd
+	label6:
+		or		edx, edx
+		jz		label8
+		jmp		label2
+	label7:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		label2
+	label8:
+		sub		edi, w
+		cmp		ebx, esi
+		jnz		label1
+	}
+#else
+	int i;
+	BYTE width;
+	BYTE *src, *dst;
+
+	src = pRLEBytes;
+	dst = pDecodeTo;
+	w = nWidth;
+
+	for(; src != &pRLEBytes[nDataSize]; dst -= 768 + w) {
+		for(i = w; i;) {
+			width = *src++;
+			if(!(width & 0x80)) {
+				i -= width;
+				if(dst < gpBufEnd) {
+					if(width & 1) {
+						dst[0] = src[0];
+						src++;
+						dst++;
+					}
+					width >>= 1;
+					if(width & 1) {
+						dst[0] = src[0];
+						dst[1] = src[1];
+						src += 2;
+						dst += 2;
+					}
+					width >>= 1;
+					for(; width; width--) {
+						dst[0] = src[0];
+						dst[1] = src[1];
+						dst[2] = src[2];
+						dst[3] = src[3];
+						src += 4;
+						dst += 4;
 					}
 				} else {
-					v4 += v7;
-					v5 += v7;
+					src += width;
+					dst += width;
 				}
-			} while (v6);
-		LABEL_17:
-			v5 += -frame_width - 768;
-		} while (&v11[frame_content_size] != v4);
+			} else {
+				width = -(char)width;
+				dst += width;
+				i -= width;
+			}
+		}
 	}
+#endif
 }
 // 69CF0C: using guessed type int gpBufEnd;
 
-void __fastcall Cel2DrawHdrOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int a6, int direction)
+void __fastcall Cel2DrawHdrOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
-	int v7;   // edx
-	char *v8; // eax
-	int v9;   // edi
-	int v10;  // ecx
-	int v11;  // [esp+Ch] [ebp-8h]
-	int v12;  // [esp+10h] [ebp-4h]
+	int v1, v2, nDataSize;
+	BYTE *pRLEBytes, *tmp;
+	DWORD *pFrameTable;
 
-	v12 = screen_y;
-	v11 = screen_x;
-	if (gpBuffer) {
-		if (pCelBuff) {
-			v7 = *(_DWORD *)&pCelBuff[4 * frame];
-			v8 = &pCelBuff[v7];
-			v9 = *(unsigned short *)&pCelBuff[v7 + a6];
-			if (*(_WORD *)&pCelBuff[v7 + a6]) {
-				if (direction != 8 && *(_WORD *)&v8[direction])
-					v10 = *(unsigned short *)&v8[direction] - v9;
-				else
-					v10 = *(_DWORD *)&pCelBuff[4 * frame + 4] - v7 - v9;
-				Cel2DecDatOnly(
-				    (char *)gpBuffer + screen_y_times_768[v12 - 16 * a6] + v11,
-				    &v8[v9],
-				    v10,
-				    frame_width);
-			}
-		}
-	}
+	/// ASSERT: assert(gpBuffer);
+	if(!gpBuffer)
+		return;
+	/// ASSERT: assert(pCelBuff != NULL);
+	if(!pCelBuff)
+		return;
+
+	pFrameTable = (DWORD *)pCelBuff;
+	pRLEBytes = &pCelBuff[pFrameTable[nCel]];
+	v1 = *(WORD *)&pRLEBytes[always_0];
+
+	if(!v1)
+		return;
+
+	nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
+
+	if(dir == 8)
+		v2 = 0;
+	else
+		v2 = *(WORD *)&pRLEBytes[dir];
+	if(v2)
+		nDataSize = v2 - v1;
+	else
+		nDataSize -= v1;
+
+	tmp = (BYTE *)gpBuffer;
+	Cel2DecDatOnly(
+		&tmp[sx + screen_y_times_768[sy - 16 * always_0]],
+		&pRLEBytes[v1],
+		nDataSize,
+		nWidth);
 }
 
-void __fastcall Cel2DecodeHdrOnly(char *pBuff, char *pCelBuff, int frame, int frame_width, int a5, int direction)
+void __fastcall Cel2DecodeHdrOnly(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
-	int v6;   // edi
-	char *v7; // esi
-	int v8;   // ebx
-	int v9;   // eax
-	int v10;  // edx
-	int v11;  // eax
+	int v1, v2, nDataSize;
+	BYTE *pRLEBytes;
+	DWORD *pFrameTable;
 
-	if (pCelBuff) {
-		if (pBuff) {
-			v6 = *(_DWORD *)&pCelBuff[4 * frame];
-			v7 = &pCelBuff[v6];
-			v8 = *(unsigned short *)&pCelBuff[v6 + a5];
-			if (*(_WORD *)&pCelBuff[v6 + a5]) {
-				v9 = *(_DWORD *)&pCelBuff[4 * frame + 4] - v6;
-				v10 = *(unsigned short *)&v7[direction];
-				if (direction == 8)
-					v10 = 0;
-				if (v10)
-					v11 = v10 - v8;
-				else
-					v11 = v9 - v8;
-				Cel2DecDatOnly(pBuff, &v7[v8], v11, frame_width);
-			}
-		}
-	}
+	/// ASSERT: assert(pCelBuff != NULL);
+	if(!pCelBuff)
+		return;
+	/// ASSERT: assert(pBuff != NULL);
+	if(!pBuff)
+		return;
+
+	pFrameTable = (DWORD *)pCelBuff;
+	pRLEBytes = &pCelBuff[pFrameTable[nCel]];
+	v1 = *(WORD *)&pRLEBytes[always_0];
+
+	if(!v1)
+		return;
+
+	nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
+
+	v2 = *(WORD *)&pRLEBytes[dir];
+	if(dir == 8)
+		v2 = 0;
+	if(v2)
+		nDataSize = v2 - v1;
+	else
+		nDataSize -= v1;
+
+	Cel2DecDatOnly(pBuff, &pRLEBytes[v1], nDataSize, nWidth);
 }
 
-void __fastcall Cel2DecDatLightOnly(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width)
+void __fastcall Cel2DecDatLightOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth)
 {
-	char *v4; // esi
-	char *v5; // edi
-	char *v6; // ebx
-	int v7;   // edx
-	int v8;   // eax
-	int v9;   // ST00_4
-	char *a3; // [esp+Ch] [ebp-10h]
+	int w;
+	BYTE *tbl;
 
-	if (pDecodeTo && pRLEBytes && gpBuffer) {
-		a3 = &pLightTbl[256 * light_table_index];
-		v4 = pRLEBytes;
-		v5 = pDecodeTo;
-		v6 = &pRLEBytes[frame_content_size];
-		do {
-			v7 = frame_width;
-			do {
-				while (1) {
-					v8 = (unsigned __int8)*v4++;
-					if ((v8 & 0x80u) == 0) /* check sign */
-						break;
-					_LOBYTE(v8) = -(char)v8;
-					v5 += v8;
-					v7 -= v8;
-					if (!v7)
-						goto LABEL_13;
-				}
-				v7 -= v8;
-				if (v5 < (char *)gpBufEnd) {
-					v9 = v7;
-					Cel2DecDatLightEntry(v8, a3, &v5, &v4);
-					v7 = v9;
+	/// ASSERT: assert(pDecodeTo != NULL);
+	if(!pDecodeTo)
+		return;
+	/// ASSERT: assert(pRLEBytes != NULL);
+	if(!pRLEBytes)
+		return;
+	/// ASSERT: assert(gpBuffer);
+	if(!gpBuffer)
+		return;
+
+#if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
+	__asm {
+		mov		eax, light_table_index
+		shl		eax, 8
+		add		eax, pLightTbl
+		mov		tbl, eax
+		mov		esi, pRLEBytes
+		mov		edi, pDecodeTo
+		mov		eax, 768
+		add		eax, nWidth
+		mov		w, eax
+		mov		ebx, nDataSize
+		add		ebx, esi
+	label1:
+		mov		edx, nWidth
+	label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		label5
+		push	ebx
+		mov		ebx, tbl
+		sub		edx, eax
+		cmp		edi, gpBufEnd
+		jb		label3
+		add		esi, eax
+		add		edi, eax
+		jmp		label4
+	label3:
+		mov		ecx, eax
+		push	edx
+		call	Cel2DecDatLightEntry
+		pop		edx
+	label4:
+		pop		ebx
+		or		edx, edx
+		jz		label6
+		jmp		label2
+	label5:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		label2
+	label6:
+		sub		edi, w
+		cmp		ebx, esi
+		jnz		label1
+		jmp		labexit
+	}
+
+	/* Assembly Macro */
+	__asm {
+	Cel2DecDatLightEntry:
+		shr		cl, 1
+		jnb		label7
+		mov		dl, [esi]
+		mov		dl, [ebx+edx]
+		mov		[edi], dl
+		add		esi, 1
+		add		edi, 1
+	label7:
+		shr		cl, 1
+		jnb		label8
+		mov		dl, [esi]
+		mov		ch, [ebx+edx]
+		mov		[edi], ch
+		mov		dl, [esi+1]
+		mov		ch, [ebx+edx]
+		mov		[edi+1], ch
+		add		esi, 2
+		add		edi, 2
+	label8:
+		test	cl, cl
+		jz		labret
+	label9:
+		mov		eax, [esi]
+		add		esi, 4
+		mov		dl, al
+		mov		ch, [ebx+edx]
+		mov		dl, ah
+		ror		eax, 10h
+		mov		[edi], ch
+		mov		ch, [ebx+edx]
+		mov		dl, al
+		mov		[edi+1], ch
+		mov		ch, [ebx+edx]
+		mov		dl, ah
+		mov		[edi+2], ch
+		mov		ch, [ebx+edx]
+		mov		[edi+3], ch
+		add		edi, 4
+		dec		cl
+		jnz		label9
+	labret:
+		retn
+	}
+
+	__asm {
+	labexit:
+	}
+#else
+	int i;
+	BYTE width;
+	BYTE *src, *dst;
+
+	src = pRLEBytes;
+	dst = pDecodeTo;
+	tbl = &pLightTbl[light_table_index * 256];
+	w = nWidth;
+
+	for(; src != &pRLEBytes[nDataSize]; dst -= 768 + w) {
+		for(i = w; i;) {
+			width = *src++;
+			if(!(width & 0x80)) {
+				i -= width;
+				if(dst < gpBufEnd) {
+					if(width & 1) {
+						dst[0] = tbl[src[0]];
+						src++;
+						dst++;
+					}
+					width >>= 1;
+					if(width & 1) {
+						dst[0] = tbl[src[0]];
+						dst[1] = tbl[src[1]];
+						src += 2;
+						dst += 2;
+					}
+					width >>= 1;
+					for(; width; width--) {
+						dst[0] = tbl[src[0]];
+						dst[1] = tbl[src[1]];
+						dst[2] = tbl[src[2]];
+						dst[3] = tbl[src[3]];
+						src += 4;
+						dst += 4;
+					}
 				} else {
-					v4 += v8;
-					v5 += v8;
+					src += width;
+					dst += width;
 				}
-			} while (v7);
-		LABEL_13:
-			v5 += -frame_width - 768;
-		} while (v6 != v4);
+			} else {
+				width = -(char)width;
+				dst += width;
+				i -= width;
+			}
+		}
 	}
+#endif
 }
 // 69BEF8: using guessed type int light_table_index;
 // 69CF0C: using guessed type int gpBufEnd;
 
-void __fastcall Cel2DecDatLightEntry(unsigned char n, char *LightIndex, char **pDecodeTo, char **pRLEBytes)
+void __fastcall Cel2DecDatLightTrans(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth)
 {
-	int i;
+	int w;
+	BOOL shift;
+	BYTE *tbl;
 
-	for (i = 0; i < n; i++) {
-		**pDecodeTo = LightIndex[**pRLEBytes];
-		(*pRLEBytes)++;
-		(*pDecodeTo)++;
+	/// ASSERT: assert(pDecodeTo != NULL);
+	if(!pDecodeTo)
+		return;
+	/// ASSERT: assert(pRLEBytes != NULL);
+	if(!pRLEBytes)
+		return;
+	/// ASSERT: assert(gpBuffer);
+	if(!gpBuffer)
+		return;
+
+#if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
+	__asm {
+		mov		eax, light_table_index
+		shl		eax, 8
+		add		eax, pLightTbl
+		mov		tbl, eax
+		mov		esi, pRLEBytes
+		mov		edi, pDecodeTo
+		mov		eax, 768
+		add		eax, nWidth
+		mov		w, eax
+		mov		ebx, nDataSize
+		add		ebx, esi
+		mov		eax, edi
+		and		eax, 1
+		mov		shift, eax
+	label1:
+		mov		edx, nWidth
+	label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		label10
+		push	ebx
+		mov		ebx, tbl
+		sub		edx, eax
+		cmp		edi, gpBufEnd
+		jb		label3
+		add		esi, eax
+		add		edi, eax
+		jmp		label9
+	label3:
+		mov		ecx, eax
+		mov		eax, edi
+		and		eax, 1
+		cmp		eax, shift
+		jnz		label6
+		shr		ecx, 1
+		jnb		label4
+		inc		esi
+		inc		edi
+		jecxz	label9
+		jmp		label7
+	label4:
+		shr		ecx, 1
+		jnb		label5
+		inc		esi
+		inc		edi
+		lodsb
+		xlat
+		stosb
+		jecxz	label9
+	label5:
+		lodsd
+		inc		edi
+		ror		eax, 8
+		xlat
+		stosb
+		ror		eax, 10h
+		inc		edi
+		xlat
+		stosb
+		loop	label5
+		jmp		label9
+	label6:
+		shr		ecx, 1
+		jnb		label7
+		lodsb
+		xlat
+		stosb
+		jecxz	label9
+		jmp		label4
+	label7:
+		shr		ecx, 1
+		jnb		label8
+		lodsb
+		xlat
+		stosb
+		inc		esi
+		inc		edi
+		jecxz	label9
+	label8:
+		lodsd
+		xlat
+		stosb
+		inc		edi
+		ror		eax, 10h
+		xlat
+		stosb
+		inc		edi
+		loop	label8
+	label9:
+		pop		ebx
+		or		edx, edx
+		jz		label11
+		jmp		label2
+	label10:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		label2
+	label11:
+		sub		edi, w
+		mov		eax, shift
+		inc		eax
+		and		eax, 1
+		mov		shift, eax
+		cmp		ebx, esi
+		jnz		label1
 	}
-}
+#else
+	int i;
+	BYTE width;
+	BYTE *src, *dst;
 
-void __fastcall Cel2DecDatLightTrans(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width)
-{
-	char *v4;         // esi
-	unsigned int v5;  // edi
-	char *v6;         // ebx
-	int v7;           // edx
-	unsigned int v8;  // eax
-	unsigned int v10; // ecx
-	char v11;         // cf
-	unsigned int v12; // ecx
-	char *v13;        // esi
-	_BYTE *v14;       // edi
-	_BYTE *v18;       // edi
-	unsigned int v21; // ecx
-	_BYTE *v25;       // edi
-	char *v26;        // [esp-4h] [ebp-24h]
-	char *v27;        // [esp+Ch] [ebp-14h]
-	int v28;          // [esp+14h] [ebp-Ch]
-	int _EAX;
-	char *_EBX;
+	src = pRLEBytes;
+	dst = pDecodeTo;
+	tbl = &pLightTbl[light_table_index * 256];
+	w = nWidth;
+	shift = (BYTE)dst & 1;
 
-	if (pDecodeTo && pRLEBytes && gpBuffer) {
-		v27 = &pLightTbl[256 * light_table_index];
-		v4 = pRLEBytes;
-		v5 = (unsigned int)pDecodeTo;
-		v6 = &pRLEBytes[frame_content_size];
-		v28 = (unsigned char)pDecodeTo & 1;
-		do {
-			v7 = frame_width;
-			do {
-				while (1) {
-					v8 = (unsigned char)*v4++;
-					if ((v8 & 0x80u) != 0)
-						break;
-					v26 = v6;
-					_EBX = v27;
-					v7 -= v8;
-					if (v5 < (unsigned int)gpBufEnd) {
-						if ((v5 & 1) == v28) {
-							v10 = v8 >> 1;
-							if (!(v8 & 1))
-								goto LABEL_13;
-							++v4;
-							++v5;
-							if (v10) {
-							LABEL_20:
-								v11 = v10 & 1;
-								v21 = v10 >> 1;
-								if (!v11)
-									goto LABEL_29;
-								_EAX = *v4;
-								ASM_XLAT(_EAX, _EBX);
-								*(_BYTE *)v5 = _EAX;
-								v4 += 2;
-								v5 += 2;
-								if (v21) {
-								LABEL_29:
-									do {
-										_EAX = *(_DWORD *)v4;
-										v4 += 4;
-										ASM_XLAT(_EAX, _EBX);
-										*(_BYTE *)v5 = _EAX;
-										v25 = (_BYTE *)(v5 + 2);
-										_EAX = _rotr(_EAX, 16);
-										ASM_XLAT(_EAX, _EBX);
-										*v25 = _EAX;
-										v5 = (unsigned int)(v25 + 2);
-										--v21;
-									} while (v21);
-								}
-								goto LABEL_23;
-							}
+	for(; src != &pRLEBytes[nDataSize]; dst -= 768 + w, shift = (shift + 1) & 1) {
+		for(i = w; i;) {
+			width = *src++;
+			if(!(width & 0x80)) {
+				i -= width;
+				if(dst < gpBufEnd) {
+					if(((BYTE)dst & 1) == shift) {
+						if(!(width & 1)) {
+							goto L_ODD;
 						} else {
-							v10 = v8 >> 1;
-							if (!(v8 & 1))
-								goto LABEL_20;
-							_EAX = *v4++;
-							ASM_XLAT(_EAX, _EBX);
-							*(_BYTE *)v5++ = _EAX;
-							if (v10) {
-							LABEL_13:
-								v11 = v10 & 1;
-								v12 = v10 >> 1;
-								if (!v11)
-									goto LABEL_30;
-								v13 = v4 + 1;
-								v14 = (_BYTE *)(v5 + 1);
-								_EAX = *v13;
-								v4 = v13 + 1;
-								ASM_XLAT(_EAX, _EBX);
-								*v14 = _EAX;
-								v5 = (unsigned int)(v14 + 1);
-								if (v12) {
-								LABEL_30:
-									do {
-										_EAX = *(_DWORD *)v4;
-										v4 += 4;
-										v18 = (_BYTE *)(v5 + 1);
-										_EAX = _rotr(_EAX, 8);
-										ASM_XLAT(_EAX, _EBX);
-										*v18 = _EAX;
-										_EAX = _rotr(_EAX, 16);
-										v18 += 2;
-										ASM_XLAT(_EAX, _EBX);
-										*v18 = _EAX;
-										v5 = (unsigned int)(v18 + 1);
-										--v12;
-									} while (v12);
-								}
-								goto LABEL_23;
+							src++;
+							dst++;
+L_EVEN:
+							width >>= 1;
+							if(width & 1) {
+								dst[0] = tbl[src[0]];
+								src += 2;
+								dst += 2;
+							}
+							width >>= 1;
+							for(; width; width--) {
+								dst[0] = tbl[src[0]];
+								dst[2] = tbl[src[2]];
+								src += 4;
+								dst += 4;
 							}
 						}
 					} else {
-						v4 += v8;
-						v5 += v8;
+						if(!(width & 1)) {
+							goto L_EVEN;
+						} else {
+							dst[0] = tbl[src[0]];
+							src++;
+							dst++;
+L_ODD:
+							width >>= 1;
+							if(width & 1) {
+								dst[1] = tbl[src[1]];
+								src += 2;
+								dst += 2;
+							}
+							width >>= 1;
+							for(; width; width--) {
+								dst[1] = tbl[src[1]];
+								dst[3] = tbl[src[3]];
+								src += 4;
+								dst += 4;
+							}
+						}
 					}
-				LABEL_23:
-					v6 = v26;
-					if (!v7)
-						goto LABEL_26;
+				} else {
+					src += width;
+					dst += width;
 				}
-				_LOBYTE(v8) = -(char)v8;
-				v5 += v8;
-				v7 -= v8;
-			} while (v7);
-		LABEL_26:
-			v5 -= frame_width + 768;
-			v28 = ((_BYTE)v28 + 1) & 1;
-		} while (v6 != v4);
+			} else {
+				width = -(char)width;
+				dst += width;
+				i -= width;
+			}
+		}
 	}
+#endif
 }
 // 69BEF8: using guessed type int light_table_index;
 // 69CF0C: using guessed type int gpBufEnd;
@@ -845,9 +1346,9 @@ void __fastcall Cel2DecodeHdrLight(int screen_x, int screen_y, char *pCelBuff, i
 				v15 = &v10[(_DWORD)cel_buf];
 				v16 = (char *)gpBuffer + screen_y_times_768[v7 - 16 * a6] + screen_x;
 				if (light_table_index)
-					Cel2DecDatLightOnly(v16, v15, v14, frame_width);
+					Cel2DecDatLightOnly((BYTE *)v16, (BYTE *)v15, v14, frame_width);
 				else
-					Cel2DecDatOnly(v16, v15, v14, frame_width);
+					Cel2DecDatOnly((BYTE *)v16, (BYTE *)v15, v14, frame_width);
 			}
 		}
 	}
@@ -881,11 +1382,11 @@ void __fastcall Cel2DecodeLightTrans(char *dst_buf, char *pCelBuff, int frame, i
 				v12 = v10 - v9;
 			v13 = &v8[v9];
 			if (cel_transparency_active) {
-				Cel2DecDatLightTrans(dst_buf, v13, v12, frame_width);
+				Cel2DecDatLightTrans((BYTE *)dst_buf, (BYTE *)v13, v12, frame_width);
 			} else if (light_table_index) {
-				Cel2DecDatLightOnly(dst_buf, v13, v12, frame_width);
+				Cel2DecDatLightOnly((BYTE *)dst_buf, (BYTE *)v13, v12, frame_width);
 			} else {
-				Cel2DecDatOnly(dst_buf, v13, v12, frame_width);
+				Cel2DecDatOnly((BYTE *)dst_buf, (BYTE *)v13, v12, frame_width);
 			}
 		}
 	}

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -11,24 +11,22 @@ extern int orgseed;      // weak
 extern int SeedCount;    // weak
 extern int dword_52B99C; // bool valid - if x/y are in bounds
 
-void __fastcall CelDrawDatOnly(char *pDecodeTo, char *pRLEBytes, int dwRLESize, int dwRLEWdt);
-void __fastcall CelDecodeOnly(int screen_x, int screen_y, void *pCelBuff, int frame, int frame_width);
-void __fastcall CelDecDatOnly(char *pBuff, char *pCelBuff, int frame, int frame_width);
-void __fastcall CelDrawHdrOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int always_0, int direction);
-void __fastcall CelDecodeHdrOnly(char *pBuff, char *pCelBuff, int frame, int frame_width, int always_0, int direction);
-void __fastcall CelDecDatLightOnly(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width);
-void __fastcall CelDecDatLightEntry(unsigned char n, char *LightIndex, char **pDecodeTo, char **pRLEBytes); /* __usercall a1@<cl> a2@<ebx> a3@<edi> a4@<esi> */
-void __fastcall CelDecDatLightTrans(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width);
-void __fastcall CelDecodeLightOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width);
+void __fastcall CelDrawDatOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
+void __fastcall CelDecodeOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
+void __fastcall CelDecDatOnly(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth);
+void __fastcall CelDrawHdrOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir);
+void __fastcall CelDecodeHdrOnly(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir);
+void __fastcall CelDecDatLightOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
+void __fastcall CelDecDatLightTrans(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
+void __fastcall CelDecodeLightOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
 void __fastcall CelDecodeHdrLightOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int always_0, int direction);
 void __fastcall CelDecodeHdrLightTrans(char *pBuff, char *pCelBuff, int frame, int frame_width, int always_0, int direction);
 void __fastcall CelDrawHdrLightRed(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int always_0, int direction, char always_1);
-void __fastcall Cel2DecDatOnly(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width);
-void __fastcall Cel2DrawHdrOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int a6, int direction);
-void __fastcall Cel2DecodeHdrOnly(char *pBuff, char *pCelBuff, int frame, int frame_width, int a5, int direction);
-void __fastcall Cel2DecDatLightOnly(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width);
-void __fastcall Cel2DecDatLightEntry(unsigned char n, char *LightIndex, char **pDecodeTo, char **pRLEBytes); /* __usercall a1@<cl> a2@<ebx> a3@<edi> a4@<esi> */
-void __fastcall Cel2DecDatLightTrans(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width);
+void __fastcall Cel2DecDatOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
+void __fastcall Cel2DrawHdrOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir);
+void __fastcall Cel2DecodeHdrOnly(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir);
+void __fastcall Cel2DecDatLightOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
+void __fastcall Cel2DecDatLightTrans(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
 void __fastcall Cel2DecodeHdrLight(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int a6, int direction);
 void __fastcall Cel2DecodeLightTrans(char *dst_buf, char *pCelBuff, int frame, int frame_width, int a5, int direction);
 void __fastcall Cel2DrawHdrLightRed(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int always_0, int direction, char always_1);

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -98,23 +98,23 @@ void __cdecl DrawDiabloMsg()
 	signed int v17;      // [esp+Ch] [ebp-8h]
 	signed int screen_x; // [esp+10h] [ebp-4h]
 
-	CelDecodeOnly(165, 318, pSTextSlidCels, 1, 12);
-	CelDecodeOnly(591, 318, pSTextSlidCels, 4, 12);
-	CelDecodeOnly(165, 366, pSTextSlidCels, 2, 12);
-	CelDecodeOnly(591, 366, pSTextSlidCels, 3, 12);
+	CelDecodeOnly(165, 318, (BYTE *)pSTextSlidCels, 1, 12);
+	CelDecodeOnly(591, 318, (BYTE *)pSTextSlidCels, 4, 12);
+	CelDecodeOnly(165, 366, (BYTE *)pSTextSlidCels, 2, 12);
+	CelDecodeOnly(591, 366, (BYTE *)pSTextSlidCels, 3, 12);
 	screen_x = 173;
 	v16 = 35;
 	do {
-		CelDecodeOnly(screen_x, 318, pSTextSlidCels, 5, 12);
-		CelDecodeOnly(screen_x, 366, pSTextSlidCels, 7, 12);
+		CelDecodeOnly(screen_x, 318, (BYTE *)pSTextSlidCels, 5, 12);
+		CelDecodeOnly(screen_x, 366, (BYTE *)pSTextSlidCels, 7, 12);
 		screen_x += 12;
 		--v16;
 	} while (v16);
 	v0 = 330;
 	v1 = 3;
 	do {
-		CelDecodeOnly(165, v0, pSTextSlidCels, 6, 12);
-		CelDecodeOnly(591, v0, pSTextSlidCels, 8, 12);
+		CelDecodeOnly(165, v0, (BYTE *)pSTextSlidCels, 6, 12);
+		CelDecodeOnly(591, v0, (BYTE *)pSTextSlidCels, 8, 12);
 		v0 += 12;
 		--v1;
 	} while (v1);

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -65,7 +65,7 @@ void __fastcall gmenu_print_text(int x, int y, char *pszStr)
 		++v3;
 		v7 = lfontframe[fontidx[i]];
 		if (v7)
-			CelDecodeLightOnly(v5, v4, (char *)BigTGold_cel, v7, 46);
+			CelDecodeLightOnly(v5, v4, (BYTE *)BigTGold_cel, v7, 46);
 		v5 += lfontkern[v7] + 2;
 	}
 }
@@ -194,7 +194,7 @@ void __cdecl gmenu_draw()
 	if (dword_634480) {
 		if (dword_63447C)
 			dword_63447C();
-		CelDecodeOnly(236, 262, sgpLogo, 1, 296);
+		CelDecodeOnly(236, 262, (BYTE *)sgpLogo, 1, 296);
 		v0 = 320;
 		for (i = dword_634480; i->fnMenu; v0 += 45) {
 			gmenu_draw_menu_item(i, v0);
@@ -234,7 +234,7 @@ void __fastcall gmenu_draw_menu_item(TMenuItem *pItem, int a2)
 	v14 = v4;
 	if (v3->dwFlags & 0x40000000) {
 		v6 = (v4 >> 1) + 80;
-		CelDecodeOnly(v6, v2 - 10, optbar_cel, 1, 287);
+		CelDecodeOnly(v6, v2 - 10, (BYTE *)optbar_cel, 1, 287);
 		v7 = (v3->dwFlags >> 12) & 0xFFF;
 		if (v7 < 2)
 			v7 = 2;
@@ -242,7 +242,7 @@ void __fastcall gmenu_draw_menu_item(TMenuItem *pItem, int a2)
 		v9 = (v5 >> 1) + 82;
 		v10 = v8;
 		gmenu_clear_buffer(v9, v2 - 12, v8 + 13, 28);
-		CelDecodeOnly(v6 + v10 + 2, v2 - 12, option_cel, 1, 27);
+		CelDecodeOnly(v6 + v10 + 2, v2 - 12, (BYTE *)option_cel, 1, 27);
 		v5 = v14;
 	}
 	v11 = 384 - (v5 >> 1);
@@ -252,8 +252,8 @@ void __fastcall gmenu_draw_menu_item(TMenuItem *pItem, int a2)
 	gmenu_print_text(384 - (v5 >> 1), v2, v3->pszStr);
 	if (v3 == sgpCurrItem) {
 		v13 = v2 + 1;
-		CelDecodeOnly(v11 - 54, v13, PentSpin_cel, (unsigned char)byte_634478, 48);
-		CelDecodeOnly(v11 + v5 + 4, v13, PentSpin_cel, (unsigned char)byte_634478, 48);
+		CelDecodeOnly(v11 - 54, v13, (BYTE *)PentSpin_cel, (unsigned char)byte_634478, 48);
+		CelDecodeOnly(v11 + v5 + 4, v13, (BYTE *)PentSpin_cel, (unsigned char)byte_634478, 48);
 	}
 }
 // 634478: using guessed type char byte_634478;

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -37,7 +37,7 @@ void __cdecl DrawCutscene()
 	unsigned int v0; // esi
 
 	j_lock_buf_priv(1);
-	CelDecodeOnly(64, 639, sgpBackCel, 1, 640);
+	CelDecodeOnly(64, 639, (BYTE *)sgpBackCel, 1, 640);
 	v0 = 0;
 	if (sgdwProgress) {
 		do

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -150,7 +150,7 @@ void __cdecl DrawInv()
 	BOOL invtest[40];
 	int frame, frame_width, colour, screen_x, screen_y, i, j, ii;
 
-	CelDecodeOnly(384, 511, pInvCels, 1, 320);
+	CelDecodeOnly(384, 511, (BYTE *)pInvCels, 1, 320);
 
 	if (plr[myplr].InvBody[INVLOC_HEAD]._itype != ITYPE_NONE) {
 		InvDrawSlotBack(517, 219, 2 * INV_SLOT_SIZE_PX, 2 * INV_SLOT_SIZE_PX);
@@ -170,7 +170,7 @@ void __cdecl DrawInv()
 		}
 
 		if (plr[myplr].InvBody[INVLOC_HEAD]._iStatFlag) {
-			CelDrawHdrOnly(517, 219, (char *)pCursCels, frame, frame_width, 0, 8);
+			CelDrawHdrOnly(517, 219, (BYTE *)pCursCels, frame, frame_width, 0, 8);
 		} else {
 			CelDrawHdrLightRed(517, 219, (char *)pCursCels, frame, frame_width, 0, 8, 1);
 		}
@@ -194,7 +194,7 @@ void __cdecl DrawInv()
 		}
 
 		if (plr[myplr].InvBody[INVLOC_RING_LEFT]._iStatFlag) {
-			CelDrawHdrOnly(432, 365, (char *)pCursCels, frame, frame_width, 0, 8);
+			CelDrawHdrOnly(432, 365, (BYTE *)pCursCels, frame, frame_width, 0, 8);
 		} else {
 			CelDrawHdrLightRed(432, 365, (char *)pCursCels, frame, frame_width, 0, 8, 1);
 		}
@@ -218,7 +218,7 @@ void __cdecl DrawInv()
 		}
 
 		if (plr[myplr].InvBody[INVLOC_RING_RIGHT]._iStatFlag) {
-			CelDrawHdrOnly(633, 365, (char *)pCursCels, frame, frame_width, 0, 8);
+			CelDrawHdrOnly(633, 365, (BYTE *)pCursCels, frame, frame_width, 0, 8);
 		} else {
 			CelDrawHdrLightRed(633, 365, (char *)pCursCels, frame, frame_width, 0, 8, 1);
 		}
@@ -242,7 +242,7 @@ void __cdecl DrawInv()
 		}
 
 		if (plr[myplr].InvBody[INVLOC_AMULET]._iStatFlag) {
-			CelDrawHdrOnly(589, 220, (char *)pCursCels, frame, frame_width, 0, 8);
+			CelDrawHdrOnly(589, 220, (BYTE *)pCursCels, frame, frame_width, 0, 8);
 		} else {
 			CelDrawHdrLightRed(589, 220, (char *)pCursCels, frame, frame_width, 0, 8, 1);
 		}
@@ -269,7 +269,7 @@ void __cdecl DrawInv()
 		}
 
 		if (plr[myplr].InvBody[INVLOC_HAND_LEFT]._iStatFlag) {
-			CelDrawHdrOnly(screen_x, screen_y, (char *)pCursCels, frame, frame_width, 0, 8);
+			CelDrawHdrOnly(screen_x, screen_y, (BYTE *)pCursCels, frame, frame_width, 0, 8);
 		} else {
 			CelDrawHdrLightRed(screen_x, screen_y, (char *)pCursCels, frame, frame_width, 0, 8, 1);
 		}
@@ -309,7 +309,7 @@ void __cdecl DrawInv()
 		}
 
 		if (plr[myplr].InvBody[INVLOC_HAND_RIGHT]._iStatFlag) {
-			CelDrawHdrOnly(screen_x, screen_y, (char *)pCursCels, frame, frame_width, 0, 8);
+			CelDrawHdrOnly(screen_x, screen_y, (BYTE *)pCursCels, frame, frame_width, 0, 8);
 		} else {
 			CelDrawHdrLightRed(screen_x, screen_y, (char *)pCursCels, frame, frame_width, 0, 8, 1);
 		}
@@ -333,7 +333,7 @@ void __cdecl DrawInv()
 		}
 
 		if (plr[myplr].InvBody[INVLOC_CHEST]._iStatFlag) {
-			CelDrawHdrOnly(517, 320, (char *)pCursCels, frame, frame_width, 0, 8);
+			CelDrawHdrOnly(517, 320, (BYTE *)pCursCels, frame, frame_width, 0, 8);
 		} else {
 			CelDrawHdrLightRed(517, 320, (char *)pCursCels, frame, frame_width, 0, 8, 1);
 		}
@@ -377,7 +377,7 @@ void __cdecl DrawInv()
 				CelDrawHdrOnly(
 				    InvRect[j + SLOTXY_INV_FIRST].X + 64,
 				    InvRect[j + SLOTXY_INV_FIRST].Y + 159,
-				    (char *)pCursCels, frame, frame_width, 0, 8);
+				    (BYTE *)pCursCels, frame, frame_width, 0, 8);
 			} else {
 				CelDrawHdrLightRed(
 				    InvRect[j + SLOTXY_INV_FIRST].X + 64,
@@ -422,7 +422,7 @@ void __cdecl DrawInvBelt()
 		}
 
 		if (plr[myplr].SpdList[i]._iStatFlag)
-			CelDrawHdrOnly(InvRect[i + 65].X + 64, InvRect[i + 65].Y + 159, (char *)pCursCels, frame, frame_width, 0, 8);
+			CelDrawHdrOnly(InvRect[i + 65].X + 64, InvRect[i + 65].Y + 159, (BYTE *)pCursCels, frame, frame_width, 0, 8);
 		else
 			CelDrawHdrLightRed(InvRect[i + 65].X + 64, InvRect[i + 65].Y + 159, (char *)pCursCels, frame, frame_width, 0, 8, 1);
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3696,7 +3696,7 @@ void __fastcall PrintItemPower(char plidx, ItemStruct *x)
 
 void __cdecl DrawUBack()
 {
-	CelDecodeOnly(88, 487, pSTextBoxCels, 1, 271);
+	CelDecodeOnly(88, 487, (BYTE *)pSTextBoxCels, 1, 271);
 
 #define TRANS_RECT_X 27
 #define TRANS_RECT_Y 28

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -85,7 +85,7 @@ void __fastcall InitQTextMsg(int m)
 
 void __cdecl DrawQTextBack()
 {
-	CelDecodeOnly(88, 487, pTextBoxCels, 1, 591);
+	CelDecodeOnly(88, 487, (BYTE *)pTextBoxCels, 1, 591);
 
 #define TRANS_RECT_X 27
 #define TRANS_RECT_Y 28

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -940,7 +940,7 @@ void __fastcall PrintQLString(int x, int y, unsigned char cjustflag, char *str, 
 		v12 = v8 + v6 + 76;
 		if (!cjustflag)
 			v12 = v6 + 76;
-		CelDecodeOnly(v12, v5 + 205, pCelBuff, ALLQUESTS, 12);
+		CelDecodeOnly(v12, v5 + 205, (BYTE *)pCelBuff, ALLQUESTS, 12);
 	}
 	v13 = 0;
 	v19 = 0;
@@ -963,7 +963,7 @@ void __fastcall PrintQLString(int x, int y, unsigned char cjustflag, char *str, 
 			v16 = v8 + v6 + 100;
 		else
 			v16 = 340 - v6;
-		CelDecodeOnly(v16, v5 + 205, pCelBuff, ALLQUESTS, 12);
+		CelDecodeOnly(v16, v5 + 205, (BYTE *)pCelBuff, ALLQUESTS, 12);
 	}
 }
 // 69BE90: using guessed type int qline;
@@ -974,7 +974,7 @@ void __cdecl DrawQuestLog()
 	int i;  // esi
 
 	PrintQLString(0, 2, 1u, "Quest Log", 3);
-	CelDecodeOnly(64, 511, pQLogCel, 1, 320);
+	CelDecodeOnly(64, 511, (BYTE *)pQLogCel, 1, 320);
 	v0 = qtopline;
 	for (i = 0; i < numqlines; ++i) {
 		PrintQLString(0, v0, 1u, questlist[qlist[i]]._qlstr, 0);

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -840,7 +840,7 @@ void __fastcall scrollrt_draw_clipped_dungeon(char *a1, int sx, int sy, int a4, 
 	v40 = *v10;
 	v41 = *(v10 - 1);
 	if (visiondebug && v50 & DFLAG_LIT)
-		Cel2DecodeHdrOnly(dst_buf, (char *)pSquareCel, 1, 64, 0, 8);
+		Cel2DecodeHdrOnly((BYTE *)dst_buf, (BYTE *)pSquareCel, 1, 64, 0, 8);
 	if (MissilePreFlag && v50 & DFLAG_MISSILE)
 		DrawClippedMissile(a1a, sy, a4, a5, 0, 8, TRUE);
 	if (light_table_index < lightmax) {
@@ -1113,7 +1113,7 @@ void __fastcall DrawClippedObject(int x, int y, int ox, int oy, BOOL pre, int a6
 	if(object[bv]._oLight)
 		Cel2DecodeHdrLight(sx, sy, (char *)object[bv]._oAnimData, object[bv]._oAnimFrame, object[bv]._oAnimWidth, a6, dir);
 	else
-		Cel2DrawHdrOnly(sx, sy, (char *)object[bv]._oAnimData, object[bv]._oAnimFrame, object[bv]._oAnimWidth, a6, dir);
+		Cel2DrawHdrOnly(sx, sy, object[bv]._oAnimData, object[bv]._oAnimFrame, object[bv]._oAnimWidth, a6, dir);
 }
 // 4B8CC1: using guessed type char pcursobj;
 
@@ -1436,7 +1436,7 @@ void __fastcall scrollrt_draw_clipped_dungeon_2(char *buffer, int x, int y, int 
 	v43 = *v12;
 	v44 = *(v12 - 1);
 	if (visiondebug && v53 & DFLAG_LIT)
-		Cel2DecodeHdrOnly(dst_buf, (char *)pSquareCel, 1, 64, a5, 8);
+		Cel2DecodeHdrOnly((BYTE *)dst_buf, (BYTE *)pSquareCel, 1, 64, a5, 8);
 	if (MissilePreFlag && v53 & DFLAG_MISSILE) {
 		v13 = sx;
 		DrawClippedMissile(a1, y, sx, sy, a5, 8, TRUE);
@@ -1980,7 +1980,7 @@ void __fastcall scrollrt_draw_dungeon(char *buffer, int x, int y, int a4, int a5
 	v42 = *v12;
 	v43 = *(v12 - 1);
 	if (visiondebug && v52 & DFLAG_LIT)
-		CelDecodeHdrOnly(dst_buf, (char *)pSquareCel, 1, 64, 0, a5);
+		CelDecodeHdrOnly((BYTE *)dst_buf, (BYTE *)pSquareCel, 1, 64, 0, a5);
 	if (MissilePreFlag && v52 & DFLAG_MISSILE)
 		DrawMissile(xa, y, sx, sy, 0, a5, TRUE);
 	if (light_table_index < lightmax) {
@@ -2255,7 +2255,7 @@ void __fastcall DrawObject(int x, int y, int ox, int oy, BOOL pre, int a6, int d
 	} else {
 		/// ASSERT: assert(object[bv]._oAnimData);
 		if(object[bv]._oAnimData) // BUGFIX: _oAnimData was already checked, this is redundant
-			CelDrawHdrOnly(sx, sy, (char *)object[bv]._oAnimData, object[bv]._oAnimFrame, object[bv]._oAnimWidth, a6, dir);
+			CelDrawHdrOnly(sx, sy, object[bv]._oAnimData, object[bv]._oAnimFrame, object[bv]._oAnimWidth, a6, dir);
 	}
 }
 // 4B8CC1: using guessed type char pcursobj;
@@ -2715,7 +2715,7 @@ void __cdecl scrollrt_draw_cursor_item()
 				v10 = v3 + 1;
 				gpBufEnd = (unsigned char *)gpBuffer + screen_y_times_768[640] - v0 - 2;
 				if (pcurs < 12) {
-					Cel2DrawHdrOnly(v9 + 64, v1 + v10 + 159, (char *)pCursCels, pcurs, v0, 0, 8);
+					Cel2DrawHdrOnly(v9 + 64, v1 + v10 + 159, (BYTE *)pCursCels, pcurs, v0, 0, 8);
 				} else {
 					colour = ICOL_WHITE;
 					if (plr[myplr].HoldItem._iMagical != ITEM_QUALITY_NORMAL)
@@ -2728,7 +2728,7 @@ void __cdecl scrollrt_draw_cursor_item()
 					if (colour == ICOL_RED)
 						Cel2DrawHdrLightRed(v12, v13, (char *)pCursCels, pcurs, cursW, 0, 8, 1);
 					else
-						Cel2DrawHdrOnly(v12, v13, (char *)pCursCels, pcurs, cursW, 0, 8);
+						Cel2DrawHdrOnly(v12, v13, (BYTE *)pCursCels, pcurs, cursW, 0, 8);
 				}
 			}
 		}

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -147,7 +147,7 @@ void __cdecl FreeStoreMem()
 
 void __cdecl DrawSTextBack()
 {
-	CelDecodeOnly(408, 487, pSTextBoxCels, 1, 271);
+	CelDecodeOnly(408, 487, (BYTE *)pSTextBoxCels, 1, 271);
 
 #define TRANS_RECT_X 347
 #define TRANS_RECT_Y 28
@@ -214,7 +214,7 @@ void __fastcall PrintSString(int x, int y, unsigned char cjustflag, char *str, i
 			v14 = v27 + v30 + v8 - 20;
 		else
 			v14 = v27 + v8 - 20;
-		CelDecodeOnly(v14, v6 + 205, pCelBuff, InStoreFlag, 12);
+		CelDecodeOnly(v14, v6 + 205, (BYTE *)pCelBuff, InStoreFlag, 12);
 	}
 	v29 = 0;
 	if (v28 > 0) {
@@ -248,7 +248,7 @@ void __fastcall PrintSString(int x, int y, unsigned char cjustflag, char *str, i
 			v22 = v27 + v30 + v8 + 4;
 		else
 			v22 = 660 - v8;
-		CelDecodeOnly(v22, v6 + 205, pCelBuff, InStoreFlag, 12);
+		CelDecodeOnly(v22, v6 + 205, (BYTE *)pCelBuff, InStoreFlag, 12);
 	}
 }
 // 6A09E0: using guessed type char stextsize;
@@ -309,18 +309,18 @@ void __fastcall DrawSArrows(int y1, int y2)
 	v4 = SStringY[y1] + 204;
 	v5 = *v2 + 204;
 	if (stextscrlubtn == -1)
-		CelDecodeOnly(665, v4, pSTextSlidCels, 10, 12);
+		CelDecodeOnly(665, v4, (BYTE *)pSTextSlidCels, 10, 12);
 	else
-		CelDecodeOnly(665, v4, pSTextSlidCels, 12, 12);
+		CelDecodeOnly(665, v4, (BYTE *)pSTextSlidCels, 12, 12);
 	if (stextscrldbtn == -1)
-		CelDecodeOnly(665, v5, pSTextSlidCels, 9, 12);
+		CelDecodeOnly(665, v5, (BYTE *)pSTextSlidCels, 9, 12);
 	else
-		CelDecodeOnly(665, v5, pSTextSlidCels, 11, 12);
+		CelDecodeOnly(665, v5, (BYTE *)pSTextSlidCels, 11, 12);
 	while (1) {
 		v4 += 12;
 		if (v4 >= v5)
 			break;
-		CelDecodeOnly(665, v4, pSTextSlidCels, 14, 12);
+		CelDecodeOnly(665, v4, (BYTE *)pSTextSlidCels, 14, 12);
 	}
 	v6 = stextsel;
 	if (stextsel == 22)
@@ -329,7 +329,7 @@ void __fastcall DrawSArrows(int y1, int y2)
 		v7 = 0;
 	else
 		v7 = (*v2 - SStringY[v3] - 24) * (1000 * (stextsval + ((v6 - stextup) >> 2)) / (storenumh - 1)) / 1000;
-	CelDecodeOnly(665, SStringY[v3 + 1] + v7 + 204, pSTextSlidCels, 13, 12);
+	CelDecodeOnly(665, SStringY[v3 + 1] + v7 + 204, (BYTE *)pSTextSlidCels, 13, 12);
 }
 // 69F108: using guessed type int stextup;
 // 69F10C: using guessed type int storenumh;

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -151,7 +151,7 @@ void __fastcall town_draw_clipped_town(BYTE *buffer, int x, int y, int sx, int s
 			    item[v10]._iAnimWidth,
 			    0,
 			    8);
-		Cel2DrawHdrOnly(v11, sy, (char *)item[v10]._iAnimData, item[v10]._iAnimFrame, item[v10]._iAnimWidth, 0, 8);
+		Cel2DrawHdrOnly(v11, sy, item[v10]._iAnimData, item[v10]._iAnimFrame, item[v10]._iAnimWidth, 0, 8);
 	}
 	if (dFlags[0][v7] & DFLAG_MONSTER) {
 		v12 = -1 - dMonster[x][y - 1]; // -1 - *(&dword_52D204 + v7); /* check */
@@ -166,7 +166,7 @@ void __fastcall town_draw_clipped_town(BYTE *buffer, int x, int y, int sx, int s
 			    towner[v12]._tAnimWidth,
 			    0,
 			    8);
-		Cel2DrawHdrOnly(v13, sy, (char *)towner[v12]._tAnimData, towner[v12]._tAnimFrame, towner[v12]._tAnimWidth, 0, 8);
+		Cel2DrawHdrOnly(v13, sy, towner[v12]._tAnimData, towner[v12]._tAnimFrame, towner[v12]._tAnimWidth, 0, 8);
 	}
 	v14 = dMonster[0][v7];
 	if (v14 > 0) {
@@ -183,7 +183,7 @@ void __fastcall town_draw_clipped_town(BYTE *buffer, int x, int y, int sx, int s
 			    towner[v16]._tAnimWidth,
 			    0,
 			    8);
-		Cel2DrawHdrOnly(v17, sy, (char *)towner[v16]._tAnimData, towner[v16]._tAnimFrame, towner[v16]._tAnimWidth, 0, 8);
+		Cel2DrawHdrOnly(v17, sy, towner[v16]._tAnimData, towner[v16]._tAnimFrame, towner[v16]._tAnimWidth, 0, 8);
 	}
 	if (dFlags[0][v7] & DFLAG_PLAYER) {
 		v18 = -1 - dPlayer[x][y - 1]; // -1 - *((_BYTE *)&themeLoc[49].height + v7 + 3);
@@ -411,7 +411,7 @@ void __fastcall town_draw_clipped_town_2(int x, int y, int a3, int a4, int a5, i
 			    item[v12]._iAnimWidth,
 			    a5,
 			    8);
-		Cel2DrawHdrOnly(v13, sy, (char *)item[v12]._iAnimData, item[v12]._iAnimFrame, item[v12]._iAnimWidth, a5, 8);
+		Cel2DrawHdrOnly(v13, sy, item[v12]._iAnimData, item[v12]._iAnimFrame, item[v12]._iAnimWidth, a5, 8);
 	}
 	if (dFlags[0][v9] & DFLAG_MONSTER) {
 		v14 = -1 - dMonster[x][y - 1]; // -1 - *(&dword_52D204 + v9); /* check */
@@ -426,7 +426,7 @@ void __fastcall town_draw_clipped_town_2(int x, int y, int a3, int a4, int a5, i
 			    towner[v14]._tAnimWidth,
 			    a5,
 			    8);
-		Cel2DrawHdrOnly(v15, sy, (char *)towner[v14]._tAnimData, towner[v14]._tAnimFrame, towner[v14]._tAnimWidth, a5, 8);
+		Cel2DrawHdrOnly(v15, sy, towner[v14]._tAnimData, towner[v14]._tAnimFrame, towner[v14]._tAnimWidth, a5, 8);
 	}
 	v16 = dMonster[0][v9];
 	if (v16 > 0) {
@@ -443,7 +443,7 @@ void __fastcall town_draw_clipped_town_2(int x, int y, int a3, int a4, int a5, i
 			    towner[v18]._tAnimWidth,
 			    a5,
 			    8);
-		Cel2DrawHdrOnly(v19, sy, (char *)towner[v18]._tAnimData, towner[v18]._tAnimFrame, towner[v18]._tAnimWidth, a5, 8);
+		Cel2DrawHdrOnly(v19, sy, towner[v18]._tAnimData, towner[v18]._tAnimFrame, towner[v18]._tAnimWidth, a5, 8);
 	}
 	if (dFlags[0][v9] & DFLAG_PLAYER) {
 		v20 = -1 - dPlayer[x][y - 1]; // -1 - *((_BYTE *)&themeLoc[49].height + v9 + 3);
@@ -654,21 +654,21 @@ void __fastcall town_draw_town_all(BYTE *buffer, int x, int y, int a4, int dir, 
 		xx = sx - item[ii]._iAnimWidth2;
 		if (ii == pcursitem)
 			CelDecodeClr(ICOL_BLUE, xx, sy, (char *)item[ii]._iAnimData, item[ii]._iAnimFrame, item[ii]._iAnimWidth, 0, dir);
-		CelDrawHdrOnly(xx, sy, (char *)item[ii]._iAnimData, item[ii]._iAnimFrame, item[ii]._iAnimWidth, 0, dir);
+		CelDrawHdrOnly(xx, sy, item[ii]._iAnimData, item[ii]._iAnimFrame, item[ii]._iAnimWidth, 0, dir);
 	}
 	if (dFlags[x][y] & DFLAG_MONSTER) {
 		mi = -1 - dMonster[x][y - 1];
 		xx = sx - towner[mi]._tAnimWidth2;
 		if (mi == pcursmonst)
 			CelDecodeClr(PAL16_BEIGE + 6, xx, sy, (char *)towner[mi]._tAnimData, towner[mi]._tAnimFrame, towner[mi]._tAnimWidth, 0, dir);
-		CelDrawHdrOnly(xx, sy, (char *)towner[mi]._tAnimData, towner[mi]._tAnimFrame, towner[mi]._tAnimWidth, 0, dir);
+		CelDrawHdrOnly(xx, sy, towner[mi]._tAnimData, towner[mi]._tAnimFrame, towner[mi]._tAnimWidth, 0, dir);
 	}
 	if (dMonster[x][y] > 0) {
 		mi = dMonster[x][y] - 1;
 		xx = sx - towner[mi]._tAnimWidth2;
 		if (mi == pcursmonst)
 			CelDecodeClr(PAL16_BEIGE + 6, xx, sy, (char *)towner[mi]._tAnimData, towner[mi]._tAnimFrame, towner[mi]._tAnimWidth, 0, dir);
-		CelDrawHdrOnly(xx, sy, (char *)towner[mi]._tAnimData, towner[mi]._tAnimFrame, towner[mi]._tAnimWidth, 0, dir);
+		CelDrawHdrOnly(xx, sy, towner[mi]._tAnimData, towner[mi]._tAnimFrame, towner[mi]._tAnimWidth, 0, dir);
 	}
 	if (dFlags[x][y] & DFLAG_PLAYER) {
 		pnum = -1 - dPlayer[x][y - 1];


### PR DESCRIPTION
This cleans up most of the main .CEL drawing functions. All draw functions for both CEL/CL2 were written in assembly, so a C version is provided for each. This also deletes two inlined functions.
```
Cel2DecDatLightOnly
Cel2DecDatLightTrans
Cel2DecDatOnly
Cel2DecodeHdrOnly
Cel2DrawHdrOnly
CelDecDatLightOnly
CelDecDatLightTrans
CelDecDatOnly
CelDecodeHdrOnly
CelDecodeLightOnly
CelDecodeOnly
CelDrawDatOnly
CelDrawHdrOnly
```