### PR TITLE
Create macro -> mem_free_dbg

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -66,25 +66,13 @@ char *spszMsgKeyTbl[4] = { "F9", "F10", "F11", "F12" }; // weak
 
 void __cdecl FreeGameMem()
 {
-	void *p;
-
 	music_stop();
 
-	p = pDungeonCels; /* todo: macro */
-	pDungeonCels = NULL;
-	mem_free_dbg(p);
-	p = pMegaTiles;
-	pMegaTiles = NULL;
-	mem_free_dbg(p);
-	p = pLevelPieces;
-	pLevelPieces = NULL;
-	mem_free_dbg(p);
-	p = level_special_cel;
-	level_special_cel = NULL;
-	mem_free_dbg(p);
-	p = pSpeedCels;
-	pSpeedCels = NULL;
-	mem_free_dbg(p);
+	MemFreeDbg(pDungeonCels);
+	MemFreeDbg(pMegaTiles);
+	MemFreeDbg(pLevelPieces);
+	MemFreeDbg(level_special_cel);
+	MemFreeDbg(pSpeedCels);
 
 	FreeMissiles();
 	FreeMonsters();

--- a/defs.h
+++ b/defs.h
@@ -85,6 +85,14 @@
 
 #define SCREENXY(x, y)	((x) + 64 + (((y) + 160) * 768))
 
+#define MemFreeDbg(p)	\
+{						\
+	void *p__p;			\
+	p__p = p;			\
+	p = NULL;			\
+	mem_free_dbg(p__p);	\
+}
+
 #ifndef INVALID_FILE_ATTRIBUTES
 #define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
 #endif


### PR DESCRIPTION
mem_free_dbg was called through a macro. This is evident by the line numbers in the debug version. This also explains why global variables will have `x = p; p = NULL` and local variables do not.
This could attribute to some of the minimal differences we can't fix. LoadFileInMem also used a macro, that way they could print the file/line number.