### PR TITLE
Fix a few func/var names

### DIFF
--- a/Source/_render.cpp
+++ b/Source/_render.cpp
@@ -7,7 +7,7 @@ void __fastcall drawTopArchesUpperScreen(unsigned char *pbDst)
 	unsigned char *src; // esi MAPDST
 	short cel_type_16; // ax MAPDST
 
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	if ( !(_BYTE)light_table_index )
 	{
@@ -2330,7 +2330,7 @@ void __fastcall drawBottomArchesUpperScreen(unsigned char *pbDst, unsigned int *
 	short cel_type_16; // ax MAPDST
 	unsigned char *tbl;
 
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	gpDrawMask = pMask;
 	if ( !(_BYTE)light_table_index )
@@ -3498,7 +3498,7 @@ void __fastcall drawUpperScreen(unsigned char *pbDst)
 			}
 		}
 	}
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	if ( !(_BYTE)light_table_index )
 	{
@@ -4615,7 +4615,7 @@ void __fastcall drawTopArchesLowerScreen(unsigned char *pbDst)
 	unsigned char *src; // esi MAPDST
 	short cel_type_16; // ax MAPDST
 
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	if ( !(_BYTE)light_table_index )
 	{
@@ -7381,7 +7381,7 @@ void __fastcall drawBottomArchesLowerScreen(unsigned char *pbDst, unsigned int *
 	unsigned char *src; // esi MAPDST
 	unsigned char *tbl;
 
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	gpDrawMask = pMask;
 	if ( (_BYTE)light_table_index )
@@ -8889,7 +8889,7 @@ void __fastcall drawLowerScreen(unsigned char *pbDst)
 			}
 		}
 	}
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	if ( (_BYTE)light_table_index )
 	{

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -16,7 +16,7 @@ extern char dDead[MAXDUNX][MAXDUNY];
 extern WORD dpiece_defs_map_1[MAXDUNX * MAXDUNY][16];
 extern char dTransVal2[MAXDUNX][MAXDUNY];
 extern char TransVal; // weak
-extern int dword_5A5594;
+extern int MicroTileLen;
 extern char dflags[40][40];
 extern int dPiece[MAXDUNX][MAXDUNY];
 extern char dTransVal[MAXDUNX][MAXDUNY];
@@ -36,7 +36,7 @@ extern BOOLEAN nSolidTable[2049];
 extern int level_frame_count[MAXTILES];
 extern ScrollStruct ScrollInfo;
 extern BYTE *pDungeonCels;
-extern int speed_cel_frame_num_from_light_index_frame_num[128][16];
+extern int SpeedFrameTbl[128][16];
 extern THEME_LOC themeLoc[MAXTHEMES];
 extern char dPlayer[MAXDUNX][MAXDUNY];
 extern int dword_5C2FF8;   // weak
@@ -70,11 +70,11 @@ extern int dminy; // weak
 extern WORD dpiece_defs_map_2[MAXDUNX][MAXDUNY][16];
 
 void __cdecl FillSolidBlockTbls();
-void __cdecl gendung_418D91();
-void __fastcall gendung_4191BF(int frames);
-void __fastcall gendung_4191FB(int f1, int f2);
-int __fastcall gendung_get_dpiece_num_from_coord(int x, int y);
-void __cdecl gendung_4192C2();
+void __cdecl MakeSpeedCels();
+void __fastcall SortTiles(int frames);
+void __fastcall SwapTile(int f1, int f2);
+int __fastcall IsometricCoord(int x, int y);
+void __cdecl SetSpeedCels();
 void __cdecl SetDungeonMicros();
 void __cdecl DRLG_InitTrans();
 void __fastcall DRLG_MRectTrans(int x1, int y1, int x2, int y2);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -9,7 +9,7 @@ ItemStruct curruitem;
 ItemGetRecordStruct itemrecord[MAXITEMS];
 ItemStruct item[MAXITEMS + 1];
 BOOL itemhold[3][3];
-unsigned char *Item2Frm[35];
+unsigned char *itemanims[35];
 int UniqueItemFlag[128];
 int numitems;
 int gnNumGetRecords;
@@ -643,7 +643,7 @@ void __cdecl InitItemGFX()
 	v0 = 0;
 	do {
 		sprintf(arglist, "Items\\%s.CEL", ItemDropStrs[v0]);
-		Item2Frm[v0] = LoadFileInMem(arglist, 0);
+		itemanims[v0] = LoadFileInMem(arglist, 0);
 		++v0;
 	} while (v0 < 35);
 	memset(UniqueItemFlag, 0, sizeof(UniqueItemFlag));
@@ -2483,7 +2483,7 @@ void __fastcall SetupItem(int i)
 	item[i]._iAnimWidth = 96;
 	item[i]._iAnimWidth2 = 16;
 	il = ItemAnimLs[it];
-	item[i]._iAnimData = Item2Frm[it];
+	item[i]._iAnimData = itemanims[it];
 	item[i]._iAnimLen = il;
 	item[i]._iIdentified = FALSE;
 	item[i]._iPostDraw = 0;
@@ -3149,7 +3149,7 @@ void __fastcall RespawnItem(int i, BOOL FlipFlag)
 	it = ItemCAnimTbl[item[i]._iCurs];
 	il = ItemAnimLs[it];
 	item[i]._iAnimLen = il;
-	item[i]._iAnimData = Item2Frm[it];
+	item[i]._iAnimData = itemanims[it];
 	item[i]._iPostDraw = 0;
 	item[i]._iRequest = FALSE;
 
@@ -3245,15 +3245,15 @@ void __cdecl FreeItemGFX()
 	void *v1; // ecx
 
 	for (i = 0; i < 35; i++) {
-		v1 = (void *)Item2Frm[i];
-		Item2Frm[i] = 0;
+		v1 = (void *)itemanims[i];
+		itemanims[i] = 0;
 		mem_free_dbg(v1);
 	}
 }
 
 void __fastcall GetItemFrm(int i)
 {
-	item[i]._iAnimData = Item2Frm[ItemCAnimTbl[item[i]._iCurs]];
+	item[i]._iAnimData = itemanims[ItemCAnimTbl[item[i]._iCurs]];
 }
 
 void __fastcall GetItemStr(int i)

--- a/Source/items.h
+++ b/Source/items.h
@@ -9,7 +9,7 @@ extern ItemStruct curruitem;
 extern ItemGetRecordStruct itemrecord[MAXITEMS];
 extern ItemStruct item[MAXITEMS + 1];
 extern BOOL itemhold[3][3];
-extern unsigned char *Item2Frm[35];
+extern unsigned char *itemanims[35];
 extern int UniqueItemFlag[128];
 extern int numitems;
 extern int gnNumGetRecords;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2592,7 +2592,7 @@ void __fastcall ObjSetMicro(int dx, int dy, int pn)
 
 	dPiece[dx][dy] = pn;
 	v3 = pn - 1;
-	v4 = (char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(dx, dy);
+	v4 = (char *)dpiece_defs_map_1 + 32 * IsometricCoord(dx, dy);
 	if (leveltype == DTYPE_HELL) {
 		v7 = (char *)pLevelPieces + 32 * v3;
 		v8 = 0;
@@ -2623,8 +2623,8 @@ void __fastcall objects_set_door_piece(int x, int y)
 	v4 = dPiece[x][y] - 1;
 	v5 = *((_WORD *)pLevelPieces + 10 * (unsigned short)v4 + 8);
 	v6 = *((_WORD *)pLevelPieces + 10 * (unsigned short)v4 + 9);
-	dpiece_defs_map_1[0][16 * gendung_get_dpiece_num_from_coord(x, y)] = v5;
-	dpiece_defs_map_1[0][16 * gendung_get_dpiece_num_from_coord(v3, v2) + 1] = v6;
+	dpiece_defs_map_1[0][16 * IsometricCoord(x, y)] = v5;
+	dpiece_defs_map_1[0][16 * IsometricCoord(v3, v2) + 1] = v6;
 }
 
 void __fastcall ObjSetMini(int x, int y, int v)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -948,7 +948,7 @@ void __fastcall InitPlayerLoc(int pnum, BOOL flag)
 	x = plr[pnum].WorldX - 1;
 	y = plr[pnum].WorldY + 1;
 	bitflags = 0;
-	pieces = dpiece_defs_map_1[gendung_get_dpiece_num_from_coord(x, y)];
+	pieces = dpiece_defs_map_1[IsometricCoord(x, y)];
 
 	for (i = 2; i < 10; i++) {
 		bitflags |= pieces[i];
@@ -967,7 +967,7 @@ void __fastcall InitPlayerLoc(int pnum, BOOL flag)
 	x = plr[pnum].WorldX;
 	y = plr[pnum].WorldY + 2;
 	bitflags = 0;
-	pieces = dpiece_defs_map_1[gendung_get_dpiece_num_from_coord(x, y)];
+	pieces = dpiece_defs_map_1[IsometricCoord(x, y)];
 
 	for (i = 2; i < 10; i++) {
 		bitflags |= pieces[i];
@@ -980,7 +980,7 @@ void __fastcall InitPlayerLoc(int pnum, BOOL flag)
 	x = plr[pnum].WorldX - 2;
 	y = plr[pnum].WorldY + 1;
 	bitflags = 0;
-	pieces = dpiece_defs_map_1[gendung_get_dpiece_num_from_coord(x, y)];
+	pieces = dpiece_defs_map_1[IsometricCoord(x, y)];
 
 	for (i = 2; i < 10; i++) {
 		bitflags |= pieces[i];

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -96,7 +96,7 @@ void __fastcall drawTopArchesUpperScreen(unsigned char *pbDst)
 	signed int i;              // edx MAPDST
 	signed int j;              // ecx MAPDST
 
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	if (!(_BYTE)light_table_index) {
 		if (level_cel_block & 0x8000)
@@ -1120,7 +1120,7 @@ void __fastcall drawBottomArchesUpperScreen(unsigned char *pbDst, unsigned int *
 	signed int i;              // ecx MAPDST
 	unsigned char *tbl;
 
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	gpDrawMask = pMask;
 	if (!(_BYTE)light_table_index) {
@@ -1772,7 +1772,7 @@ void __fastcall drawUpperScreen(unsigned char *pbDst)
 			}
 		}
 	}
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	if (!(_BYTE)light_table_index) {
 		if (level_cel_block & 0x8000)
@@ -2378,7 +2378,7 @@ void __fastcall drawTopArchesLowerScreen(unsigned char *pbDst)
 	signed int i;              // edx MAPDST
 	signed int j;              // ecx MAPDST
 
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	if (!(_BYTE)light_table_index) {
 		if (level_cel_block & 0x8000)
@@ -3615,7 +3615,7 @@ void __fastcall drawBottomArchesLowerScreen(unsigned char *pbDst, unsigned int *
 	unsigned int n_draw_shift; // ecx MAPDST
 	unsigned char *tbl;
 
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	gpDrawMask = pMask;
 	if ((_BYTE)light_table_index) {
@@ -4427,7 +4427,7 @@ void __fastcall drawLowerScreen(unsigned char *pbDst)
 			}
 		}
 	}
-	gpCelFrame = (unsigned char *)speed_cel_frame_num_from_light_index_frame_num;
+	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pbDst;
 	if ((_BYTE)light_table_index) {
 		if ((_BYTE)light_table_index == lightmax) {

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -609,7 +609,7 @@ void __fastcall scrollrt_draw_lower(int x, int y, int sx, int sy, int a5, int so
 	v7 = x;
 	sya = y;
 	sxa = x;
-	v8 = (unsigned short *)((char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(x, y));
+	v8 = (unsigned short *)((char *)dpiece_defs_map_1 + 32 * IsometricCoord(x, y));
 	if (some_flag) {
 		if (v6 < 0x70 && v7 < 0x70) {
 			v9 = v7;
@@ -696,7 +696,7 @@ LABEL_23:
 						drawLowerScreen(v29 + 32);
 					arch_draw_type = 0;
 					v31 = 2;
-					for (i = 2; i < dword_5A5594; i += 2) {
+					for (i = 2; i < MicroTileLen; i += 2) {
 						v29 -= 24576;
 						level_cel_block = v8[v31];
 						if (level_cel_block)
@@ -1151,7 +1151,7 @@ void __fastcall scrollrt_draw_clipped_e_flag(char *buffer, int x, int y, int a4,
 	v11 = (unsigned char)(nTransTable[v7] & TransList[v9]);
 	light_table_index = v8;
 	cel_transparency_active = v11;
-	v12 = gendung_get_dpiece_num_from_coord(x, y);
+	v12 = IsometricCoord(x, y);
 	arch_draw_type = 1;
 	v13 = (unsigned short *)((char *)dpiece_defs_map_1 + 32 * v12);
 	v14 = *v13;
@@ -1166,7 +1166,7 @@ void __fastcall scrollrt_draw_clipped_e_flag(char *buffer, int x, int y, int a4,
 	arch_draw_type = 0;
 	pbDst = a1;
 	v16 = 2;
-	for (i = 2; i < dword_5A5594; i += 2) {
+	for (i = 2; i < MicroTileLen; i += 2) {
 		pbDst -= 24576;
 		level_cel_block = v13[v16];
 		if (level_cel_block)
@@ -1224,7 +1224,7 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 	a1 = y;
 	xa = x;
 	v8 = sx;
-	v29 = (char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(x, y);
+	v29 = (char *)dpiece_defs_map_1 + 32 * IsometricCoord(x, y);
 	if (some_flag) {
 		if (v7 >= 0 && v7 < MAXDUNY && xa >= 0 && xa < MAXDUNX) {
 			v9 = 112 * xa + v7;
@@ -1235,7 +1235,7 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 				a6a = 0;
 				cel_transparency_active = (unsigned char)(nTransTable[v10] & TransList[dung_map[0][v9]]);
 				a1a = (unsigned char *)gpBuffer + screen_y_times_768[sy] + v8 - 24544;
-				if ((dword_5A5594 >> 1) - 1 > 0) {
+				if ((MicroTileLen >> 1) - 1 > 0) {
 					v24 = (unsigned short *)(v29 + 6);
 					do {
 						if (a6 <= a6a) {
@@ -1247,7 +1247,7 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 						a1a -= 24576;
 						++a6a;
 						v24 += 2;
-					} while (a6a < (dword_5A5594 >> 1) - 1);
+					} while (a6a < (MicroTileLen >> 1) - 1);
 				}
 				v12 = 2 * a6 + 2;
 				if (v12 < 8)
@@ -1286,7 +1286,7 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 					a6b = 0;
 					cel_transparency_active = (unsigned char)(nTransTable[v15] & TransList[dung_map[0][v14]]);
 					v16 = (unsigned char *)gpBuffer + screen_y_times_768[sy] + v8 - 24576;
-					if ((dword_5A5594 >> 1) - 1 > 0) {
+					if ((MicroTileLen >> 1) - 1 > 0) {
 						a5a = (unsigned short *)(v29 + 6);
 						do {
 							if (a6 <= a6b) {
@@ -1302,7 +1302,7 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 							++a6b;
 							a5a += 2;
 							v16 -= 24576;
-						} while (a6b < (dword_5A5594 >> 1) - 1);
+						} while (a6b < (MicroTileLen >> 1) - 1);
 					}
 					if (2 * a6 + 2 < 8)
 						scrollrt_draw_clipped_dungeon_2(
@@ -1336,7 +1336,7 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 				a6c = 0;
 				cel_transparency_active = (unsigned char)(nTransTable[v20] & TransList[dung_map[0][v19]]);
 				a1b = (unsigned char *)gpBuffer + screen_y_times_768[sy] + v8 - 24576;
-				if ((dword_5A5594 >> 1) - 1 > 0) {
+				if ((MicroTileLen >> 1) - 1 > 0) {
 					a5b = (unsigned short *)(v29 + 4);
 					do {
 						if (a6 <= a6c) {
@@ -1348,7 +1348,7 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 						a1b -= 24576;
 						++a6c;
 						a5b += 2;
-					} while (a6c < (dword_5A5594 >> 1) - 1);
+					} while (a6c < (MicroTileLen >> 1) - 1);
 				}
 				v22 = 2 * a6 + 2;
 				if (v22 < 8)
@@ -1649,7 +1649,7 @@ void __fastcall scrollrt_draw_clipped_e_flag_2(char *buffer, int x, int y, int a
 	v12 = (unsigned char)(nTransTable[v8] & TransList[v10]);
 	light_table_index = v9;
 	cel_transparency_active = v12;
-	v13 = (unsigned short *)((char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(x, y));
+	v13 = (unsigned short *)((char *)dpiece_defs_map_1 + 32 * IsometricCoord(x, y));
 	if (!a4) {
 		v14 = v13[2];
 		level_cel_block = v13[2];
@@ -1754,7 +1754,7 @@ void __fastcall scrollrt_draw_upper(int x, int y, int sx, int sy, int a5, int a6
 	v8 = x;
 	ya = y;
 	xa = x;
-	v9 = (unsigned short *)((char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(x, y));
+	v9 = (unsigned short *)((char *)dpiece_defs_map_1 + 32 * IsometricCoord(x, y));
 	a5a = 2 * a6 + 2;
 	if (a5a > 8)
 		a5a = 8;
@@ -1837,7 +1837,7 @@ void __fastcall scrollrt_draw_upper(int x, int y, int sx, int sy, int a5, int a6
 					if (v27)
 						drawUpperScreen(v26 + 32);
 					arch_draw_type = 0;
-					for (i = 1; i < (dword_5A5594 >> 1) - 1; ++i) {
+					for (i = 1; i < (MicroTileLen >> 1) - 1; ++i) {
 						v26 -= 24576;
 						if (a6 >= i) {
 							v28 = v9[2 * i];
@@ -2299,7 +2299,7 @@ void __fastcall scrollrt_draw_e_flag(char *buffer, int x, int y, int a4, int a5,
 	a1 = (unsigned char *)v8;
 	v25 = (unsigned char *)v8;
 	cel_transparency_active = v14 & v13;
-	v16 = gendung_get_dpiece_num_from_coord(xa, y);
+	v16 = IsometricCoord(xa, y);
 	arch_draw_type = 1;
 	v17 = (unsigned short *)((char *)dpiece_defs_map_1 + 32 * v16);
 	v18 = *v17;
@@ -2312,7 +2312,7 @@ void __fastcall scrollrt_draw_e_flag(char *buffer, int x, int y, int a4, int a5,
 	if (v19)
 		drawUpperScreen(a1 + 32);
 	arch_draw_type = 0;
-	for (i = 1; i < (dword_5A5594 >> 1) - 1; ++i) {
+	for (i = 1; i < (MicroTileLen >> 1) - 1; ++i) {
 		v25 -= 24576;
 		if (a4 >= i) {
 			v20 = v17[2 * i];

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -149,7 +149,7 @@ void __fastcall town_draw_clipped_e_flag(BYTE *buffer, int x, int y, int sx, int
 	WORD *defs;
 
 	buf = buffer;
-	defs = dpiece_defs_map_1[gendung_get_dpiece_num_from_coord(x, y)];
+	defs = dpiece_defs_map_1[IsometricCoord(x, y)];
 
 	for (i = 0; i < 12; i += 2) {
 		level_cel_block = defs[i];
@@ -313,7 +313,7 @@ void __fastcall town_draw_lower(int x, int y, int sx, int sy, int a5, int some_f
 			v7 = &screen_y_times_768[sy];
 			a1 = (unsigned char *)&gpBuffer[*v7 + 32 + sx];
 			v25 = 1;
-			v8 = (char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(x, y);
+			v8 = (char *)dpiece_defs_map_1 + 32 * IsometricCoord(x, y);
 			do {
 				v9 = *(unsigned short *)&v8[2 * v25];
 				level_cel_block = *(unsigned short *)&v8[2 * v25];
@@ -343,7 +343,7 @@ void __fastcall town_draw_lower(int x, int y, int sx, int sy, int a5, int some_f
 		do {
 			if (y >= 0 && y < MAXDUNY && v12 >= 0 && v12 < MAXDUNX * 112 && (level_cel_block = dPiece[0][v12 + y]) != 0) {
 				v13 = (unsigned char *)gpBuffer + *v11 + sx;
-				v14 = (char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(xa, ya);
+				v14 = (char *)dpiece_defs_map_1 + 32 * IsometricCoord(xa, ya);
 				v26 = 0;
 				do {
 					v15 = *(unsigned short *)&v14[2 * v26];
@@ -376,7 +376,7 @@ void __fastcall town_draw_lower(int x, int y, int sx, int sy, int a5, int some_f
 		if (y >= 0 && y < MAXDUNY && xa >= 0 && xa < MAXDUNX && (level_cel_block = dPiece[xa][y]) != 0) {
 			v18 = &screen_y_times_768[v6];
 			v19 = (unsigned char *)gpBuffer + *v18 + sx;
-			v20 = (char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(xa, ya);
+			v20 = (char *)dpiece_defs_map_1 + 32 * IsometricCoord(xa, ya);
 			v27 = 0;
 			do {
 				v21 = *(unsigned short *)&v20[2 * v27];
@@ -405,7 +405,7 @@ void __fastcall town_draw_clipped_e_flag_2(BYTE *buffer, int x, int y, int a4, i
 	else
 		buf = buffer + 768 * 32 * a4;
 
-	defs = dpiece_defs_map_1[gendung_get_dpiece_num_from_coord(x, y)];
+	defs = dpiece_defs_map_1[IsometricCoord(x, y)];
 
 	for (i = 0; i < 6; i++) {
 		if (a4 <= i) {
@@ -581,7 +581,7 @@ void __fastcall town_draw_lower_2(int x, int y, int sx, int sy, int a5, int a6, 
 				v9 = &screen_y_times_768[sy];
 				a1 = (unsigned char *)gpBuffer + *v9 + sx - 24544;
 				sxa = 0;
-				v10 = &dpiece_defs_map_1[0][16 * gendung_get_dpiece_num_from_coord(x, y) + 3];
+				v10 = &dpiece_defs_map_1[0][16 * IsometricCoord(x, y) + 3];
 				v23 = v10;
 				do {
 					if (a6 <= sxa) {
@@ -620,7 +620,7 @@ LABEL_18:
 			if (ya >= 0 && ya < MAXDUNY && v14 >= 0 && v14 < MAXDUNX * 112 && (level_cel_block = dPiece[0][v14 + ya]) != 0) {
 				a1a = (unsigned char *)gpBuffer + *v13 + v11 - 768 * 32;
 				sxb = 0;
-				v15 = &dpiece_defs_map_1[0][16 * gendung_get_dpiece_num_from_coord(xa, ya) + 3];
+				v15 = &dpiece_defs_map_1[0][16 * IsometricCoord(xa, ya) + 3];
 				do {
 					if (a6 <= sxb) {
 						v16 = (unsigned short)*(v15 - 1);
@@ -657,7 +657,7 @@ LABEL_18:
 			v20 = &screen_y_times_768[v8];
 			a1b = (unsigned char *)gpBuffer + *v20 + v11 - 768 * 32;
 			sxc = 0;
-			v21 = &dpiece_defs_map_1[0][16 * gendung_get_dpiece_num_from_coord(xa, ya) + 2];
+			v21 = &dpiece_defs_map_1[0][16 * IsometricCoord(xa, ya) + 2];
 			do {
 				if (a6 <= sxc) {
 					v22 = (unsigned short)*v21;
@@ -685,7 +685,7 @@ void __fastcall town_draw_e_flag(BYTE *buffer, int x, int y, int a4, int dir, in
 	WORD *defs;
 
 	buf = buffer;
-	defs = dpiece_defs_map_1[gendung_get_dpiece_num_from_coord(x, y)];
+	defs = dpiece_defs_map_1[IsometricCoord(x, y)];
 
 	for (i = 0; i < 7; i++) {
 		if (a4 >= i) {
@@ -809,7 +809,7 @@ void __fastcall town_draw_upper(int x, int y, int sx, int sy, int a5, int a6, in
 			if (!v10) {
 				a1 = (int *)&gpBuffer[sx + 32 + screen_y_times_768[sy]];
 				sxa = 0;
-				v12 = &dpiece_defs_map_1[0][16 * gendung_get_dpiece_num_from_coord(x, y) + 1];
+				v12 = &dpiece_defs_map_1[0][16 * IsometricCoord(x, y) + 1];
 				do {
 					if (a6 >= sxa) {
 						v13 = (unsigned short)*v12;
@@ -849,7 +849,7 @@ LABEL_19:
 				v17 = gpBuffer;
 				if (!v10) {
 					v18 = (unsigned char *)gpBuffer + v14 + screen_y_times_768[sy];
-					v19 = (char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(xa, ya);
+					v19 = (char *)dpiece_defs_map_1 + 32 * IsometricCoord(xa, ya);
 					sxb = 0;
 					do {
 						if (a6 >= sxb) {
@@ -893,7 +893,7 @@ LABEL_19:
 			v23 = sy;
 			if (!v10) {
 				v24 = (unsigned char *)gpBuffer + v14 + screen_y_times_768[sy];
-				v25 = (char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(xa, v7);
+				v25 = (char *)dpiece_defs_map_1 + 32 * IsometricCoord(xa, v7);
 				sxc = 0;
 				do {
 					if (a6 >= sxc) {
@@ -1250,7 +1250,7 @@ void __fastcall T_DrawView(int StartX, int StartY)
 // 69CF94: using guessed type int cel_transparency_active;
 // 6AA705: using guessed type char stextflag;
 
-void __cdecl town_init_dpiece_defs_map()
+void __cdecl SetTownMicros()
 {
 	int(*v0)[112]; // ebx
 	int v1;        // ebp
@@ -1268,7 +1268,7 @@ void __cdecl town_init_dpiece_defs_map()
 		v1 = 0;
 		do {
 			v2 = (*v0)[0];
-			v3 = (char *)dpiece_defs_map_1 + 32 * gendung_get_dpiece_num_from_coord(v1, y);
+			v3 = (char *)dpiece_defs_map_1 + 32 * IsometricCoord(v1, y);
 			if (v2) {
 				v4 = (char *)pLevelPieces + 32 * v2 - 32;
 				v5 = 0;
@@ -1586,7 +1586,7 @@ void __fastcall CreateTown(int entry)
 		v2 = (int(*)[112])((char *)v2 + 4);
 		++v1;
 	} while ((signed int)v2 < (signed int)dPiece[1]);
-	town_init_dpiece_defs_map();
+	SetTownMicros();
 }
 // 5CF328: using guessed type int dmaxx;
 // 5CF32C: using guessed type int dmaxy;

--- a/Source/town.h
+++ b/Source/town.h
@@ -16,7 +16,7 @@ void __fastcall town_draw_upper(int x, int y, int sx, int sy, int a5, int a6, in
 void __fastcall T_DrawGame(int x, int y);
 void __fastcall T_DrawZoom(int x, int y);
 void __fastcall T_DrawView(int StartX, int StartY);
-void __cdecl town_init_dpiece_defs_map();
+void __cdecl SetTownMicros();
 void __fastcall T_FillSector(unsigned char *P3Tiles, unsigned char *pSector, int xi, int yi, int w, int h);
 void __fastcall T_FillTile(unsigned char *P3Tiles, int xx, int yy, int t);
 void __cdecl T_Pass3();


### PR DESCRIPTION
Cleaning up some naming.
From PSX symbol file:
`dword_5A5594 -> MicroTileLen`
From 1.00 debut assert:
`Item2Frm -> itemanims`
Educated guess based on functionality:
```
gendung_418D91 -> MakeSpeedCels
gendung_4191BF -> SortTiles
gendung_4191FB -> SwapTile
gendung_get_dpiece_num_from_coord -> IsometricCoord
gendung_4192C2 -> SetSpeedCels
speed_cel_frame_num_from_light_index_frame_num -> SpeedFrameTbl
town_init_dpiece_defs_map -> SetTownMicros
```