### PR TITLE
mpqapi_write_file bin exact

### DIFF
--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -326,7 +326,7 @@ _BLOCKENTRY *__fastcall mpqapi_add_file(const char *pszName, _BLOCKENTRY *pBlk, 
 	return v12;
 }
 
-BOOLEAN __fastcall mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, int dwLen, _BLOCKENTRY *pBlk)
+BOOL __fastcall mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, int dwLen, _BLOCKENTRY *pBlk)
 {
 	const char *v4;              // esi
 	const char *v5;              // eax

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -5,7 +5,7 @@
 int sgdwMpqOffset; // idb
 char mpq_buf[4096];
 _HASHENTRY *sgpHashTbl;
-BOOLEAN save_archive_modified; // weak
+BOOL save_archive_modified; // weak
 _BLOCKENTRY *sgpBlockTbl;
 BOOLEAN save_archive_open; // weak
 
@@ -269,19 +269,16 @@ void __fastcall mpqapi_remove_hash_entries(BOOL(__stdcall *fnGetName)(DWORD, cha
 
 BOOL __fastcall mpqapi_write_file(const char *pszName, const BYTE *pbData, DWORD dwLen)
 {
-	const BYTE *v3;  // edi
-	const char *v4;  // esi
-	_BLOCKENTRY *v5; // eax
+	_BLOCKENTRY *blockEntry;
 
-	v3 = pbData;
-	v4 = pszName;
-	save_archive_modified = 1;
+	save_archive_modified = TRUE;
 	mpqapi_remove_hash_entry(pszName);
-	v5 = mpqapi_add_file(v4, 0, 0);
-	if (mpqapi_write_file_contents(v4, v3, dwLen, v5))
-		return 1;
-	mpqapi_remove_hash_entry(v4);
-	return 0;
+	blockEntry = mpqapi_add_file(pszName, 0, 0);
+	if (!mpqapi_write_file_contents(pszName, pbData, dwLen, blockEntry)) {
+		mpqapi_remove_hash_entry(pszName);
+		return FALSE;
+	}
+	return TRUE;
 }
 // 65AB0C: using guessed type int save_archive_modified;
 

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -21,7 +21,7 @@ int __fastcall mpqapi_get_hash_index(short index, int hash_a, int hash_b, int lo
 void __fastcall mpqapi_remove_hash_entries(BOOL(__stdcall *fnGetName)(DWORD, char *));
 BOOL __fastcall mpqapi_write_file(const char *pszName, const BYTE *pbData, DWORD dwLen);
 _BLOCKENTRY *__fastcall mpqapi_add_file(const char *pszName, _BLOCKENTRY *pBlk, int block_index);
-BOOLEAN __fastcall mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, int dwLen, _BLOCKENTRY *pBlk);
+BOOL __fastcall mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, int dwLen, _BLOCKENTRY *pBlk);
 int __fastcall mpqapi_find_free_block(int size, int *block_size);
 void __fastcall mpqapi_rename(char *pszOld, char *pszNew);
 BOOL __fastcall mpqapi_has_file(const char *pszName);

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -3,7 +3,7 @@
 #define __MPQAPI_H__
 
 extern char mpq_buf[4096];
-extern BOOLEAN save_archive_modified; // weak
+extern BOOL save_archive_modified; // weak
 extern BOOLEAN save_archive_open;     // weak
 
 BOOL __fastcall mpqapi_set_hidden(const char *pszArchive, BOOL hidden);


### PR DESCRIPTION
The only real diff is the test statement: 
![image](https://user-images.githubusercontent.com/46401660/55162959-2c68ea80-5169-11e9-939e-5011b2c5c1be.png)
But once mpqapi_write_file_contents is cleaned up and the type is changed to BOOL (instead of BOOLEAN) this should be fine as well. 