### PR TITLE
Clean CPrintString + Font index

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -19,7 +19,7 @@ int dropGoldValue; // idb
 BOOL drawmanaflag; // idb
 BOOL chrbtnactive;
 char sgszTalkMsg[80];
-void *pPanelText;
+BYTE *pPanelText;
 int frame_4B8800; // idb
 char *pLifeBuff;
 void *pBtmBuff;
@@ -109,33 +109,23 @@ const int lineoffset[25] = {
 	768 * 606 + 241,
 	768 * 617 + 241
 };
-const unsigned char fontidx[256] = {
-	0, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 32, 33, 34, 35, 36, 37, 38, 39,
-	40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
-	50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-	60, 61, 62, 63, 64, 65, 66, 67, 68, 69,
-	70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-	80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
-	90, 91, 92, 93, 94, 95, 96, 97, 98, 99,
-	100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
-	110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
-	120, 121, 122, 123, 124, 125, 126, 1, 67, 117,
-	101, 97, 97, 97, 97, 99, 101, 101, 101, 105,
-	105, 105, 65, 65, 69, 97, 65, 111, 111, 111,
-	117, 117, 121, 79, 85, 99, 76, 89, 80, 102,
-	97, 105, 111, 117, 110, 78, 97, 111, 63, 1,
-	1, 1, 1, 33, 60, 62, 111, 43, 50, 51,
-	39, 117, 80, 46, 44, 49, 48, 62, 1, 1,
-	1, 63, 65, 65, 65, 65, 65, 65, 65, 67,
-	69, 69, 69, 69, 73, 73, 73, 73, 68, 78,
-	79, 79, 79, 79, 79, 88, 48, 85, 85, 85,
-	85, 89, 98, 66, 97, 97, 97, 97, 97, 97,
-	97, 99, 101, 101, 101, 101, 105, 105, 105, 105,
-	111, 110, 111, 111, 111, 111, 111, 47, 48, 117,
-	117, 117, 117, 121, 98, 121
+const unsigned char gbFontTransTbl[256] = {
+	'\0', 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+	0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+	' ',  '!',  '\"', '#',  '$',  '%',  '&',  '\'', '(',  ')',  '*',  '+',  ',',  '-',  '.',  '/',
+	'0',  '1',  '2',  '3',  '4',  '5',  '6',  '7',  '8',  '9',  ':',  ';',  '<',  '=',  '>',  '?',
+	'@',  'A',  'B',  'C',  'D',  'E',  'F',  'G',  'H',  'I',  'J',  'K',  'L',  'M',  'N',  'O',
+	'P',  'Q',  'R',  'S',  'T',  'U',  'V',  'W',  'X',  'Y',  'Z',  '[',  '\\', ']',  '^',  '_',
+	'`',  'a',  'b',  'c',  'd',  'e',  'f',  'g',  'h',  'i',  'j',  'k',  'l',  'm',  'n',  'o',
+	'p',  'q',  'r',  's',  't',  'u',  'v',  'w',  'x',  'y',  'z',  '{',  '|',  '}',  '~',  0x01,
+	'C',  'u',  'e',  'a',  'a',  'a',  'a',  'c',  'e',  'e',  'e',  'i',  'i',  'i',  'A',  'A',
+	'E',  'a',  'A',  'o',  'o',  'o',  'u',  'u',  'y',  'O',  'U',  'c',  'L',  'Y',  'P',  'f',
+	'a',  'i',  'o',  'u',  'n',  'N',  'a',  'o',  '?',  0x01, 0x01, 0x01, 0x01, '!',  '<',  '>',
+	'o',  '+',  '2',  '3',  '\'', 'u',  'P',  '.',  ',',  '1',  '0',  '>',  0x01, 0x01, 0x01, '?',
+	'A',  'A',  'A',  'A',  'A',  'A',  'A',  'C',  'E',  'E',  'E',  'E',  'I',  'I',  'I',  'I',
+	'D',  'N',  'O',  'O',  'O',  'O',  'O',  'X',  '0',  'U',  'U',  'U',  'U',  'Y',  'b',  'B',
+	'a',  'a',  'a',  'a',  'a',  'a',  'a',  'c',  'e',  'e',  'e',  'e',  'i',  'i',  'i',  'i',
+	'o',  'n',  'o',  'o',  'o',  'o',  'o',  '/',  '0',  'u',  'u',  'u',  'u',  'y',  'b',  'y'
 };
 
 /* data */
@@ -660,162 +650,296 @@ void __fastcall ToggleSpell(int slot)
 }
 // 52571C: using guessed type int drawpanflag;
 
-void __fastcall CPrintString(int No, unsigned int glyph, unsigned char col)
+void __fastcall CPrintString(int nOffset, int nCel, char col)
 {
-	int *v3;          // ebx
-	char *v4;         // esi
-	char *v5;         // edi
-	int v6;           // ebx
-	signed int v7;    // edx
-	unsigned int v8;  // eax
-	unsigned int v9;  // ecx
-	char v10;         // cf
-	unsigned int v11; // ecx
-	signed int v12;   // edx
-	int v13;          // eax
-	int v14;          // ecx
-	char v15;         // al
-	signed int v16;   // edx
-	int v17;          // eax
-	int v18;          // ecx
-	char v19;         // al
-	signed int v20;   // edx
-	int v21;          // eax
-	int v22;          // ecx
-	char v23;         // al
+	/// ASSERT: assert(gpBuffer);
 
-	v3 = (int *)((char *)pPanelText + 4 * glyph);
-	v4 = (char *)pPanelText + *v3;
-	v5 = (char *)gpBuffer + No;
-	v6 = (int)&v4[v3[1] - *v3];
-	if ((_BYTE)col) {
-		if ((unsigned char)col == 1) {
-			do {
-				v12 = 13;
-				do {
-					while (1) {
-						v13 = (unsigned char)*v4++;
-						if ((v13 & 0x80u) == 0)
-							break;
-						_LOBYTE(v13) = -(char)v13;
-						v5 += v13;
-						v12 -= v13;
-						if (!v12)
-							goto LABEL_28;
-					}
-					v12 -= v13;
-					v14 = v13;
-					do {
-						v15 = *v4++;
-						if ((unsigned char)v15 > 0xFDu) {
-							v15 = -65;
-						} else if ((unsigned char)v15 >= 0xF0u) {
-							v15 -= 62;
-						}
-						*v5++ = v15;
-						--v14;
-					} while (v14);
-				} while (v12);
-			LABEL_28:
-				v5 -= 781;
-			} while ((char *)v6 != v4);
-		} else if ((unsigned char)col == 2) {
-			do {
-				v16 = 13;
-				do {
-					while (1) {
-						v17 = (unsigned char)*v4++;
-						if ((v17 & 0x80u) == 0)
-							break;
-						_LOBYTE(v17) = -(char)v17;
-						v5 += v17;
-						v16 -= v17;
-						if (!v16)
-							goto LABEL_39;
-					}
-					v16 -= v17;
-					v18 = v17;
-					do {
-						v19 = *v4++;
-						if ((unsigned char)v19 >= 0xF0u)
-							v19 -= 16;
-						*v5++ = v19;
-						--v18;
-					} while (v18);
-				} while (v16);
-			LABEL_39:
-				v5 -= 781;
-			} while ((char *)v6 != v4);
-		} else {
-			do {
-				v20 = 13;
-				do {
-					while (1) {
-						v21 = (unsigned char)*v4++;
-						if ((v21 & 0x80u) == 0)
-							break;
-						_LOBYTE(v21) = -(char)v21;
-						v5 += v21;
-						v20 -= v21;
-						if (!v20)
-							goto LABEL_52;
-					}
-					v20 -= v21;
-					v22 = v21;
-					do {
-						v23 = *v4++;
-						if ((unsigned char)v23 >= 0xF0u) {
-							if ((unsigned char)v23 >= 0xFEu)
-								v23 = -49;
-							else
-								v23 -= 46;
-						}
-						*v5++ = v23;
-						--v22;
-					} while (v22);
-				} while (v20);
-			LABEL_52:
-				v5 -= 781;
-			} while ((char *)v6 != v4);
-		}
-	} else {
-		do {
-			v7 = 13;
-			do {
-				while (1) {
-					v8 = (unsigned char)*v4++;
-					if ((v8 & 0x80u) == 0)
-						break;
-					_LOBYTE(v8) = -(char)v8;
-					v5 += v8;
-					v7 -= v8;
-					if (!v7)
-						goto LABEL_15;
-				}
-				v7 -= v8;
-				v9 = v8 >> 1;
-				if (v8 & 1) {
-					*v5++ = *v4++;
-					if (!v9)
-						continue;
-				}
-				v10 = v9 & 1;
-				v11 = v8 >> 2;
-				if (v10) {
-					*(_WORD *)v5 = *(_WORD *)v4;
-					v4 += 2;
-					v5 += 2;
-					if (!v11)
-						continue;
-				}
-				qmemcpy(v5, v4, 4 * v11);
-				v4 += 4 * v11;
-				v5 += 4 * v11;
-			} while (v7);
-		LABEL_15:
-			v5 -= 781;
-		} while ((char *)v6 != v4);
+#if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
+	__asm {
+		mov		ebx, pPanelText
+		mov		eax, nCel
+		shl		eax, 2
+		add		ebx, eax
+		mov		edx, [ebx+4]
+		sub		edx, [ebx]
+		mov		esi, pPanelText
+		add		esi, [ebx]
+		mov		edi, gpBuffer
+		add		edi, nOffset
+		mov		ebx, edx
+		add		ebx, esi
+		xor		edx, edx
+		mov		dl, col
+		cmp		edx, COL_WHITE
+		jz		c0_label1
+		cmp		edx, COL_BLUE
+		jz		c1_label1
+		cmp		edx, COL_RED
+		jz		c2_label1
+		jmp		d_label1
+
+	// Case 0
+	c0_label1:
+		mov		edx, 13
+	c0_label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		c0_label6
+		sub		edx, eax
+		mov		ecx, eax
+		shr		ecx, 1
+		jnb		c0_label3
+		movsb
+		jecxz	c0_label5
+	c0_label3:
+		shr		ecx, 1
+		jnb		c0_label4
+		movsw
+		jecxz	c0_label5
+	c0_label4:
+		rep movsd
+	c0_label5:
+		or		edx, edx
+		jz		c0_label7
+		jmp		c0_label2
+	c0_label6:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		c0_label2
+	c0_label7:
+		sub		edi, 768 + 13
+		cmp		ebx, esi
+		jnz		c0_label1
+		jmp		labret
+
+	// Case 1
+	c1_label1:
+		mov		edx, 13
+	c1_label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		c1_label6
+		sub		edx, eax
+		mov		ecx, eax
+	c1_label3:
+		lodsb
+		cmp		al, PAL16_GRAY + 13
+		ja		c1_label4
+		cmp		al, PAL16_GRAY
+		jb		c1_label5
+		sub		al, PAL16_GRAY - (PAL16_BLUE + 2)
+		jmp		c1_label5
+	c1_label4:
+		mov		al, PAL16_BLUE + 15
+	c1_label5:
+		stosb
+		loop	c1_label3
+		or		edx, edx
+		jz		c1_label7
+		jmp		c1_label2
+	c1_label6:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		c1_label2
+	c1_label7:
+		sub		edi, 768 + 13
+		cmp		ebx, esi
+		jnz		c1_label1
+		jmp		labret
+
+	// Case 2
+	c2_label1:
+		mov		edx, 13
+	c2_label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		c2_label5
+		sub		edx, eax
+		mov		ecx, eax
+	c2_label3:
+		lodsb
+		cmp		al, PAL16_GRAY
+		jb		c2_label4
+		sub		al, PAL16_GRAY - PAL16_RED
+	c2_label4:
+		stosb
+		loop	c2_label3
+		or		edx, edx
+		jz		c2_label6
+		jmp		c2_label2
+	c2_label5:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		c2_label2
+	c2_label6:
+		sub		edi, 768 + 13
+		cmp		ebx, esi
+		jnz		c2_label1
+		jmp		labret
+
+	// Default
+	d_label1:
+		mov		edx, 13
+	d_label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		d_label6
+		sub		edx, eax
+		mov		ecx, eax
+	d_label3:
+		lodsb
+		cmp		al, PAL16_GRAY
+		jb		d_label5
+		cmp		al, PAL16_GRAY + 14
+		jnb		d_label4
+		sub		al, PAL16_GRAY - (PAL16_YELLOW + 2)
+		jmp		d_label5
+	d_label4:
+		mov		al, PAL16_YELLOW + 15
+	d_label5:
+		stosb
+		loop	d_label3
+		or		edx, edx
+		jz		d_label7
+		jmp		d_label2
+	d_label6:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		d_label2
+	d_label7:
+		sub		edi, 768 + 13
+		cmp		ebx, esi
+		jnz		d_label1
+
+	labret:
 	}
+#else
+	int i;
+	BYTE width, pix;
+	BYTE *src, *dst, *end;
+	DWORD *pFrameTable;
+
+	pFrameTable = (DWORD *)&pPanelText[4 * nCel];
+	src = &pPanelText[pFrameTable[0]];
+	end = &src[pFrameTable[1] - pFrameTable[0]];
+	dst = &gpBuffer[nOffset];
+
+	switch(col) {
+	case COL_WHITE:
+		for(; src != end; dst -= 768 + 13) {
+			for(i = 13; i;) {
+				width = *src++;
+				if(!(width & 0x80)) {
+					i -= width;
+					if(width & 1) {
+						dst[0] = src[0];
+						src++;
+						dst++;
+					}
+					width >>= 1;
+					if(width & 1) {
+						dst[0] = src[0];
+						dst[1] = src[1];
+						src += 2;
+						dst += 2;
+					}
+					width >>= 1;
+					while(width) {
+						dst[0] = src[0];
+						dst[1] = src[1];
+						dst[2] = src[2];
+						dst[3] = src[3];
+						src += 4;
+						dst += 4;
+						width--;
+					}
+				} else {
+					width = -(char)width;
+					dst += width;
+					i -= width;
+				}
+			}
+		}
+		break;
+	case COL_BLUE:
+		for(; src != end; dst -= 768 + 13) {
+			for(i = 13; i;) {
+				width = *src++;
+				if(!(width & 0x80)) {
+					i -= width;
+					while(width) {
+						pix = *src++;
+						if(pix > PAL16_GRAY + 13)
+							pix = PAL16_BLUE + 15;
+						else if(pix >= PAL16_GRAY)
+							pix -= PAL16_GRAY - (PAL16_BLUE + 2);
+						*dst++ = pix;
+						width--;
+					}
+				} else {
+					width = -(char)width;
+					dst += width;
+					i -= width;
+				}
+			}
+		}
+		break;
+	case COL_RED:
+		for(; src != end; dst -= 768 + 13) {
+			for(i = 13; i;) {
+				width = *src++;
+				if(!(width & 0x80)) {
+					i -= width;
+					while(width) {
+						pix = *src++;
+						if(pix >= PAL16_GRAY)
+							pix -= PAL16_GRAY - PAL16_RED;
+						*dst++ = pix;
+						width--;
+					}
+				} else {
+					width = -(char)width;
+					dst += width;
+					i -= width;
+				}
+			}
+		}
+		break;
+	default:
+		for(; src != end; dst -= 768 + 13) {
+			for(i = 13; i;) {
+				width = *src++;
+				if(!(width & 0x80)) {
+					i -= width;
+					while(width) {
+						pix = *src++;
+						if(pix >= PAL16_GRAY) {
+							if(pix >= PAL16_GRAY + 14)
+								pix = PAL16_YELLOW + 15;
+							else
+								pix -= PAL16_GRAY - (PAL16_YELLOW + 2);
+						}
+						*dst++ = pix;
+						width--;
+					}
+				} else {
+					width = -(char)width;
+					dst += width;
+					i -= width;
+				}
+			}
+		}
+		break;
+	}
+#endif
 }
 
 void __fastcall AddPanelString(char *str, BOOL just)
@@ -1558,7 +1682,7 @@ int __fastcall control_WriteStringToBuffer(char *str)
 		if (!*str)
 			return 1;
 		++str;
-		v1 += fontkern[fontframe[fontidx[v2]]];
+		v1 += fontkern[fontframe[gbFontTransTbl[v2]]];
 	} while (v1 < 125);
 	return 0;
 }
@@ -1694,7 +1818,7 @@ void __fastcall control_print_info_str(int y, char *str, BOOLEAN center, int lin
 			goto LABEL_14;
 		do {
 			++v8;
-			v7 += fontkern[fontframe[fontidx[v6]]] + 2;
+			v7 += fontkern[fontframe[gbFontTransTbl[v6]]] + 2;
 			v6 = *v8;
 		} while (*v8);
 		if (v7 < 288)
@@ -1707,7 +1831,7 @@ void __fastcall control_print_info_str(int y, char *str, BOOLEAN center, int lin
 		if (!*v5)
 			break;
 		++v5;
-		v9 = fontidx[v11];
+		v9 = gbFontTransTbl[v11];
 		_LOBYTE(v9) = fontframe[v9];
 		v10 = (unsigned char)v9;
 		v4 += fontkern[(unsigned char)v9] + 2;
@@ -1732,7 +1856,7 @@ void __fastcall PrintGameStr(int x, int y, char *str, int color)
 	v5 = screen_y_times_768[y + 160] + x + 64;
 	for (i = *str; *v4; i = *v4) {
 		++v4;
-		v7 = fontframe[fontidx[i]];
+		v7 = fontframe[gbFontTransTbl[i]];
 		if (v7)
 			CPrintString(v5, v7, color);
 		v5 += fontkern[v7] + 1;
@@ -1989,7 +2113,7 @@ void __fastcall ADD_PlrStringXY(int x, int y, int width, char *pszStr, char col)
 		v11 = *pszStr;
 		do {
 			++v6;
-			v10 += fontkern[fontframe[fontidx[v11]]] + 1;
+			v10 += fontkern[fontframe[gbFontTransTbl[v11]]] + 1;
 			v11 = *v6;
 		} while (*v6);
 	}
@@ -1998,7 +2122,7 @@ void __fastcall ADD_PlrStringXY(int x, int y, int width, char *pszStr, char col)
 	widthb = v9 + widtha;
 	while (v7) {
 		++pszStr;
-		v12 = fontframe[fontidx[v7]];
+		v12 = fontframe[gbFontTransTbl[v7]];
 		v13 = v12;
 		v9 += fontkern[v12] + 1;
 		if (v12) {
@@ -2035,7 +2159,7 @@ void __fastcall MY_PlrStringXY(int x, int y, int width, char *pszStr, char col, 
 		v11 = *pszStr;
 		do {
 			++v10;
-			v8 += base + fontkern[fontframe[fontidx[v11]]];
+			v8 += base + fontkern[fontframe[gbFontTransTbl[v11]]];
 			v11 = *v10;
 		} while (*v10);
 	}
@@ -2044,7 +2168,7 @@ void __fastcall MY_PlrStringXY(int x, int y, int width, char *pszStr, char col, 
 	widthb = v16 + widtha;
 	while (v7) {
 		++v6;
-		v12 = fontframe[fontidx[v7]];
+		v12 = fontframe[gbFontTransTbl[v7]];
 		v13 = v12;
 		v16 += base + fontkern[v12];
 		if (v12) {
@@ -2413,7 +2537,7 @@ void __fastcall PrintSBookStr(int x, int y, BOOLEAN cjustflag, char *pszStr, int
 			goto LABEL_14;
 		do {
 			++v9;
-			v6 += fontkern[fontframe[fontidx[v8]]] + 1;
+			v6 += fontkern[fontframe[gbFontTransTbl[v8]]] + 1;
 			v8 = *v9;
 		} while (*v9);
 		if (v6 < 222)
@@ -2426,7 +2550,7 @@ void __fastcall PrintSBookStr(int x, int y, BOOLEAN cjustflag, char *pszStr, int
 		if (!*v5)
 			break;
 		++v5;
-		v10 = fontframe[fontidx[v12]];
+		v10 = fontframe[gbFontTransTbl[v12]];
 		v11 = v10;
 		v7 += fontkern[v10] + 1;
 		if (v10) {
@@ -2496,7 +2620,7 @@ void __fastcall DrawGoldSplit(int amount)
 		v3 = tempstr[0];
 		for (i = 0; i < v3; v3 = tempstr[i]) {
 			++i;
-			screen_x += fontkern[fontframe[fontidx[(unsigned char)v3]]] + 1;
+			screen_x += fontkern[fontframe[gbFontTransTbl[(unsigned char)v3]]] + 1;
 		}
 		screen_xa = screen_x + 452;
 	}
@@ -2701,7 +2825,7 @@ char *__fastcall control_print_talk_msg(char *msg, int x, int y, int *a4, int ju
 	if (!v7)
 		return 0;
 	while (1) {
-		v10 = fontframe[fontidx[v7]];
+		v10 = fontframe[gbFontTransTbl[v7]];
 		v11 = v10;
 		a3 = v8 + fontkern[v10] + 1;
 		if (a3 > 514)

--- a/Source/control.h
+++ b/Source/control.h
@@ -15,7 +15,7 @@ extern int lvlbtndown;    // weak
 extern int dropGoldValue; // idb
 extern BOOL drawmanaflag; // idb
 extern BOOL chrbtnactive;
-extern void *pPanelText;
+extern BYTE *pPanelText;
 extern int frame_4B8800; // idb
 extern char *pLifeBuff;
 extern void *pBtmBuff;
@@ -60,7 +60,7 @@ void __cdecl DrawSpellList();
 void __cdecl SetSpell();
 void __fastcall SetSpeedSpell(int slot);
 void __fastcall ToggleSpell(int slot);
-void __fastcall CPrintString(int No, unsigned int glyph, unsigned char col); /* check arg names */
+void __fastcall CPrintString(int nOffset, int nCel, char col);
 void __fastcall AddPanelString(char *str, BOOL just);
 void __cdecl ClearPanel();
 void __fastcall DrawPanelBox(int x, int y, int w, int h, int sx, int sy);
@@ -123,7 +123,7 @@ void __fastcall control_up_down(char a1);
 extern const unsigned char fontframe[127];
 extern const unsigned char fontkern[68];
 extern const int lineoffset[25];
-extern const unsigned char fontidx[256];
+extern const unsigned char gbFontTransTbl[256];
 
 /* data */
 

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -135,7 +135,7 @@ void __cdecl DrawDiabloMsg()
 		goto LABEL_27;
 	do {
 		v12 = (unsigned char)tempstr[v11++];
-		v10 += fontkern[fontframe[fontidx[v12]]] + 1;
+		v10 += fontkern[fontframe[gbFontTransTbl[v12]]] + 1;
 	} while (v11 < v9);
 	if (v10 < 442)
 	LABEL_27:
@@ -143,7 +143,7 @@ void __cdecl DrawDiabloMsg()
 	v13 = 0;
 	if (v9 > 0) {
 		do {
-			v14 = fontframe[fontidx[(unsigned char)tempstr[v13]]];
+			v14 = fontframe[gbFontTransTbl[(unsigned char)tempstr[v13]]];
 			if (v14)
 				CPrintString(v8, v14, 3);
 			++v13;

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -63,7 +63,7 @@ void __fastcall gmenu_print_text(int x, int y, char *pszStr)
 	v5 = x;
 	for (i = *pszStr; *v3; i = *v3) {
 		++v3;
-		v7 = lfontframe[fontidx[i]];
+		v7 = lfontframe[gbFontTransTbl[i]];
 		if (v7)
 			CelDecodeLightOnly(v5, v4, (BYTE *)BigTGold_cel, v7, 46);
 		v5 += lfontkern[v7] + 2;
@@ -280,7 +280,7 @@ int __fastcall gmenu_get_lfont(TMenuItem *pItem)
 	if (pItem->dwFlags & 0x40000000)
 		return 490;
 	v2 = pItem->pszStr;
-	for (i = 0;; i += lfontkern[lfontframe[fontidx[v4]]] + 2) {
+	for (i = 0;; i += lfontkern[lfontframe[gbFontTransTbl[v4]]] + 2) {
 		v4 = *v2;
 		if (!*v2)
 			break;

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -129,7 +129,7 @@ void __cdecl DrawHelp()
 					}
 					v5 = *v1;
 					tempstr[v2++] = *v1++;
-					v3 += fontkern[fontframe[fontidx[v5]]] + 1;
+					v3 += fontkern[fontframe[gbFontTransTbl[v5]]] + 1;
 					v4 = *v1;
 					if (*v1 == ('|')) {
 						if (v3 < 577)
@@ -173,7 +173,7 @@ void __cdecl DrawHelp()
 				}
 				v10 = *v1;
 				tempstr[v7++] = *v1++;
-				v8 += fontkern[fontframe[fontidx[v10]]] + 1;
+				v8 += fontkern[fontframe[gbFontTransTbl[v10]]] + 1;
 				v9 = *v1;
 				if (*v1 == ('|')) {
 					if (v8 < 577)
@@ -212,7 +212,7 @@ void __fastcall DrawHelpLine(int always_0, int help_line_nr, char *text, text_co
 	v5 = screen_y_times_768[SStringY[help_line_nr] + 204] + always_0 + 96;
 	for (i = *text; *text; i = *text) {
 		++text;
-		v7 = fontframe[fontidx[i]];
+		v7 = fontframe[gbFontTransTbl[i]];
 		v8 = v7;
 		v4 += fontkern[v7] + 1;
 		if (v7) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -430,7 +430,7 @@ void __cdecl DrawInvBelt()
 		    && plr[myplr].SpdList[i]._iStatFlag
 		    && plr[myplr].SpdList[i]._itype != ITYPE_GOLD) {
 			fi = i + 49;
-			ff = fontframe[fontidx[fi]];
+			ff = fontframe[gbFontTransTbl[fi]];
 			CPrintString(InvRect[i + 65].X + 64 + screen_y_times_768[InvRect[i + 65].Y + 159] - fontkern[ff] + 28, ff, 0);
 		}
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3730,7 +3730,7 @@ void __fastcall PrintUString(int x, int y, int cjustflag, char *str, int col)
 			goto LABEL_16;
 		do {
 			v11 = (unsigned char)str[v9++];
-			v10 += fontkern[fontframe[fontidx[v11]]] + 1;
+			v10 += fontkern[fontframe[gbFontTransTbl[v11]]] + 1;
 		} while (v9 < v15);
 		if (v10 < 257)
 		LABEL_16:
@@ -3741,7 +3741,7 @@ void __fastcall PrintUString(int x, int y, int cjustflag, char *str, int col)
 	a3 = 0;
 	if (v15 > 0) {
 		while (1) {
-			v13 = fontframe[fontidx[(unsigned char)v5[v12]]];
+			v13 = fontframe[gbFontTransTbl[(unsigned char)v5[v12]]];
 			v14 = v13;
 			v8 += fontkern[v13] + 1;
 			if (v13) {

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -244,7 +244,7 @@ void __cdecl DrawQText()
 			if (*i == 124 || v1 >= 543)
 				break;
 			v4 = *i++;
-			v5 = fontidx[v4];
+			v5 = gbFontTransTbl[v4];
 			if (v5) {
 				qstr[v2] = v5;
 				v1 += mfontkern[mfontframe[v5]] + 2;
@@ -269,7 +269,7 @@ void __cdecl DrawQText()
 			v9 = qstr;
 			do {
 				++v0;
-				v10 = mfontframe[fontidx[v8]];
+				v10 = mfontframe[gbFontTransTbl[v8]];
 				if (*v0 == 10)
 					++v0;
 				if (v10)

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -118,7 +118,7 @@ void __fastcall PrintPlrMsg(unsigned int x, unsigned int y, unsigned int width, 
 
 		while (1) {
 			if (*sstr) {
-				c = fontidx[(unsigned char)*sstr++];
+				c = gbFontTransTbl[(unsigned char)*sstr++];
 				c = fontframe[c];
 				len += fontkern[c] + 1;
 				if (!c) // allow wordwrap on blank glyph
@@ -132,7 +132,7 @@ void __fastcall PrintPlrMsg(unsigned int x, unsigned int y, unsigned int width, 
 		}
 
 		while (str < endstr) {
-			c = fontidx[(unsigned char)*str++];
+			c = gbFontTransTbl[(unsigned char)*str++];
 			c = fontframe[c];
 			if (c)
 				CPrintString(screen, c, col);

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -929,7 +929,7 @@ void __fastcall PrintQLString(int x, int y, unsigned char cjustflag, char *str, 
 			goto LABEL_24;
 		do {
 			v11 = (unsigned char)str[v9++];
-			v10 += fontkern[fontframe[fontidx[v11]]] + 1;
+			v10 += fontkern[fontframe[gbFontTransTbl[v11]]] + 1;
 		} while (v9 < v20);
 		if (v10 < 257)
 		LABEL_24:
@@ -946,7 +946,7 @@ void __fastcall PrintQLString(int x, int y, unsigned char cjustflag, char *str, 
 	v19 = 0;
 	if (v20 > 0) {
 		do {
-			v14 = fontframe[fontidx[(unsigned char)str[v13]]];
+			v14 = fontframe[gbFontTransTbl[(unsigned char)str[v13]]];
 			v15 = v14;
 			v8 += fontkern[v14] + 1;
 			if (v14 && v8 <= 257) {

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -202,7 +202,7 @@ void __fastcall PrintSString(int x, int y, unsigned char cjustflag, char *str, i
 		if (v28 > 0) {
 			do {
 				v13 = (unsigned char)str[v11++];
-				v12 += fontkern[fontframe[fontidx[v13]]] + 1;
+				v12 += fontkern[fontframe[gbFontTransTbl[v13]]] + 1;
 			} while (v11 < v28);
 		}
 		if (v12 < v25)
@@ -219,7 +219,7 @@ void __fastcall PrintSString(int x, int y, unsigned char cjustflag, char *str, i
 	v29 = 0;
 	if (v28 > 0) {
 		do {
-			v15 = fontframe[fontidx[(unsigned char)str[v29]]];
+			v15 = fontframe[gbFontTransTbl[(unsigned char)str[v29]]];
 			v16 = v15;
 			v17 = v30 + fontkern[v15] + 1;
 			v30 += fontkern[v15] + 1;
@@ -236,9 +236,9 @@ void __fastcall PrintSString(int x, int y, unsigned char cjustflag, char *str, i
 		v19 = screen_y_times_768[v6 + 204] - v8 + 656;
 		v20 = strlen(valstr);
 		while ((--v20 & 0x80000000) == 0) {
-			v21 = fontframe[fontidx[(unsigned char)valstr[v20]]];
+			v21 = fontframe[gbFontTransTbl[(unsigned char)valstr[v20]]];
 			v19 += -1 - fontkern[v21];
-			if (fontframe[fontidx[(unsigned char)valstr[v20]]])
+			if (fontframe[gbFontTransTbl[(unsigned char)valstr[v20]]])
 				CPrintString(v19, v21, col);
 		}
 		v8 = v26;


### PR DESCRIPTION
CPrintString is now bin exact. Yes, the lack of a switch/if case for the ASM version is *intentional*. For whatever reason the devs wrote it that way.

fontidx -> [gbFontTransTbl (taken from PSX symbol 3)](https://github.com/diasurgical/scalpel/blob/master/psx/_dump_/3/_dump_c_/decls.h#L2206)