### PR TITLE
Fix crash in draw town

### DIFF
--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -15,8 +15,8 @@ static CRITICAL_SECTION sgMemCrit;
 int SeedCount;    // weak
 int dword_52B99C; // BOOLEAN valid - if x/y are in bounds
 
-const int rand_increment = 1;           // unused
-const int rand_multiplier = 0x015A4E35; // unused
+const int rand_increment = 1;
+const int rand_multiplier = 0x015A4E35;
 
 void __fastcall CelDrawDatOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth)
 {
@@ -2321,7 +2321,7 @@ void __fastcall SetRndSeed(int s)
 int __cdecl GetRndSeed()
 {
 	SeedCount++;
-	sglGameSeed = 0x015A4E35 * sglGameSeed + 1;
+	sglGameSeed = rand_multiplier * sglGameSeed + rand_increment;
 	return abs(sglGameSeed);
 }
 // 52B97C: using guessed type int sglGameSeed;

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -474,7 +474,7 @@ void __fastcall town_draw_clipped_town_2(int x, int y, int a3, int a4, int a5, i
 		Cel2DrawHdrOnly(v13, sy, item[v12]._iAnimData, item[v12]._iAnimFrame, item[v12]._iAnimWidth, a5, 8);
 	}
 	if (dFlags[0][v9] & DFLAG_MONSTER) {
-		v14 = -1 - dMonster[x][y - 1]; // -1 - *(&dword_52D204 + v9); /* check */
+		v14 = -1 - dMonster[y][a3 - 1]; // -1 - *(&dword_52D204 + v9); /* check */
 		v15 = sx - towner[v14]._tAnimWidth2;
 		if (v14 == pcursmonst)
 			CelDrawHdrClrHL(
@@ -506,7 +506,7 @@ void __fastcall town_draw_clipped_town_2(int x, int y, int a3, int a4, int a5, i
 		Cel2DrawHdrOnly(v19, sy, towner[v18]._tAnimData, towner[v18]._tAnimFrame, towner[v18]._tAnimWidth, a5, 8);
 	}
 	if (dFlags[0][v9] & DFLAG_PLAYER) {
-		v20 = -1 - dPlayer[x][y - 1]; // -1 - *((_BYTE *)&themeLoc[49].height + v9 + 3);
+		v20 = -1 - dPlayer[y][a3 - 1]; // -1 - *((_BYTE *)&themeLoc[49].height + v9 + 3);
 		v21 = v20;
 		v22 = sy + plr[v21]._pyoff;
 		v23 = sx + plr[v21]._pxoff - plr[v21]._pAnimWidth2;


### PR DESCRIPTION
The args for `town_draw_clipped_town_2` are wrong. It would use the pointer for the buffer as the X coordinate and would guarantee a crash when drawing the player. This is very rare but I've experienced it.

Also plugged in the constants in engine.cpp.