### PR TITLE
S_StartSBuy [request for feedback]

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -692,33 +692,23 @@ void __fastcall PrintStoreItem(ItemStruct *x, int l, char iclr)
 
 void __cdecl S_StartSBuy()
 {
-	int v0;  // ST10_4
-	int v1;  // eax
-	int *v2; // ecx
+	int i;
 
-	v0 = plr[myplr]._pGold;
 	stextsize = 1;
 	stextscrl = 1;
 	stextsval = 0;
-	sprintf(tempstr, "I have these items for sale :           Your gold : %i", v0);
-	AddSText(0, 1, 1u, tempstr, COL_GOLD, 0);
+	sprintf(tempstr, "I have these items for sale :           Your gold : %i", plr[myplr]._pGold);
+	AddSText(0, 1, 1, tempstr, COL_GOLD, 0);
 	AddSLine(3);
 	AddSLine(21);
 	S_ScrollSBuy(stextsval);
-	AddSText(0, 22, 1u, "Back", COL_WHITE, 0);
+	AddSText(0, 22, 1, "Back", COL_WHITE, 0);
 	OffsetSTextY(22, 6);
-	v1 = 0;
 	storenumh = 0;
-	if (smithitem[0]._itype != -1) {
-		v2 = &smithitem[0]._itype;
-		do {
-			v2 += 92;
-			++v1;
-		} while (*v2 != -1);
-		storenumh = v1;
-	}
-	stextsmax = v1 - 4;
-	if (v1 - 4 < 0)
+	for (i = 0; smithitem[i]._itype != -1; ++i)
+		++storenumh;
+	stextsmax = storenumh - 4;
+	if (storenumh - 4 < 0)
 		stextsmax = 0;
 }
 // 69F10C: using guessed type int storenumh;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -706,7 +706,7 @@ void __cdecl S_StartSBuy()
 	OffsetSTextY(22, 6);
 	storenumh = 0;
 	for (i = 0; smithitem[i]._itype != -1; i++)
-		++storenumh;
+		storenumh++;
 	stextsmax = storenumh - 4;
 	if (stextsmax < 0)
 		stextsmax = 0;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -708,7 +708,7 @@ void __cdecl S_StartSBuy()
 	for (i = 0; smithitem[i]._itype != -1; i++)
 		++storenumh;
 	stextsmax = storenumh - 4;
-	if (storenumh - 4 < 0)
+	if (stextsmax < 0)
 		stextsmax = 0;
 }
 // 69F10C: using guessed type int storenumh;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -705,7 +705,7 @@ void __cdecl S_StartSBuy()
 	AddSText(0, 22, 1, "Back", COL_WHITE, 0);
 	OffsetSTextY(22, 6);
 	storenumh = 0;
-	for (i = 0; smithitem[i]._itype != -1; ++i)
+	for (i = 0; smithitem[i]._itype != -1; i++)
 		++storenumh;
 	stextsmax = storenumh - 4;
 	if (storenumh - 4 < 0)


### PR DESCRIPTION
Hi everyone,
I'm trying to nail down why building it via the IDE leads to a different binary than the one docker gives. The only difference in this function (built via the IDE) is that the xor instruction is generated a little lower down the order:
![image](https://user-images.githubusercontent.com/46401660/54496156-7ee61380-48ec-11e9-890d-f73887982d2f.png)
Unfortunately my hardware is too crappy to install Docker, I would be greatful if someone could tell me whether this is also the case with Docker.