### PR TITLE
Fix type for 'gpBuffer'

### DIFF
--- a/Source/asm_trans_rect.inc
+++ b/Source/asm_trans_rect.inc
@@ -50,7 +50,7 @@ x2loop:
 #else // _MSC_VER && _M_IX86
 {
 	int row, col;
-	char *pix = &gpBuffer->row[TRANS_RECT_Y + TRANS_RECT_HEIGHT - 1].pixels[TRANS_RECT_X];
+	BYTE *pix = &gpBuffer[SCREENXY(TRANS_RECT_X, TRANS_RECT_Y + TRANS_RECT_HEIGHT - 1)];
 	for (row = TRANS_RECT_HEIGHT >> 1; row != 0; row--) {
 		for (col = TRANS_RECT_WIDTH >> 1; col != 0; col--) {
 			*pix++ = 0;

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -175,7 +175,7 @@ void __cdecl DrawAutomap()
 		return;
 	}
 
-	gpBufEnd = (unsigned char *)&gpBuffer->row[352];
+	gpBufEnd = (unsigned char *)&gpBuffer[(352 + 160) * 768];
 
 	MapX = (ViewX - 16) >> 1;
 	while (MapX + AutoMapXOfs < 0)

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -22,7 +22,7 @@ void __cdecl CaptureScreen()
 		j_lock_buf_priv(2);
 		success = CaptureHdr(hObject, 640, 480);
 		if (success) {
-			success = CapturePix(hObject, 640, 480, 768, (BYTE *)gpBuffer->row[0].pixels);
+			success = CapturePix(hObject, 640, 480, 768, &gpBuffer[SCREENXY(0, 0)]);
 			if (success) {
 				success = CapturePal(hObject, palette);
 			}

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -185,12 +185,11 @@ int SpellPages[6][7] = {
 
 void __fastcall DrawSpellCel(int xp, int yp, BYTE *Trans, int nCel, int w)
 {
-	BYTE *tmp, *dst, *tbl, *end;
+	BYTE *dst, *tbl, *end;
 
 	/// ASSERT: assert(gpBuffer);
 
-	tmp = (BYTE *)gpBuffer; /* remove when fixed */
-	dst = &tmp[screen_y_times_768[yp] + xp];
+	dst = &gpBuffer[xp + screen_y_times_768[yp]];
 	tbl = SplTransTbl;
 
 #if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
@@ -844,7 +843,7 @@ void __fastcall DrawPanelBox(int x, int y, int w, int h, int sx, int sy)
 	unsigned int v11; // ecx
 
 	v6 = (char *)pBtmBuff + 640 * y + x;
-	v7 = &gpBuffer->row_unused_1[sy].col_unused_1[sx];
+	v7 = (char *)&gpBuffer[768 * sy + sx];
 	v8 = h;
 	do {
 		v9 = w >> 1;
@@ -870,7 +869,7 @@ void __fastcall SetFlaskHeight(char *buf, int min, int max, int c, int r)
 	int v7;   // edx
 
 	v5 = &buf[88 * min];
-	v6 = &gpBuffer->row_unused_1[r].col_unused_1[c];
+	v6 = (char *)&gpBuffer[768 * r + c];
 	v7 = max - min;
 	do {
 		qmemcpy(v6, v5, 0x58u);
@@ -2268,7 +2267,7 @@ void __cdecl RedBack()
 	_LOWORD(v0) = v0 & 0xF400;
 	v12 = v0 + 768 * 6;
 	if (leveltype == DTYPE_HELL) {
-		v7 = gpBuffer->row[0].pixels;
+		v7 = (char *)&gpBuffer[SCREENXY(0, 0)];
 		_EBX = &pLightTbl[v12];
 		v9 = 352;
 		do {
@@ -2284,7 +2283,7 @@ void __cdecl RedBack()
 			--v9;
 		} while (v9);
 	} else {
-		v1 = gpBuffer->row[0].pixels;
+		v1 = (char *)&gpBuffer[SCREENXY(0, 0)];
 		_EBX = &pLightTbl[v12];
 		v3 = 352;
 		do {

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -2,11 +2,11 @@
 
 #include "../types.h"
 
-Screen *sgpBackBuf;
+BYTE *sgpBackBuf;
 LPDIRECTDRAW lpDDInterface;
 IDirectDrawPalette *lpDDPalette; // idb
 int sgdwLockCount;
-Screen *gpBuffer;
+BYTE *gpBuffer;
 IDirectDrawSurface *lpDDSBackBuf;
 IDirectDrawSurface *lpDDSPrimary;
 #ifdef _DEBUG
@@ -128,7 +128,7 @@ void __cdecl dx_create_back_buffer()
 #else
 			lpDDSPrimary->lpVtbl->Unlock(lpDDSPrimary, NULL);
 #endif
-			sgpBackBuf = (Screen *)DiabloAllocPtr(sizeof(Screen));
+			sgpBackBuf = (BYTE *)DiabloAllocPtr(656 * 768);
 			return;
 		}
 		if (error_code != DDERR_CANTLOCKSURFACE)
@@ -238,7 +238,7 @@ void __cdecl lock_buf_priv()
 		DDErrMsg(error_code, 235, "C:\\Src\\Diablo\\Source\\dx.cpp");
 
 	gpBufEnd += (int)ddsd.lpSurface;
-	gpBuffer = (Screen *)ddsd.lpSurface;
+	gpBuffer = (BYTE *)ddsd.lpSurface;
 	sgdwLockCount++;
 }
 
@@ -280,7 +280,7 @@ void __cdecl unlock_buf_priv()
 
 void __cdecl dx_cleanup()
 {
-	Screen *v0; // ecx
+	BYTE *v0; // ecx
 
 	if (ghMainWnd)
 		ShowWindow(ghMainWnd, SW_HIDE);

--- a/Source/dx.h
+++ b/Source/dx.h
@@ -4,7 +4,7 @@
 
 extern IDirectDraw *lpDDInterface;
 extern IDirectDrawPalette *lpDDPalette; // idb
-extern Screen *gpBuffer;
+extern BYTE *gpBuffer;
 extern IDirectDrawSurface *lpDDSBackBuf;
 extern IDirectDrawSurface *lpDDSPrimary;
 extern char gbBackBuf;    // weak

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -119,7 +119,6 @@ void __fastcall CelDrawDatOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, 
 
 void __fastcall CelDecodeOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
 {
-	BYTE *tmp;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer);
@@ -129,11 +128,10 @@ void __fastcall CelDecodeOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWid
 	if(!pCelBuff)
 		return;
 
-	tmp = (BYTE *)gpBuffer;
 	pFrameTable = (DWORD *)pCelBuff;
 
 	CelDrawDatOnly(
-		&tmp[sx + screen_y_times_768[sy]],
+		&gpBuffer[sx + screen_y_times_768[sy]],
 		&pCelBuff[pFrameTable[nCel]],
 		pFrameTable[nCel + 1] - pFrameTable[nCel],
 		nWidth);
@@ -162,7 +160,7 @@ void __fastcall CelDecDatOnly(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth)
 void __fastcall CelDrawHdrOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int v1, v2, nDataSize;
-	BYTE *pRLEBytes, *tmp;
+	BYTE *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer);
@@ -190,9 +188,8 @@ void __fastcall CelDrawHdrOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWi
 	else
 		nDataSize -= v1;
 
-	tmp = (BYTE *)gpBuffer;
 	CelDrawDatOnly(
-		&tmp[sx + screen_y_times_768[sy - 16 * always_0]],
+		&gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]],
 		&pRLEBytes[v1],
 		nDataSize,
 		nWidth);
@@ -575,7 +572,7 @@ L_ODD:
 void __fastcall CelDecodeLightOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth)
 {
 	int nDataSize;
-	BYTE *pDecodeTo, *pRLEBytes, *tmp;
+	BYTE *pDecodeTo, *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer);
@@ -585,12 +582,11 @@ void __fastcall CelDecodeLightOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int
 	if(!pCelBuff)
 		return;
 
-	tmp = (BYTE *)gpBuffer;
 	pFrameTable = (DWORD *)pCelBuff;
 
 	nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
 	pRLEBytes = &pCelBuff[pFrameTable[nCel]];
-	pDecodeTo = &tmp[sx + screen_y_times_768[sy]];
+	pDecodeTo = &gpBuffer[sx + screen_y_times_768[sy]];
 
 	if(light_table_index)
 		CelDecDatLightOnly(pDecodeTo, pRLEBytes, nDataSize, nWidth);
@@ -602,7 +598,7 @@ void __fastcall CelDecodeLightOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int
 void __fastcall CelDecodeHdrLightOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int hdr, nDataSize, v1, v2;
-	BYTE *pRLEBytes, *pDecodeTo, *tmp, *v9;
+	BYTE *pRLEBytes, *pDecodeTo, *v9;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer);
@@ -629,8 +625,7 @@ void __fastcall CelDecodeHdrLightOnly(int sx, int sy, BYTE *pCelBuff, int nCel, 
 		nDataSize = v1 - hdr;
 
 	pRLEBytes = &v9[hdr];
-	tmp = (BYTE *)gpBuffer;
-	pDecodeTo = &tmp[sx + screen_y_times_768[sy - 16 * always_0]];
+	pDecodeTo = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	if(light_table_index)
 		CelDecDatLightOnly(pDecodeTo, pRLEBytes, nDataSize, nWidth);
@@ -683,7 +678,7 @@ void __fastcall CelDecodeHdrLightTrans(BYTE *pBuff, BYTE *pCelBuff, int nCel, in
 void __fastcall CelDrawHdrLightRed(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir, char light)
 {
 	int w, hdr, idx, nDataSize, v1;
-	BYTE *src, *dst, *tbl, *tmp, *pRLEBytes;
+	BYTE *src, *dst, *tbl, *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer);
@@ -709,8 +704,7 @@ void __fastcall CelDrawHdrLightRed(int sx, int sy, BYTE *pCelBuff, int nCel, int
 		nDataSize = pFrameTable[1] - pFrameTable[0] - hdr;
 
 	src = &pRLEBytes[hdr];
-	tmp = (BYTE *)gpBuffer;
-	dst = &tmp[sx + screen_y_times_768[sy - 16 * always_0]];
+	dst = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	idx = light4flag ? 1024 : 4096;
 	if(light == 2)
@@ -908,7 +902,7 @@ void __fastcall Cel2DecDatOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, 
 void __fastcall Cel2DrawHdrOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int v1, v2, nDataSize;
-	BYTE *pRLEBytes, *tmp;
+	BYTE *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer);
@@ -936,9 +930,8 @@ void __fastcall Cel2DrawHdrOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nW
 	else
 		nDataSize -= v1;
 
-	tmp = (BYTE *)gpBuffer;
 	Cel2DecDatOnly(
-		&tmp[sx + screen_y_times_768[sy - 16 * always_0]],
+		&gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]],
 		&pRLEBytes[v1],
 		nDataSize,
 		nWidth);
@@ -1351,7 +1344,7 @@ L_ODD:
 void __fastcall Cel2DecodeHdrLight(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int hdr, nDataSize, v1;
-	BYTE *pRLEBytes, *pDecodeTo, *tmp, *v9;
+	BYTE *pRLEBytes, *pDecodeTo, *v9;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer);
@@ -1376,8 +1369,7 @@ void __fastcall Cel2DecodeHdrLight(int sx, int sy, BYTE *pCelBuff, int nCel, int
 		nDataSize = pFrameTable[1] - pFrameTable[0] - hdr;
 
 	pRLEBytes = &v9[hdr];
-	tmp = (BYTE *)gpBuffer;
-	pDecodeTo = &tmp[sx + screen_y_times_768[sy - 16 * always_0]];
+	pDecodeTo = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	if(light_table_index)
 		Cel2DecDatLightOnly(pDecodeTo, pRLEBytes, nDataSize, nWidth);
@@ -1426,7 +1418,7 @@ void __fastcall Cel2DecodeLightTrans(BYTE *pBuff, BYTE *pCelBuff, int nCel, int 
 void __fastcall Cel2DrawHdrLightRed(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir, char light)
 {
 	int w, hdr, idx, nDataSize, v1;
-	BYTE *src, *dst, *tbl, *tmp, *pRLEBytes;
+	BYTE *src, *dst, *tbl, *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer);
@@ -1452,8 +1444,7 @@ void __fastcall Cel2DrawHdrLightRed(int sx, int sy, BYTE *pCelBuff, int nCel, in
 		nDataSize = pFrameTable[1] - pFrameTable[0] - hdr;
 
 	src = &pRLEBytes[hdr];
-	tmp = (BYTE *)gpBuffer;
-	dst = &tmp[sx + screen_y_times_768[sy - 16 * always_0]];
+	dst = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	idx = light4flag ? 1024 : 4096;
 	if(light == 2)
@@ -1665,7 +1656,7 @@ void __fastcall CelDecodeRect(BYTE *pBuff, int always_0, int hgt, int wdt, BYTE 
 void __fastcall CelDecodeClr(char col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int w, hdr, nDataSize, v1;
-	BYTE *src, *dst, *tmp;
+	BYTE *src, *dst;
 
 	/// ASSERT: assert(pCelBuff != NULL);
 	if(!pCelBuff)
@@ -1707,8 +1698,7 @@ void __fastcall CelDecodeClr(char col, int sx, int sy, BYTE *pCelBuff, int nCel,
 		nDataSize -= hdr;
 
 	src += hdr;
-	tmp = (BYTE *)gpBuffer;
-	dst = &tmp[sx + screen_y_times_768[sy - 16 * always_0]];
+	dst = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	__asm {
 		mov		esi, src
@@ -1773,8 +1763,7 @@ void __fastcall CelDecodeClr(char col, int sx, int sy, BYTE *pCelBuff, int nCel,
 
 	src = &pRLEBytes[hdr];
 	end = &src[nDataSize];
-	tmp = (BYTE *)gpBuffer;
-	dst = &tmp[sx + screen_y_times_768[sy - 16 * always_0]];
+	dst = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	for(; src != end; dst -= 768 + nWidth) {
 		for(w = nWidth; w;) {
@@ -1804,7 +1793,7 @@ void __fastcall CelDecodeClr(char col, int sx, int sy, BYTE *pCelBuff, int nCel,
 void __fastcall CelDrawHdrClrHL(char col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int w, hdr, nDataSize, v1;
-	BYTE *src, *dst, *tmp;
+	BYTE *src, *dst;
 
 	/// ASSERT: assert(pCelBuff != NULL);
 	if(!pCelBuff)
@@ -1846,8 +1835,7 @@ void __fastcall CelDrawHdrClrHL(char col, int sx, int sy, BYTE *pCelBuff, int nC
 		nDataSize -= hdr;
 
 	src += hdr;
-	tmp = (BYTE *)gpBuffer;
-	dst = &tmp[sx + screen_y_times_768[sy - 16 * always_0]];
+	dst = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	__asm {
 		mov		esi, src
@@ -1937,8 +1925,7 @@ void __fastcall CelDrawHdrClrHL(char col, int sx, int sy, BYTE *pCelBuff, int nC
 
 	src = &pRLEBytes[hdr];
 	end = &src[nDataSize];
-	tmp = (BYTE *)gpBuffer;
-	dst = &tmp[sx + screen_y_times_768[sy - 16 * always_0]];
+	dst = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	for(; src != end; dst -= 768 + nWidth) {
 		for(w = nWidth; w;) {
@@ -2457,7 +2444,7 @@ void __fastcall Cl2ApplyTrans(BYTE *p, BYTE *ttbl, int nCel)
 void __fastcall Cl2DecodeFrm1(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int hdr, nDataSize;
-	BYTE *pRLEBytes, *tmp;
+	BYTE *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer != NULL);
@@ -2485,9 +2472,8 @@ void __fastcall Cl2DecodeFrm1(int sx, int sy, BYTE *pCelBuff, int nCel, int nWid
 	if(!nDataSize)
 		nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
 
-	tmp = (BYTE *)gpBuffer;
 	Cl2DecDatFrm1(
-		&tmp[sx + screen_y_times_768[sy - 16 * always_0]],
+		&gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]],
 		&pRLEBytes[hdr],
 		nDataSize - hdr,
 		nWidth);
@@ -2637,7 +2623,7 @@ void __fastcall Cl2DecDatFrm1(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, i
 void __fastcall Cl2DecodeFrm2(char col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int hdr, nDataSize;
-	BYTE *pRLEBytes, *tmp;
+	BYTE *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer != NULL);
@@ -2665,9 +2651,8 @@ void __fastcall Cl2DecodeFrm2(char col, int sx, int sy, BYTE *pCelBuff, int nCel
 	if(!nDataSize)
 		nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
 
-	tmp = (BYTE *)gpBuffer;
 	Cl2DecDatFrm2(
-		&tmp[sx + screen_y_times_768[sy - 16 * always_0]],
+		&gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]],
 		&pRLEBytes[hdr],
 		nDataSize - hdr,
 		nWidth,
@@ -2839,7 +2824,7 @@ void __fastcall Cl2DecDatFrm2(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, i
 void __fastcall Cl2DecodeFrm3(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir, char light)
 {
 	int hdr, idx, nDataSize;
-	BYTE *pRLEBytes, *tmp;
+	BYTE *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer != NULL);
@@ -2873,9 +2858,8 @@ void __fastcall Cl2DecodeFrm3(int sx, int sy, BYTE *pCelBuff, int nCel, int nWid
 	if(light >= 4)
 		idx += (light - 1) << 8;
 
-	tmp = (BYTE *)gpBuffer;
 	Cl2DecDatLightTbl1(
-		&tmp[sx + screen_y_times_768[sy - 16 * always_0]],
+		&gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]],
 		&pRLEBytes[hdr],
 		nDataSize - hdr,
 		nWidth,
@@ -3037,7 +3021,7 @@ void __fastcall Cl2DecDatLightTbl1(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSi
 void __fastcall Cl2DecodeLightTbl(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int hdr, nDataSize;
-	BYTE *pRLEBytes, *pDecodeTo, *tmp;
+	BYTE *pRLEBytes, *pDecodeTo;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer != NULL);
@@ -3065,8 +3049,7 @@ void __fastcall Cl2DecodeLightTbl(int sx, int sy, BYTE *pCelBuff, int nCel, int 
 	if(!nDataSize)
 		nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
 
-	tmp = (BYTE *)gpBuffer;
-	pDecodeTo = &tmp[sx + screen_y_times_768[sy - 16 * always_0]];
+	pDecodeTo = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	if(light_table_index)
 		Cl2DecDatLightTbl1(pDecodeTo, &pRLEBytes[hdr], nDataSize - hdr, nWidth, (BYTE *)&pLightTbl[light_table_index * 256]);
@@ -3078,7 +3061,7 @@ void __fastcall Cl2DecodeLightTbl(int sx, int sy, BYTE *pCelBuff, int nCel, int 
 void __fastcall Cl2DecodeFrm4(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int hdr, nDataSize;
-	BYTE *pRLEBytes, *tmp;
+	BYTE *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer != NULL);
@@ -3106,9 +3089,8 @@ void __fastcall Cl2DecodeFrm4(int sx, int sy, BYTE *pCelBuff, int nCel, int nWid
 	if(!nDataSize)
 		nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
 
-	tmp = (BYTE *)gpBuffer;
 	Cl2DecDatFrm4(
-		&tmp[sx + screen_y_times_768[sy - 16 * always_0]],
+		&gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]],
 		&pRLEBytes[hdr],
 		nDataSize - hdr,
 		nWidth);
@@ -3272,7 +3254,7 @@ void __fastcall Cl2DecDatFrm4(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, i
 void __fastcall Cl2DecodeClrHL(char col, int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int hdr, nDataSize;
-	BYTE *pRLEBytes, *tmp;
+	BYTE *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer != NULL);
@@ -3300,10 +3282,9 @@ void __fastcall Cl2DecodeClrHL(char col, int sx, int sy, BYTE *pCelBuff, int nCe
 	if(!nDataSize)
 		nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
 
-	tmp = (BYTE *)gpBuffer;
 	gpBufEnd -= 768;
 	Cl2DecDatClrHL(
-		&tmp[sx + screen_y_times_768[sy - 16 * always_0]],
+		&gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]],
 		&pRLEBytes[hdr],
 		nDataSize - hdr,
 		nWidth,
@@ -3489,7 +3470,7 @@ void __fastcall Cl2DecDatClrHL(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, 
 void __fastcall Cl2DecodeFrm5(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir, char light)
 {
 	int hdr, idx, nDataSize;
-	BYTE *pRLEBytes, *tmp;
+	BYTE *pRLEBytes;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer != NULL);
@@ -3523,9 +3504,8 @@ void __fastcall Cl2DecodeFrm5(int sx, int sy, BYTE *pCelBuff, int nCel, int nWid
 	if(light >= 4)
 		idx += (light - 1) << 8;
 
-	tmp = (BYTE *)gpBuffer;
 	Cl2DecDatLightTbl2(
-		&tmp[sx + screen_y_times_768[sy - 16 * always_0]],
+		&gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]],
 		&pRLEBytes[hdr],
 		nDataSize - hdr,
 		nWidth,
@@ -3701,7 +3681,7 @@ void __fastcall Cl2DecDatLightTbl2(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSi
 void __fastcall Cl2DecodeFrm6(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int always_0, int dir)
 {
 	int hdr, nDataSize;
-	BYTE *pRLEBytes, *pDecodeTo, *tmp;
+	BYTE *pRLEBytes, *pDecodeTo;
 	DWORD *pFrameTable;
 
 	/// ASSERT: assert(gpBuffer != NULL);
@@ -3729,8 +3709,7 @@ void __fastcall Cl2DecodeFrm6(int sx, int sy, BYTE *pCelBuff, int nCel, int nWid
 	if(!nDataSize)
 		nDataSize = pFrameTable[nCel + 1] - pFrameTable[nCel];
 
-	tmp = (BYTE *)gpBuffer;
-	pDecodeTo = &tmp[sx + screen_y_times_768[sy - 16 * always_0]];
+	pDecodeTo = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	if(light_table_index)
 		Cl2DecDatLightTbl2(pDecodeTo, &pRLEBytes[hdr], nDataSize - hdr, nWidth, (BYTE *)&pLightTbl[light_table_index * 256]);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -281,8 +281,8 @@ void __cdecl DrawInv()
 
 			CelDecodeHdrLightTrans(
 			    frame_width == INV_SLOT_SIZE_PX
-			        ? (BYTE *)&gpBuffer->row[160].pixels[581]
-			        : (BYTE *)&gpBuffer->row[160].pixels[567],
+			        ? &gpBuffer[SCREENXY(581, 160)]
+			        : &gpBuffer[SCREENXY(567, 160)],
 			    (BYTE *)pCursCels, frame, frame_width, 0, 8);
 
 			cel_transparency_active = 0;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3765,8 +3765,8 @@ void __fastcall DrawULine(int y)
 	char *v2;      // edi
 	signed int v3; // edx
 
-	v1 = &gpBuffer->row[25].pixels[26];
-	v2 = &gpBuffer->row_unused_1[0].pixels[screen_y_times_768[SStringY[y] + 198] + 26];
+	v1 = (char *)&gpBuffer[SCREENXY(26, 25)];
+	v2 = (char *)&gpBuffer[screen_y_times_768[SStringY[y] + 198] + 26 + 64];
 	v3 = 3;
 	do {
 		qmemcpy(v2, v1, 0x10A); /* find real fix */

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -96,14 +96,13 @@ void __cdecl DrawQTextBack()
 
 void __fastcall PrintQTextChr(int sx, int sy, BYTE *pCelBuff, int nCel)
 {
-	BYTE *dst, *pStart, *pEnd, *end, *tmp;
+	BYTE *dst, *pStart, *pEnd, *end;
 
 	/// ASSERT: assert(gpBuffer);
 
-	tmp = (BYTE *)gpBuffer;
-	dst = &tmp[sx + screen_y_times_768[sy]];
-	pStart = &tmp[screen_y_times_768[209]];
-	pEnd = &tmp[screen_y_times_768[469]];
+	dst = &gpBuffer[sx + screen_y_times_768[sy]];
+	pStart = &gpBuffer[screen_y_times_768[209]];
+	pEnd = &gpBuffer[screen_y_times_768[469]];
 
 #if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
 	__asm {

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -2463,7 +2463,7 @@ void __fastcall DrawZoom(int x, int y)
 LABEL_24:
 	v11 = (_WORD *)((char *)gpBuffer + a6b);
 	v12 = (char *)gpBuffer + a5a;
-	v13 = &gpBuffer->row_unused_1[1].col_unused_1[a6b];
+	v13 = (char *)&gpBuffer[a6b + 768];
 	v14 = 176;
 	do {
 		v15 = v19;
@@ -2499,7 +2499,7 @@ void __cdecl ClearScreenBuffer()
 	j_lock_buf_priv(3);
 
 	for (i = 0; i < 480; i++)
-		memset(gpBuffer->row[i].pixels, 0, 640);
+		memset(&gpBuffer[SCREENXY(0, i)], 0, 640);
 
 	j_unlock_buf_priv(3);
 }
@@ -2627,7 +2627,7 @@ void __cdecl scrollrt_draw_cursor_back_buffer()
 	if (sgdwCursWdt) {
 		v1 = sgdwCursY;
 		v2 = sgSaveBack;
-		v3 = &gpBuffer->row[sgdwCursY].pixels[sgdwCursX];
+		v3 = (char *)&gpBuffer[SCREENXY(sgdwCursX, sgdwCursY)];
 		v4 = sgdwCursHgt;
 		if (sgdwCursHgt) {
 			v5 = sgdwCursHgt;
@@ -2699,7 +2699,7 @@ void __cdecl scrollrt_draw_cursor_item()
 				v14 = sgSaveBack;
 				v6 = 1 - v3 + v5;
 				sgdwCursHgt = v6;
-				v7 = &gpBuffer->row[v3].pixels[v2 & 0xFFFFFFFC];
+				v7 = (char *)&gpBuffer[SCREENXY(v2 & 0xFFFFFFFC, v3)];
 				if (v6) {
 					v8 = v6;
 					do {

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -311,7 +311,7 @@ void __fastcall town_draw_lower(int x, int y, int sx, int sy, int a5, int some_f
 		if (y >= 0 && y < MAXDUNY && x >= 0 && x < MAXDUNX && (level_cel_block = dPiece[x][y]) != 0) {
 			v6 = sy;
 			v7 = &screen_y_times_768[sy];
-			a1 = (unsigned char *)&gpBuffer->row_unused_1[0].col_unused_1[*v7 + 32 + sx];
+			a1 = (unsigned char *)&gpBuffer[*v7 + 32 + sx];
 			v25 = 1;
 			v8 = (char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(x, y);
 			do {
@@ -770,7 +770,7 @@ void __fastcall town_draw_upper(int x, int y, int sx, int sy, int a5, int a6, in
 	int v14;            // esi
 	int v15;            // edi
 	int v16;            // eax
-	Screen *v17;        // eax
+	BYTE *v17;        // eax
 	unsigned char *v18; // ebx
 	char *v19;          // edi
 	int v20;            // eax
@@ -807,7 +807,7 @@ void __fastcall town_draw_upper(int x, int y, int sx, int sy, int a5, int a6, in
 			v10 = v9 == 0;
 			v11 = sy;
 			if (!v10) {
-				a1 = (int *)&gpBuffer->row_unused_1[0].col_unused_1[sx + 32 + screen_y_times_768[sy]];
+				a1 = (int *)&gpBuffer[sx + 32 + screen_y_times_768[sy]];
 				sxa = 0;
 				v12 = &dpiece_defs_map_1[0][16 * gendung_get_dpiece_num_from_coord(x, y) + 1];
 				do {
@@ -1164,7 +1164,7 @@ void __fastcall T_DrawZoom(int x, int y)
 LABEL_24:
 	v11 = (_WORD *)((char *)gpBuffer + a5a);
 	v12 = (char *)gpBuffer + a6b;
-	v13 = &gpBuffer->row_unused_1[1].col_unused_1[a5a];
+	v13 = (char *)&gpBuffer[a5a + 768];
 	v14 = 176;
 	do {
 		v15 = v19;

--- a/defs.h
+++ b/defs.h
@@ -83,6 +83,8 @@
 #define PAL16_RED		224
 #define PAL16_GRAY		240
 
+#define SCREENXY(x, y)	((x) + 64 + (((y) + 160) * 768))
+
 #ifndef INVALID_FILE_ATTRIBUTES
 #define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
 #endif

--- a/structs.h
+++ b/structs.h
@@ -1188,22 +1188,6 @@ typedef struct DeadStruct {
 } DeadStruct;
 
 //////////////////////////////////////////////////
-// dx
-//////////////////////////////////////////////////
-
-typedef struct ScreenRow {
-	char col_unused_1[64];
-	char pixels[640];
-	char col_unused_2[64];
-} ScreenRow;
-
-typedef struct Screen { /* create union for work data vs visible data */
-	ScreenRow row_unused_1[160];
-	ScreenRow row[480];
-	ScreenRow row_unused_2[16];
-} Screen;
-
-//////////////////////////////////////////////////
 // diabloui
 //////////////////////////////////////////////////
 


### PR DESCRIPTION
Finally getting this done and out of the way. This solves issue #385 and makes PrintQTextChr bin exact as well. For referencing coordinates, use the macro `SCREENXY(x, y)`.