### PR TITLE
mpqapi_reg_load_modification_time bin exact

### DIFF
--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -65,10 +65,13 @@ BOOL __fastcall mpqapi_reg_load_modification_time(char *dst, int size)
 	iSize = size;
 	pszDst = dst;
 	memset(dst, 0, size);
-	if (SRegLoadData("Diablo", "Video Player ", 0, (unsigned char *)pszDst, iSize, (LPDWORD)&nbytes_read))
-		if (nbytes_read != size)
-			return FALSE;
+	if (!SRegLoadData("Diablo", "Video Player ", 0, (unsigned char *)pszDst, iSize, (LPDWORD)&nbytes_read)) {
+		return FALSE;
+	}
 
+	if (nbytes_read != size)
+		return FALSE;
+			
 	for (; iSize >= 8; iSize -=8) {
 		pbData = pszDst;
 		pszDst += 8;
@@ -77,6 +80,7 @@ BOOL __fastcall mpqapi_reg_load_modification_time(char *dst, int size)
 
 	return TRUE;
 }
+
 void __fastcall mpqapi_xor_buf(char *pbData)
 {
 	signed int v1; // eax

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -55,31 +55,28 @@ void __fastcall mpqapi_store_creation_time(const char *pszArchive, int dwChar)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-BOOLEAN __fastcall mpqapi_reg_load_modification_time(char *dst, int size)
+BOOL __fastcall mpqapi_reg_load_modification_time(char *dst, int size)
 {
-	unsigned int v2; // esi
-	char *v3;        // edi
-	unsigned int v6; // esi
-	char *v7;        // ecx
-	int nbytes_read; // [esp+8h] [ebp-4h]
+	unsigned int iSize;
+	char *pszDst;
+	char *pbData;
+	int nbytes_read;
 
-	v2 = size;
-	v3 = dst;
+	iSize = size;
+	pszDst = dst;
 	memset(dst, 0, size);
-	if (!SRegLoadData("Diablo", "Video Player ", 0, (unsigned char *)v3, v2, (LPDWORD)&nbytes_read) || nbytes_read != v2)
-		return 0;
-	if (v2 >= 8) {
-		v6 = v2 >> 3;
-		do {
-			v7 = v3;
-			v3 += 8;
-			mpqapi_xor_buf(v7);
-			--v6;
-		} while (v6);
-	}
-	return 1;
-}
+	if (SRegLoadData("Diablo", "Video Player ", 0, (unsigned char *)pszDst, iSize, (LPDWORD)&nbytes_read))
+		if (nbytes_read != size)
+			return FALSE;
 
+	for (; iSize >= 8; iSize -=8) {
+		pbData = pszDst;
+		pszDst += 8;
+		mpqapi_xor_buf(pbData);
+	}
+
+	return TRUE;
+}
 void __fastcall mpqapi_xor_buf(char *pbData)
 {
 	signed int v1; // eax

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -8,7 +8,7 @@ extern BOOLEAN save_archive_open;     // weak
 
 BOOL __fastcall mpqapi_set_hidden(const char *pszArchive, BOOL hidden);
 void __fastcall mpqapi_store_creation_time(const char *pszArchive, int dwChar);
-BOOLEAN __fastcall mpqapi_reg_load_modification_time(char *dst, int size);
+BOOL __fastcall mpqapi_reg_load_modification_time(char *dst, int size);
 void __fastcall mpqapi_xor_buf(char *pbData);
 void __fastcall mpqapi_update_multi_creation_time(DWORD dwChar);
 BOOLEAN __fastcall mpqapi_reg_store_modification_time(char *pbData, DWORD dwLen);


### PR DESCRIPTION
Here is a screenshot of the diff (origin on the left hand side), note the unsigned int is needed, changing it to a regular int leads to the jump on line 28 turning into jl.
![image](https://user-images.githubusercontent.com/46401660/55282491-fa13e480-5344-11e9-8dbf-b09e98b56282.png)
