### PR TITLE
Fix dTransVal and pLightTbl

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -2491,7 +2491,7 @@ void __cdecl RedBack()
 
 	if(leveltype != DTYPE_HELL) {
 		dst = &gpBuffer[SCREENXY(0, 0)];
-		tbl = (BYTE *)&pLightTbl[idx];
+		tbl = &pLightTbl[idx];
 		for(h = 352; h; h--, dst += 768 - 640) {
 			for(w = 640; w; w--) {
 				*dst = tbl[*dst];
@@ -2500,7 +2500,7 @@ void __cdecl RedBack()
 		}
 	} else {
 		dst = &gpBuffer[SCREENXY(0, 0)];
-		tbl = (BYTE *)&pLightTbl[idx];
+		tbl = &pLightTbl[idx];
 		for(h = 352; h; h--, dst += 768 - 640) {
 			for(w = 640; w; w--) {
 				if(*dst >= 32)

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -126,7 +126,7 @@ void __cdecl DRLG_Init_Globals()
 		c = (light4flag) ? 3 : 15;
 	else
 		c = 0;
-	memset(dTransVal, c, sizeof(dTransVal));
+	memset(dLight, c, sizeof(dLight));
 }
 // 525728: using guessed type int light4flag;
 // 646A28: using guessed type int lightflag;
@@ -1664,7 +1664,7 @@ void __cdecl DRLG_L5FloodTVal()
 		xx = 16;
 
 		for (i = 0; i < DMAXX; i++) {
-			if (dungeon[i][j] == 13 && !dung_map[xx][yy]) {
+			if (dungeon[i][j] == 13 && !dTransVal[xx][yy]) {
 				DRLG_L5FTVR(i, j, xx, yy, 0);
 				TransVal++;
 			}
@@ -1677,36 +1677,36 @@ void __cdecl DRLG_L5FloodTVal()
 
 void __fastcall DRLG_L5FTVR(int i, int j, int x, int y, int d)
 {
-	if (dung_map[x][y] || dungeon[i][j] != 13) {
+	if (dTransVal[x][y] || dungeon[i][j] != 13) {
 		if (d == 1) {
-			dung_map[x][y] = TransVal;
-			dung_map[x][y + 1] = TransVal;
+			dTransVal[x][y] = TransVal;
+			dTransVal[x][y + 1] = TransVal;
 		}
 		if (d == 2) {
-			dung_map[x + 1][y] = TransVal;
-			dung_map[x + 1][y + 1] = TransVal;
+			dTransVal[x + 1][y] = TransVal;
+			dTransVal[x + 1][y + 1] = TransVal;
 		}
 		if (d == 3) {
-			dung_map[x][y] = TransVal;
-			dung_map[x + 1][y] = TransVal;
+			dTransVal[x][y] = TransVal;
+			dTransVal[x + 1][y] = TransVal;
 		}
 		if (d == 4) {
-			dung_map[x][y + 1] = TransVal;
-			dung_map[x + 1][y + 1] = TransVal;
+			dTransVal[x][y + 1] = TransVal;
+			dTransVal[x + 1][y + 1] = TransVal;
 		}
 		if (d == 5)
-			dung_map[x + 1][y + 1] = TransVal;
+			dTransVal[x + 1][y + 1] = TransVal;
 		if (d == 6)
-			dung_map[x][y + 1] = TransVal;
+			dTransVal[x][y + 1] = TransVal;
 		if (d == 7)
-			dung_map[x + 1][y] = TransVal;
+			dTransVal[x + 1][y] = TransVal;
 		if (d == 8)
-			dung_map[x][y] = TransVal;
+			dTransVal[x][y] = TransVal;
 	} else {
-		dung_map[x][y] = TransVal;
-		dung_map[x + 1][y] = TransVal;
-		dung_map[x][y + 1] = TransVal;
-		dung_map[x + 1][y + 1] = TransVal;
+		dTransVal[x][y] = TransVal;
+		dTransVal[x + 1][y] = TransVal;
+		dTransVal[x][y + 1] = TransVal;
+		dTransVal[x + 1][y + 1] = TransVal;
 		DRLG_L5FTVR(i + 1, j, x + 2, y, 1);
 		DRLG_L5FTVR(i - 1, j, x - 2, y, 2);
 		DRLG_L5FTVR(i, j + 1, x, y + 2, 3);
@@ -1730,25 +1730,25 @@ void __cdecl DRLG_L5TransFix()
 
 		for (i = 0; i < DMAXX; i++) {
 			if (dungeon[i][j] == 23 && dungeon[i][j - 1] == 18) {
-				dung_map[xx + 1][yy] = dung_map[xx][yy];
-				dung_map[xx + 1][yy + 1] = dung_map[xx][yy];
+				dTransVal[xx + 1][yy] = dTransVal[xx][yy];
+				dTransVal[xx + 1][yy + 1] = dTransVal[xx][yy];
 			}
 			if (dungeon[i][j] == 24 && dungeon[i + 1][j] == 19) {
-				dung_map[xx][yy + 1] = dung_map[xx][yy];
-				dung_map[xx + 1][yy + 1] = dung_map[xx][yy];
+				dTransVal[xx][yy + 1] = dTransVal[xx][yy];
+				dTransVal[xx + 1][yy + 1] = dTransVal[xx][yy];
 			}
 			if (dungeon[i][j] == 18) {
-				dung_map[xx + 1][yy] = dung_map[xx][yy];
-				dung_map[xx + 1][yy + 1] = dung_map[xx][yy];
+				dTransVal[xx + 1][yy] = dTransVal[xx][yy];
+				dTransVal[xx + 1][yy + 1] = dTransVal[xx][yy];
 			}
 			if (dungeon[i][j] == 19) {
-				dung_map[xx][yy + 1] = dung_map[xx][yy];
-				dung_map[xx + 1][yy + 1] = dung_map[xx][yy];
+				dTransVal[xx][yy + 1] = dTransVal[xx][yy];
+				dTransVal[xx + 1][yy + 1] = dTransVal[xx][yy];
 			}
 			if (dungeon[i][j] == 20) {
-				dung_map[xx + 1][yy] = dung_map[xx][yy];
-				dung_map[xx][yy + 1] = dung_map[xx][yy];
-				dung_map[xx + 1][yy + 1] = dung_map[xx][yy];
+				dTransVal[xx + 1][yy] = dTransVal[xx][yy];
+				dTransVal[xx][yy + 1] = dTransVal[xx][yy];
+				dTransVal[xx + 1][yy + 1] = dTransVal[xx][yy];
 			}
 			xx += 2;
 		}

--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -2628,7 +2628,7 @@ void __cdecl DRLG_L2FloodTVal()
 	do {
 		i = 0;
 		x = 16;
-		v2 = &dung_map[16][v0];
+		v2 = &dTransVal[16][v0];
 		v3 = (unsigned char *)dungeon + v1;
 		do {
 			if (*v3 == 3 && !*v2) {
@@ -2676,7 +2676,7 @@ void __fastcall DRLG_L2FTVR(int i, int j, int x, int y, int d)
 	v9 = 112 * x + y;
 	ja = v7;
 	v21 = v8;
-	if (!dung_map[0][v9]) {
+	if (!dTransVal[0][v9]) {
 		v19 = x;
 		ia = v8 - 1;
 		v10 = x - 2;
@@ -2685,10 +2685,10 @@ void __fastcall DRLG_L2FTVR(int i, int j, int x, int y, int d)
 		v12 = v6 - 2;
 		for (k = 40 * v8; dungeon[0][v11 + ja] == 3; v11 = k) {
 			v13 = TransVal;
-			dung_map[0][v9] = TransVal;
-			dung_map[1][v9] = v13;
-			dung_map[0][v9 + 1] = v13;
-			dung_map[1][v9 + 1] = v13;
+			dTransVal[0][v9] = TransVal;
+			dTransVal[1][v9] = v13;
+			dTransVal[0][v9 + 1] = v13;
+			dTransVal[1][v9 + 1] = v13;
 			DRLG_L2FTVR(ia + 2, ja, v10 + 4, v6, 1);
 			DRLG_L2FTVR(ia, ja, v10, v6, 2);
 			DRLG_L2FTVR(v21, ya + 2, x, v12 + 4, 3);
@@ -2708,7 +2708,7 @@ void __fastcall DRLG_L2FTVR(int i, int j, int x, int y, int d)
 			++v21;
 			++ia;
 			v9 = v19 * 112 + v6;
-			if (dung_map[v19][v6])
+			if (dTransVal[v19][v6])
 				break;
 		}
 		v5 = x;
@@ -2716,32 +2716,32 @@ void __fastcall DRLG_L2FTVR(int i, int j, int x, int y, int d)
 	v14 = TransVal;
 	if (d == 1) {
 		v15 = v6 + 112 * v5;
-		dung_map[0][v15] = TransVal;
-		dung_map[0][v15 + 1] = v14;
+		dTransVal[0][v15] = TransVal;
+		dTransVal[0][v15 + 1] = v14;
 	}
 	if (d == 2) {
 		v16 = v6 + 112 * v5;
-		dung_map[1][v16] = v14;
-		dung_map[1][v16 + 1] = v14;
+		dTransVal[1][v16] = v14;
+		dTransVal[1][v16 + 1] = v14;
 	}
 	if (d == 3) {
 		v17 = v6 + 112 * v5;
-		dung_map[0][v17] = v14;
-		dung_map[1][v17] = v14;
+		dTransVal[0][v17] = v14;
+		dTransVal[1][v17] = v14;
 	}
 	if (d == 4) {
 		v18 = v6 + 112 * v5;
-		dung_map[0][v18 + 1] = v14;
-		dung_map[1][v18 + 1] = v14;
+		dTransVal[0][v18 + 1] = v14;
+		dTransVal[1][v18 + 1] = v14;
 	}
 	if (d == 5)
-		dung_map[v5 + 1][v6 + 1] = v14;
+		dTransVal[v5 + 1][v6 + 1] = v14;
 	if (d == 6)
-		dung_map[v5][v6 + 1] = v14;
+		dTransVal[v5][v6 + 1] = v14;
 	if (d == 7)
-		dung_map[v5 + 1][v6] = v14;
+		dTransVal[v5 + 1][v6] = v14;
 	if (d == 8)
-		dung_map[v5][v6] = v14;
+		dTransVal[v5][v6] = v14;
 }
 // 5A5590: using guessed type char TransVal;
 
@@ -2760,7 +2760,7 @@ void __cdecl DRLG_L2TransFix()
 	char *v10;     // [esp+Ch] [ebp-4h]
 
 	v0 = 0;
-	v10 = &dung_map[16][16];
+	v10 = &dTransVal[16][16];
 	do {
 		v1 = v10;
 		v2 = (char *)dungeon + v0;

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -2148,7 +2148,7 @@ void __cdecl DRLG_L4FloodTVal()
 	do {
 		i = 0;
 		x = 16;
-		v2 = &dung_map[16][v0];
+		v2 = &dTransVal[16][v0];
 		v3 = (unsigned char *)dungeon + v1;
 		do {
 			if (*v3 == 6 && !*v2) {
@@ -2196,7 +2196,7 @@ void __fastcall DRLG_L4FTVR(int i, int j, int x, int y, int d)
 	v9 = 112 * x + y;
 	ja = v7;
 	v21 = v8;
-	if (!dung_map[0][v9]) {
+	if (!dTransVal[0][v9]) {
 		v19 = x;
 		ia = v8 - 1;
 		v10 = x - 2;
@@ -2205,10 +2205,10 @@ void __fastcall DRLG_L4FTVR(int i, int j, int x, int y, int d)
 		v12 = v6 - 2;
 		for (k = 40 * v8; dungeon[0][v11 + ja] == 6; v11 = k) {
 			v13 = TransVal;
-			dung_map[0][v9] = TransVal;
-			dung_map[1][v9] = v13;
-			dung_map[0][v9 + 1] = v13;
-			dung_map[1][v9 + 1] = v13;
+			dTransVal[0][v9] = TransVal;
+			dTransVal[1][v9] = v13;
+			dTransVal[0][v9 + 1] = v13;
+			dTransVal[1][v9 + 1] = v13;
 			DRLG_L4FTVR(ia + 2, ja, v10 + 4, v6, 1);
 			DRLG_L4FTVR(ia, ja, v10, v6, 2);
 			DRLG_L4FTVR(v21, ya + 2, x, v12 + 4, 3);
@@ -2228,7 +2228,7 @@ void __fastcall DRLG_L4FTVR(int i, int j, int x, int y, int d)
 			++v21;
 			++ia;
 			v9 = v19 * 112 + v6;
-			if (dung_map[v19][v6])
+			if (dTransVal[v19][v6])
 				break;
 		}
 		v5 = x;
@@ -2236,32 +2236,32 @@ void __fastcall DRLG_L4FTVR(int i, int j, int x, int y, int d)
 	v14 = TransVal;
 	if (d == 1) {
 		v15 = v6 + 112 * v5;
-		dung_map[0][v15] = TransVal;
-		dung_map[0][v15 + 1] = v14;
+		dTransVal[0][v15] = TransVal;
+		dTransVal[0][v15 + 1] = v14;
 	}
 	if (d == 2) {
 		v16 = v6 + 112 * v5;
-		dung_map[1][v16] = v14;
-		dung_map[1][v16 + 1] = v14;
+		dTransVal[1][v16] = v14;
+		dTransVal[1][v16 + 1] = v14;
 	}
 	if (d == 3) {
 		v17 = v6 + 112 * v5;
-		dung_map[0][v17] = v14;
-		dung_map[1][v17] = v14;
+		dTransVal[0][v17] = v14;
+		dTransVal[1][v17] = v14;
 	}
 	if (d == 4) {
 		v18 = v6 + 112 * v5;
-		dung_map[0][v18 + 1] = v14;
-		dung_map[1][v18 + 1] = v14;
+		dTransVal[0][v18 + 1] = v14;
+		dTransVal[1][v18 + 1] = v14;
 	}
 	if (d == 5)
-		dung_map[v5 + 1][v6 + 1] = v14;
+		dTransVal[v5 + 1][v6 + 1] = v14;
 	if (d == 6)
-		dung_map[v5][v6 + 1] = v14;
+		dTransVal[v5][v6 + 1] = v14;
 	if (d == 7)
-		dung_map[v5 + 1][v6] = v14;
+		dTransVal[v5 + 1][v6] = v14;
 	if (d == 8)
-		dung_map[v5][v6] = v14;
+		dTransVal[v5][v6] = v14;
 }
 // 5A5590: using guessed type char TransVal;
 
@@ -2275,7 +2275,7 @@ void __cdecl DRLG_L4TransFix()
 	char *v5;      // [esp+10h] [ebp-4h]
 
 	v0 = 0;
-	v5 = &dung_map[16][16];
+	v5 = &dTransVal[16][16];
 	do {
 		v1 = v5;
 		v2 = (char *)dungeon + v0;

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -341,7 +341,7 @@ void __fastcall CelDecDatLightOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSi
 
 	src = pRLEBytes;
 	dst = pDecodeTo;
-	tbl = (BYTE *)&pLightTbl[light_table_index * 256];
+	tbl = &pLightTbl[light_table_index * 256];
 	w = nWidth;
 
 	for(; src != &pRLEBytes[nDataSize]; dst -= 768 + w) {
@@ -505,7 +505,7 @@ void __fastcall CelDecDatLightTrans(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataS
 
 	src = pRLEBytes;
 	dst = pDecodeTo;
-	tbl = (BYTE *)&pLightTbl[light_table_index * 256];
+	tbl = &pLightTbl[light_table_index * 256];
 	w = nWidth;
 	shift = (BYTE)dst & 1;
 
@@ -712,7 +712,7 @@ void __fastcall CelDrawHdrLightRed(int sx, int sy, BYTE *pCelBuff, int nCel, int
 	if(light >= 4)
 		idx += (light - 1) << 8;
 
-	tbl = (BYTE *)&pLightTbl[idx];
+	tbl = &pLightTbl[idx];
 
 #if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
 	__asm {
@@ -1092,7 +1092,7 @@ void __fastcall Cel2DecDatLightOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataS
 
 	src = pRLEBytes;
 	dst = pDecodeTo;
-	tbl = (BYTE *)&pLightTbl[light_table_index * 256];
+	tbl = &pLightTbl[light_table_index * 256];
 	w = nWidth;
 
 	for(; src != &pRLEBytes[nDataSize]; dst -= 768 + w) {
@@ -1271,7 +1271,7 @@ void __fastcall Cel2DecDatLightTrans(BYTE *pDecodeTo, BYTE *pRLEBytes, int nData
 
 	src = pRLEBytes;
 	dst = pDecodeTo;
-	tbl = (BYTE *)&pLightTbl[light_table_index * 256];
+	tbl = &pLightTbl[light_table_index * 256];
 	w = nWidth;
 	shift = (BYTE)dst & 1;
 
@@ -1452,7 +1452,7 @@ void __fastcall Cel2DrawHdrLightRed(int sx, int sy, BYTE *pCelBuff, int nCel, in
 	if(light >= 4)
 		idx += (light - 1) << 8;
 
-	tbl = (BYTE *)&pLightTbl[idx];
+	tbl = &pLightTbl[idx];
 
 #if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
 	__asm {
@@ -2891,7 +2891,7 @@ void __fastcall Cl2DecodeFrm3(int sx, int sy, BYTE *pCelBuff, int nCel, int nWid
 		&pRLEBytes[hdr],
 		nDataSize - hdr,
 		nWidth,
-		(BYTE *)&pLightTbl[idx]);
+		&pLightTbl[idx]);
 }
 // 525728: using guessed type int light4flag;
 
@@ -3080,7 +3080,7 @@ void __fastcall Cl2DecodeLightTbl(int sx, int sy, BYTE *pCelBuff, int nCel, int 
 	pDecodeTo = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	if(light_table_index)
-		Cl2DecDatLightTbl1(pDecodeTo, &pRLEBytes[hdr], nDataSize - hdr, nWidth, (BYTE *)&pLightTbl[light_table_index * 256]);
+		Cl2DecDatLightTbl1(pDecodeTo, &pRLEBytes[hdr], nDataSize - hdr, nWidth, &pLightTbl[light_table_index * 256]);
 	else
 		Cl2DecDatFrm1(pDecodeTo, &pRLEBytes[hdr], nDataSize - hdr, nWidth);
 }
@@ -3537,7 +3537,7 @@ void __fastcall Cl2DecodeFrm5(int sx, int sy, BYTE *pCelBuff, int nCel, int nWid
 		&pRLEBytes[hdr],
 		nDataSize - hdr,
 		nWidth,
-		(BYTE *)&pLightTbl[idx]);
+		&pLightTbl[idx]);
 }
 // 525728: using guessed type int light4flag;
 
@@ -3740,7 +3740,7 @@ void __fastcall Cl2DecodeFrm6(int sx, int sy, BYTE *pCelBuff, int nCel, int nWid
 	pDecodeTo = &gpBuffer[sx + screen_y_times_768[sy - 16 * always_0]];
 
 	if(light_table_index)
-		Cl2DecDatLightTbl2(pDecodeTo, &pRLEBytes[hdr], nDataSize - hdr, nWidth, (BYTE *)&pLightTbl[light_table_index * 256]);
+		Cl2DecDatLightTbl2(pDecodeTo, &pRLEBytes[hdr], nDataSize - hdr, nWidth, &pLightTbl[light_table_index * 256]);
 	else
 		Cl2DecDatFrm4(pDecodeTo, &pRLEBytes[hdr], nDataSize - hdr, nWidth);
 }

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -14,12 +14,12 @@ int nlevel_frames; // weak
 char pdungeon[40][40];
 char dDead[MAXDUNX][MAXDUNY];
 WORD dpiece_defs_map_1[MAXDUNX * MAXDUNY][16];
-char dTransVal2[MAXDUNX][MAXDUNY];
+char dPreLight[MAXDUNX][MAXDUNY];
 char TransVal; // weak
 int MicroTileLen;
 char dflags[40][40];
 int dPiece[MAXDUNX][MAXDUNY];
-char dTransVal[MAXDUNX][MAXDUNY];
+char dLight[MAXDUNX][MAXDUNY];
 int setloadflag_2; // weak
 int tile_defs[MAXTILES];
 BYTE *pMegaTiles;
@@ -27,7 +27,7 @@ BYTE *pLevelPieces;
 int gnDifficulty; // idb
 char block_lvid[2049];
 //char byte_5B78EB;
-char dung_map[MAXDUNX][MAXDUNY];
+char dTransVal[MAXDUNX][MAXDUNY];
 BOOLEAN nTrapTable[2049];
 BYTE leveltype;
 unsigned char currlevel; // idb
@@ -348,7 +348,7 @@ void __cdecl MakeSpeedCels()
 #else
 				src = &pDungeonCels[pFrameTable[currtile]];
 				dst = &pSpeedCels[frameidx];
-				tbl = (BYTE *)&pLightTbl[256 * j];
+				tbl = &pLightTbl[256 * j];
 				for(k = lfs_adder; k; k--) {
 					*dst++ = tbl[*src++];
 				}
@@ -402,7 +402,7 @@ void __cdecl MakeSpeedCels()
 #else
 				src = &pDungeonCels[pFrameTable[currtile]];
 				dst = &pSpeedCels[frameidx];
-				tbl = (BYTE *)&pLightTbl[256 * j];
+				tbl = &pLightTbl[256 * j];
 				for(k = 32; k; k--) {
 					for(l = 32; l;) {
 						width = *src++;
@@ -560,7 +560,7 @@ void __cdecl SetDungeonMicros()
 
 void __cdecl DRLG_InitTrans()
 {
-	memset(dung_map, 0, sizeof(dung_map));
+	memset(dTransVal, 0, sizeof(dTransVal));
 	memset(TransList, 0, sizeof(TransList));
 	TransVal = 1;
 }
@@ -580,7 +580,7 @@ void __fastcall DRLG_MRectTrans(int x1, int y1, int x2, int y2)
 	i = 2 * y1 + 17;
 	for (ty_enda = 2 * y2 + 16; i <= ty_enda; ++i) {
 		if (v4 <= v5) {
-			v7 = &dung_map[v4][i];
+			v7 = &dTransVal[v4][i];
 			j = v5 - v4 + 1;
 			do {
 				*v7 = TransVal;
@@ -601,7 +601,7 @@ void __fastcall DRLG_RectTrans(int x1, int y1, int x2, int y2)
 
 	for (i = y1; i <= y2; ++i) {
 		if (x1 <= x2) {
-			v5 = &dung_map[x1][i];
+			v5 = &dTransVal[x1][i];
 			j = x2 - x1 + 1;
 			do {
 				*v5 = TransVal;
@@ -616,7 +616,7 @@ void __fastcall DRLG_RectTrans(int x1, int y1, int x2, int y2)
 
 void __fastcall DRLG_CopyTrans(int sx, int sy, int dx, int dy)
 {
-	dung_map[dx][dy] = dung_map[sx][sy];
+	dTransVal[dx][dy] = dTransVal[sx][sy];
 }
 
 void __fastcall DRLG_ListTrans(int num, unsigned char *List)

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -14,12 +14,12 @@ extern int nlevel_frames; // weak
 extern char pdungeon[40][40];
 extern char dDead[MAXDUNX][MAXDUNY];
 extern WORD dpiece_defs_map_1[MAXDUNX * MAXDUNY][16];
-extern char dTransVal2[MAXDUNX][MAXDUNY];
+extern char dPreLight[MAXDUNX][MAXDUNY];
 extern char TransVal; // weak
 extern int MicroTileLen;
 extern char dflags[40][40];
 extern int dPiece[MAXDUNX][MAXDUNY];
-extern char dTransVal[MAXDUNX][MAXDUNY];
+extern char dLight[MAXDUNX][MAXDUNY];
 extern int setloadflag_2; // weak
 extern int tile_defs[MAXTILES];
 extern BYTE *pMegaTiles;
@@ -27,7 +27,7 @@ extern BYTE *pLevelPieces;
 extern int gnDifficulty; // idb
 extern char block_lvid[2049];
 //char byte_5B78EB;
-extern char dung_map[MAXDUNX][MAXDUNY];
+extern char dTransVal[MAXDUNX][MAXDUNY];
 extern BOOLEAN nTrapTable[2049];
 extern BYTE leveltype;
 extern unsigned char currlevel; // idb

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -1288,8 +1288,8 @@ void __cdecl lighting_color_cycling()
 			tbl[0] = tbl[1];
 			tbl++;
 		}
-		*tbl = col;
-		tbl += 225;
+		*tbl++ = col;
+		tbl += 224;
 	}
 }
 // 525728: using guessed type int light4flag;

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -13,7 +13,7 @@ char lightmax;             // weak
 int dolighting;            // weak
 BYTE lightblock[8][8][16][16];
 int visionid;
-char *pLightTbl; /* todo: struct? */
+BYTE *pLightTbl;
 BOOL lightflag;
 
 char CrawlTable[2749] = {
@@ -529,7 +529,7 @@ void __fastcall DoLighting(int nXPos, int nYPos, int nRadius, int Lnum)
 	}
 
 	if(nXPos >= 0 && nXPos < MAXDUNX && nYPos >= 0 && nYPos < MAXDUNY) {
-		dTransVal[nXPos][nYPos] = 0;
+		dLight[nXPos][nYPos] = 0;
 	}
 
 	mult = xoff + 8 * yoff;
@@ -541,8 +541,8 @@ void __fastcall DoLighting(int nXPos, int nYPos, int nRadius, int Lnum)
 				temp_y = nYPos + y;
 				v = lightradius[nRadius][radius_block];
 				if(temp_x >= 0 && temp_x < MAXDUNX && temp_y >= 0 && temp_y < MAXDUNY) {
-					if(v < dTransVal[temp_x][temp_y]) {
-						dTransVal[temp_x][temp_y] = v;
+					if(v < dLight[temp_x][temp_y]) {
+						dLight[temp_x][temp_y] = v;
 					}
 				}
 			}
@@ -558,8 +558,8 @@ void __fastcall DoLighting(int nXPos, int nYPos, int nRadius, int Lnum)
 				temp_y = nYPos - x;
 				v = lightradius[nRadius][radius_block];
 				if(temp_x >= 0 && temp_x < MAXDUNX && temp_y >= 0 && temp_y < MAXDUNY) {
-					if(v < dTransVal[temp_x][temp_y]) {
-						dTransVal[temp_x][temp_y] = v;
+					if(v < dLight[temp_x][temp_y]) {
+						dLight[temp_x][temp_y] = v;
 					}
 				}
 			}
@@ -575,8 +575,8 @@ void __fastcall DoLighting(int nXPos, int nYPos, int nRadius, int Lnum)
 				temp_y = nYPos - y;
 				v = lightradius[nRadius][radius_block];
 				if(temp_x >= 0 && temp_x < MAXDUNX && temp_y >= 0 && temp_y < MAXDUNY) {
-					if(v < dTransVal[temp_x][temp_y]) {
-						dTransVal[temp_x][temp_y] = v;
+					if(v < dLight[temp_x][temp_y]) {
+						dLight[temp_x][temp_y] = v;
 					}
 				}
 			}
@@ -592,8 +592,8 @@ void __fastcall DoLighting(int nXPos, int nYPos, int nRadius, int Lnum)
 				temp_y = nYPos + x;
 				v = lightradius[nRadius][radius_block];
 				if(temp_x >= 0 && temp_x < MAXDUNX && temp_y >= 0 && temp_y < MAXDUNY) {
-					if(v < dTransVal[temp_x][temp_y]) {
-						dTransVal[temp_x][temp_y] = v;
+					if(v < dLight[temp_x][temp_y]) {
+						dLight[temp_x][temp_y] = v;
 					}
 				}
 			}
@@ -629,7 +629,7 @@ void __fastcall DoUnLight(int nXPos, int nYPos, int nRadius)
 			v8 = radius_block + 112 * x;
 			do {
 				if (v7 >= 0 && v7 < 112 && radius_block >= 0 && radius_block < 112)
-					dTransVal[0][v8] = dTransVal2[0][v8];
+					dLight[0][v8] = dPreLight[0][v8];
 				++v7;
 				v8 += 112;
 			} while (v7 < max_x);
@@ -747,7 +747,7 @@ void __fastcall DoVision(int nXPos, int nYPos, int nRadius, BOOL doautomap, BOOL
 						}
 						dFlags[nCrawlX][nCrawlY] |= DFLAG_VISIBLE;
 						if(!nBlockerFlag) {
-							nTrans = dung_map[nCrawlX][nCrawlY];
+							nTrans = dTransVal[nCrawlX][nCrawlY];
 							if(nTrans != 0) {
 								TransList[nTrans] = 1;
 							}
@@ -761,7 +761,7 @@ void __fastcall DoVision(int nXPos, int nYPos, int nRadius, BOOL doautomap, BOOL
 
 void __cdecl FreeLightTable()
 {
-	char *ptr;
+	BYTE *ptr;
 
 	ptr = pLightTbl;
 	pLightTbl = NULL;
@@ -770,7 +770,7 @@ void __cdecl FreeLightTable()
 
 void __cdecl InitLightTable()
 {
-	pLightTbl = (char *)DiabloAllocPtr(LIGHTSIZE);
+	pLightTbl = DiabloAllocPtr(LIGHTSIZE);
 }
 
 void __cdecl MakeLightTable()
@@ -781,7 +781,7 @@ void __cdecl MakeLightTable()
 	BYTE *tbl, *trn;
 	BYTE blood[16];
 
-	tbl = (BYTE *)pLightTbl;
+	tbl = pLightTbl;
 	shade = 0;
 
 	if(light4flag) {
@@ -849,7 +849,7 @@ void __cdecl MakeLightTable()
 	}
 
 	if(leveltype == DTYPE_HELL) {
-		tbl = (BYTE *)pLightTbl;
+		tbl = pLightTbl;
 		for(i = 0; i < lights; i++) {
 			l1 = lights - i;
 			l2 = l1;
@@ -962,9 +962,9 @@ void __cdecl ToggleLighting()
 
 	lightflag ^= 1;
 	if (lightflag) {
-		memset(dTransVal, 0, sizeof(dTransVal));
+		memset(dLight, 0, sizeof(dLight));
 	} else {
-		memcpy(dTransVal, dTransVal2, sizeof(dTransVal));
+		memcpy(dLight, dPreLight, sizeof(dLight));
 		for (i = 0; i < 4; i++) {
 			if (plr[i].plractive) {
 				if (currlevel == plr[i].plrlevel)
@@ -1148,7 +1148,7 @@ void __cdecl ProcessLightList()
 
 void __cdecl SavePreLighting()
 {
-	memcpy(dTransVal2, dTransVal, 0x3100u);
+	memcpy(dPreLight, dLight, 0x3100u);
 }
 
 void __cdecl InitVision()
@@ -1279,7 +1279,7 @@ void __cdecl lighting_color_cycling()
 		return;
 	}
 
-	tbl = (BYTE *)pLightTbl;
+	tbl = pLightTbl;
 
 	for(j = 0; j < l; j++) {
 		tbl++;

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -13,7 +13,7 @@ extern char lightmax;             // weak
 extern int dolighting;            // weak
 extern BYTE lightblock[8][8][16][16];
 extern int visionid;
-extern char *pLightTbl; /* todo: struct? */
+extern BYTE *pLightTbl;
 extern BOOL lightflag;
 
 void __fastcall RotateRadius(int *x, int *y, int *dx, int *dy, int *lx, int *ly, int *bx, int *by);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -105,7 +105,7 @@ void __fastcall LoadGame(BOOL firstflag)
 
 	for (j = 0; j < MAXDUNY; j++) {
 		for (i = 0; i < MAXDUNX; i++)
-			dTransVal[i][j] = BLoad();
+			dLight[i][j] = BLoad();
 	}
 	for (j = 0; j < MAXDUNY; j++) {
 		for (i = 0; i < MAXDUNX; i++)
@@ -135,11 +135,11 @@ void __fastcall LoadGame(BOOL firstflag)
 		}
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
-				dTransVal[i][j] = BLoad();
+				dLight[i][j] = BLoad();
 		}
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
-				dTransVal2[i][j] = BLoad();
+				dPreLight[i][j] = BLoad();
 		}
 		for (j = 0; j < DMAXY; j++) {
 			for (i = 0; i < DMAXX; i++)
@@ -355,7 +355,7 @@ void __cdecl SaveGame()
 
 	for (j = 0; j < MAXDUNY; j++) {
 		for (i = 0; i < MAXDUNX; i++)
-			BSave(dTransVal[i][j]);
+			BSave(dLight[i][j]);
 	}
 	for (j = 0; j < MAXDUNY; j++) {
 		for (i = 0; i < MAXDUNX; i++)
@@ -385,11 +385,11 @@ void __cdecl SaveGame()
 		}
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
-				BSave(dTransVal[i][j]);
+				BSave(dLight[i][j]);
 		}
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
-				BSave(dTransVal2[i][j]);
+				BSave(dPreLight[i][j]);
 		}
 		for (j = 0; j < DMAXY; j++) {
 			for (i = 0; i < DMAXX; i++)
@@ -578,11 +578,11 @@ void __cdecl SaveLevel()
 		}
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
-				BSave(dTransVal[i][j]);
+				BSave(dLight[i][j]);
 		}
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
-				BSave(dTransVal2[i][j]);
+				BSave(dPreLight[i][j]);
 		}
 		for (j = 0; j < DMAXY; j++) {
 			for (i = 0; i < DMAXX; i++)
@@ -671,11 +671,11 @@ void __cdecl LoadLevel()
 		}
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
-				dTransVal[i][j] = BLoad();
+				dLight[i][j] = BLoad();
 		}
 		for (j = 0; j < MAXDUNY; j++) {
 			for (i = 0; i < MAXDUNX; i++)
-				dTransVal2[i][j] = BLoad();
+				dPreLight[i][j] = BLoad();
 		}
 		for (j = 0; j < DMAXY; j++) {
 			for (i = 0; i < DMAXX; i++)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3282,20 +3282,20 @@ void __fastcall MI_Fireball(int i)
 				CheckMissileCol(i, dam, dam, 0, mx - 1, my + 1, 1);
 			if (!CheckBlock(px, py, mx - 1, my - 1))
 				CheckMissileCol(i, dam, dam, 0, mx - 1, my - 1, 1);
-			if (!TransList[dung_map[mx][my]]
-			    || (missile[i]._mixvel < 0 && ((TransList[dung_map[mx][my + 1]] && nSolidTable[dPiece[mx][my + 1]]) || (TransList[dung_map[mx][my - 1]] && nSolidTable[dPiece[mx][my - 1]])))) {
+			if (!TransList[dTransVal[mx][my]]
+			    || (missile[i]._mixvel < 0 && ((TransList[dTransVal[mx][my + 1]] && nSolidTable[dPiece[mx][my + 1]]) || (TransList[dTransVal[mx][my - 1]] && nSolidTable[dPiece[mx][my - 1]])))) {
 				missile[i]._mix++;
 				missile[i]._miy++;
 				missile[i]._miyoff -= 32;
 			}
 			if (missile[i]._miyvel > 0
-			    && (TransList[dung_map[mx + 1][my]] && nSolidTable[dPiece[mx + 1][my]]
-			           || TransList[dung_map[mx - 1][my]] && nSolidTable[dPiece[mx - 1][my]])) {
+			    && (TransList[dTransVal[mx + 1][my]] && nSolidTable[dPiece[mx + 1][my]]
+			           || TransList[dTransVal[mx - 1][my]] && nSolidTable[dPiece[mx - 1][my]])) {
 				missile[i]._miyoff -= 32;
 			}
 			if (missile[i]._mixvel > 0
-			    && (TransList[dung_map[mx][my + 1]] && nSolidTable[dPiece[mx][my + 1]]
-			           || TransList[dung_map[mx][my - 1]] && nSolidTable[dPiece[mx][my - 1]])) {
+			    && (TransList[dTransVal[mx][my + 1]] && nSolidTable[dPiece[mx][my + 1]]
+			           || TransList[dTransVal[mx][my - 1]] && nSolidTable[dPiece[mx][my - 1]])) {
 				missile[i]._mixoff -= 32;
 			}
 			missile[i]._mimfnum = 0;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -986,7 +986,7 @@ void __fastcall PlaceUniqueMonst(int uniqindex, int miniontype, int packsize)
 	}
 
 	sprintf(filestr, "Monsters\\Monsters\\%s.TRN", Uniq->mTrnName);
-	LoadFileWithMem(filestr, (BYTE *)&pLightTbl[256 * (uniquetrans + 19)]);
+	LoadFileWithMem(filestr, &pLightTbl[256 * (uniquetrans + 19)]);
 
 	Monst->_uniqtrans = uniquetrans++;
 
@@ -1120,7 +1120,7 @@ void __fastcall PlaceGroup(int mtype, int num, int leaderf, int leader)
 		j = 0;
 		for (try2 = 0; j < num && try2 < 100; xp += offset_x[random(94, 8)], yp += offset_x[random(94, 8)]) {
 			if (!MonstPlace(xp, yp)
-			    || (dung_map[x1][y1] != dung_map[xp][yp])
+			    || (dTransVal[x1][y1] != dTransVal[xp][yp])
 			    || (leaderf & 2) && ((abs(xp - x1) >= 4) || (abs(yp - y1) >= 4))) {
 				try2++;
 				continue;
@@ -1539,7 +1539,7 @@ void __fastcall M_Enemy(int i)
 				goto LABEL_18;
 			v3 = v1->_my;
 			v4 = v2[2];
-			v19 = dung_map[v2[1]][v4] == dung_map[v1->_mx][v3];
+			v19 = dTransVal[v2[1]][v4] == dTransVal[v1->_mx][v3];
 			v5 = abs(v3 - v4);
 			if (abs(v1->_mx - v2[1]) <= v5)
 				v6 = v1->_my - v2[2];
@@ -1587,7 +1587,7 @@ void __fastcall M_Enemy(int i)
 		}
 		v12 = v1->_my;
 		v13 = monster[v10]._my;
-		v20 = dung_map[monster[v10]._mx][v13] == dung_map[v1->_mx][v12];
+		v20 = dTransVal[monster[v10]._mx][v13] == dTransVal[v1->_mx][v12];
 		v14 = abs(v12 - v13);
 		if (abs(v1->_mx - monster[v10]._mx) <= v14)
 			v15 = v1->_my - monster[v10]._my;
@@ -3984,7 +3984,7 @@ void __fastcall MAI_Sneak(int i)
 	v2 = &monster[v1];
 	if (v2->_mmode == MM_STAND) {
 		v3 = v2->_my;
-		if (dTransVal[v2->_mx][v3] != lightmax) {
+		if (dLight[v2->_mx][v3] != lightmax) {
 			v17 = v2->_mx - (unsigned char)v2->_menemyx;
 			v4 = v3 - (unsigned char)v2->_menemyy;
 			md = M_GetDir(v1);
@@ -4255,8 +4255,8 @@ void __fastcall MAI_Round(int i, BOOL special)
 			MonstCheckDoors(arglist);
 		v30 = random(114, 100);
 		if ((abs(v7) >= 2 || abs(v32) >= 2) && v3->_msquelch == -1) {
-			v29 = &dung_map[v6][v28];
-			if (dung_map[v3->_mx][v3->_my] == *v29) {
+			v29 = &dTransVal[v6][v28];
+			if (dTransVal[v3->_mx][v3->_my] == *v29) {
 				if (_LOBYTE(v3->_mgoal) != MGOAL_MOVE) {
 					v9 = abs(v7);
 					//v11 = v10;
@@ -4282,7 +4282,7 @@ void __fastcall MAI_Round(int i, BOOL special)
 				v17 = v3->_mgoalvar1;
 				v3->_mgoalvar1 = v17 + 1;
 				if (v17 < 2 * v16 || (v18 = DirOK(arglist, md), !v18)) {
-					if (dung_map[v3->_mx][v3->_my] == *v29) {
+					if (dTransVal[v3->_mx][v3->_my] == *v29) {
 						//_LOBYTE(v19) = M_RoundWalk(arglist, md, &v3->_mgoalvar2);
 						if (!M_RoundWalk(arglist, md, &v3->_mgoalvar2)) {
 							v21 = random(125, 10);
@@ -4622,7 +4622,7 @@ void __fastcall MAI_RoundRanged(int i, int missile_type, unsigned char checkdoor
 		if (v6->_msquelch != -1)
 			goto LABEL_50;
 		//v13 = y2;
-		if (dung_map[v6->_mx][v6->_my] != dung_map[x2][y2])
+		if (dTransVal[v6->_mx][v6->_my] != dTransVal[x2][y2])
 			goto LABEL_50;
 		if (_LOBYTE(v6->_mgoal) != MGOAL_MOVE) {
 			if (abs(v9) < 3) {
@@ -4776,7 +4776,7 @@ void __fastcall MAI_RR2(int i, int mistype, int dam)
 		{
 			if (v4->_msquelch == -1) {
 				//v12 = y2;
-				if (dung_map[v4->_mx][v4->_my] == dung_map[x2][y2]) {
+				if (dTransVal[v4->_mx][v4->_my] == dTransVal[x2][y2]) {
 					if (_LOBYTE(v4->_mgoal) != MGOAL_MOVE) {
 						v15 = abs(v8);
 						//v12 = v16;
@@ -4997,8 +4997,8 @@ void __fastcall MAI_SkelKing(int i)
 			MonstCheckDoors(arglist);
 		v35 = random(126, 100);
 		if ((abs(v5) >= 2 || abs(v4) >= 2) && v2->_msquelch == -1) {
-			v32 = &dung_map[x2][y2];
-			if (dung_map[v2->_mx][v2->_my] == *v32) {
+			v32 = &dTransVal[x2][y2];
+			if (dTransVal[v2->_mx][v2->_my] == *v32) {
 				if (_LOBYTE(v2->_mgoal) != MGOAL_MOVE) {
 					v7 = abs(v5);
 					//v9 = v8;
@@ -5027,7 +5027,7 @@ void __fastcall MAI_SkelKing(int i)
 				v15 = v2->_mgoalvar1;
 				v2->_mgoalvar1 = v15 + 1;
 				if (v15 < 2 * v14 || (v16 = DirOK(arglist, md), !v16)) {
-					if (dung_map[v2->_mx][v2->_my] == *v32) {
+					if (dTransVal[v2->_mx][v2->_my] == *v32) {
 						//_LOBYTE(v17) = M_RoundWalk(arglist, md, &v2->_mgoalvar2);
 						if (!M_RoundWalk(arglist, md, &v2->_mgoalvar2)) {
 							v19 = random(125, 10);
@@ -5153,7 +5153,7 @@ void __fastcall MAI_Rhino(int i)
 			}
 			v15 = esi3->_mgoalvar1;
 			esi3->_mgoalvar1 = v15 + 1;
-			if (v15 < 2 * v14 && dung_map[esi3->_mx][esi3->_my] == dung_map[v1][v2]) {
+			if (v15 < 2 * v14 && dTransVal[esi3->_mx][esi3->_my] == dTransVal[v1][v2]) {
 				//_LOBYTE(v16) = M_RoundWalk(arglist, midir, &esi3->_mgoalvar2);
 				if (!M_RoundWalk(arglist, midir, &esi3->_mgoalvar2)) {
 					v18 = random(125, 10);
@@ -5288,7 +5288,7 @@ void __fastcall MAI_Counselor(int i)
 			v18 = v17;
 			if (abs(v4) < 2 && abs(v6) < 2
 			    || monster[v2]._msquelch != -1
-			    || dung_map[monster[v2]._mx][monster[v2]._my] != dung_map[x2][y2]) {
+			    || dTransVal[monster[v2]._mx][monster[v2]._my] != dTransVal[x2][y2]) {
 				v1 = arglist;
 			LABEL_20:
 				v15 = v1;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1034,7 +1034,7 @@ void __fastcall PlrClrTrans(int x, int y)
 
 	for (i = y - 1; i <= y + 1; i++) {
 		for (j = x - 1; j <= x + 1; j++) {
-			TransList[dung_map[j][i]] = 0;
+			TransList[dTransVal[j][i]] = 0;
 		}
 	}
 }
@@ -1048,8 +1048,8 @@ void __fastcall PlrDoTrans(int x, int y)
 	} else {
 		for (i = y - 1; i <= y + 1; i++) {
 			for (j = x - 1; j <= x + 1; j++) {
-				if (!nSolidTable[dPiece[j][i]] && dung_map[j][i]) {
-					TransList[dung_map[j][i]] = 1;
+				if (!nSolidTable[dPiece[j][i]] && dTransVal[j][i]) {
+					TransList[dTransVal[j][i]] = 1;
 				}
 			}
 		}

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -109,7 +109,7 @@ void __fastcall drawTopArchesUpperScreen(BYTE *pBuff)
 	if ((_BYTE)light_table_index != lightmax) {
 		if (!(level_cel_block & 0x8000)) {
 			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
-			tbl = (unsigned char *)&pLightTbl[256 * light_table_index];
+			tbl = &pLightTbl[256 * light_table_index];
 			cel_type_16 = (unsigned char)(level_cel_block >> 12);
 			switch (cel_type_16) {
 			case 0: // upper (top transparent), with lighting
@@ -1364,7 +1364,7 @@ void __fastcall drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 	if ((_BYTE)light_table_index != lightmax) {
 		if (!(level_cel_block & 0x8000)) {
 			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
-			tbl = (unsigned char *)&pLightTbl[256 * light_table_index];
+			tbl = &pLightTbl[256 * light_table_index];
 			cel_type_16 = (unsigned char)(level_cel_block >> 12);
 			switch (cel_type_16) {
 			case 0: // upper (bottom transparent), with lighting
@@ -2005,7 +2005,7 @@ void __fastcall drawUpperScreen(BYTE *pBuff)
 	if ((_BYTE)light_table_index != lightmax) {
 		if (!(level_cel_block & 0x8000)) {
 			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
-			tbl = (unsigned char *)&pLightTbl[256 * light_table_index];
+			tbl = &pLightTbl[256 * light_table_index];
 			cel_type_16 = (unsigned short)level_cel_block >> 12;
 			switch (cel_type_16) {
 			case 0: // upper (solid), with lighting
@@ -2834,7 +2834,7 @@ void __fastcall drawTopArchesLowerScreen(BYTE *pBuff)
 	}
 	if (!(level_cel_block & 0x8000)) {
 		src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
-		tbl = (unsigned char *)&pLightTbl[256 * light_table_index];
+		tbl = &pLightTbl[256 * light_table_index];
 		cel_type_16 = (unsigned char)(level_cel_block >> 12);
 		switch (cel_type_16) {
 		case 0: // lower (top transparent), with lighting
@@ -3882,7 +3882,7 @@ void __fastcall drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 		}
 		if (!(level_cel_block & 0x8000)) {
 			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
-			tbl = (unsigned char *)&pLightTbl[256 * light_table_index];
+			tbl = &pLightTbl[256 * light_table_index];
 			cel_type_16 = (unsigned char)(level_cel_block >> 12);
 			switch (cel_type_16) {
 			case 0: // lower (bottom transparent), with lighting
@@ -4684,7 +4684,7 @@ void __fastcall drawLowerScreen(BYTE *pBuff)
 		}
 		if (!(level_cel_block & 0x8000)) {
 			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
-			tbl = (unsigned char *)&pLightTbl[256 * light_table_index];
+			tbl = &pLightTbl[256 * light_table_index];
 			cel_type_16 = (unsigned short)level_cel_block >> 12;
 			switch (cel_type_16) {
 			case 0: // lower (solid), with lighting

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -76,7 +76,7 @@ void __fastcall DrawMissile(int x, int y, int sx, int sy, int a5, int a6, BOOL p
 
 	if(dMissile[x][y] == -1) {
 		for(i = 0; i < nummissiles; i++) {
-			/// ASSERT: assert(missileactive[i] < MAXMISSILES)
+			/// ASSERT: assert(missileactive[i] < MAXMISSILES);
 			if(missileactive[i] >= MAXMISSILES)
 				break;
 			m = &missile[missileactive[i]];
@@ -137,7 +137,7 @@ void __fastcall DrawClippedMissile(int x, int y, int sx, int sy, int a5, int a6,
 
 	if(dMissile[x][y] == -1) {
 		for(i = 0; i < nummissiles; i++) {
-			/// ASSERT: assert(missileactive[i] < MAXMISSILES)
+			/// ASSERT: assert(missileactive[i] < MAXMISSILES);
 			if(missileactive[i] >= MAXMISSILES)
 				break;
 			m = &missile[missileactive[i]];
@@ -557,10 +557,10 @@ void __fastcall scrollrt_draw_lower(int x, int y, int sx, int sy, int a5, int so
 	if(some_flag) {
 		if((DWORD)y < MAXDUNY && (DWORD)x < MAXDUNX) {
 			level_piece_id = dPiece[x][y];
-			light_table_index = dTransVal[x][y];
+			light_table_index = dLight[x][y];
 			if(level_piece_id != 0) {
 				dst = &gpBuffer[sx + 32 + screen_y_times_768[sy]];
-				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 				arch_draw_type = 2;
 				level_cel_block = pMap[1];
 				if(level_cel_block != 0) {
@@ -612,12 +612,12 @@ void __fastcall scrollrt_draw_lower(int x, int y, int sx, int sy, int a5, int so
 		}
 		if(y < MAXDUNY && x >= 0) {
 			level_piece_id = dPiece[x][y];
-			light_table_index = dTransVal[x][y];
+			light_table_index = dLight[x][y];
 			if(level_piece_id == 0) {
 				world_draw_black_tile(&gpBuffer[sx + screen_y_times_768[sy]]);
 			} else {
 				dst = &gpBuffer[sx + screen_y_times_768[sy]];
-				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 				arch_draw_type = 1;
 				level_cel_block = pMap[0];
 				if(level_cel_block != 0) {
@@ -651,12 +651,12 @@ void __fastcall scrollrt_draw_lower(int x, int y, int sx, int sy, int a5, int so
 
 	if(some_flag && (DWORD)y < MAXDUNY && (DWORD)x < MAXDUNX) {
 		level_piece_id = dPiece[x][y];
-		light_table_index = dTransVal[x][y];
+		light_table_index = dLight[x][y];
 		if(level_piece_id == 0) {
 			world_draw_black_tile(&gpBuffer[sx + screen_y_times_768[sy]]);
 		} else {
 			dst = &gpBuffer[sx + screen_y_times_768[sy]];
-			cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+			cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 			arch_draw_type = 1;
 			level_cel_block = pMap[0];
 			if(level_cel_block != 0) {
@@ -756,7 +756,7 @@ void __fastcall scrollrt_draw_clipped_dungeon(char *a1, int sx, int sy, int a4, 
 	v8 = dPlayer[0][v6 - 1];
 	v48 = dPlayer[0][v6];
 	v46 = dArch[0][v6];
-	v9 = dung_map[0][v6];
+	v9 = dTransVal[0][v6];
 	v10 = (int *)((char *)dMonster + 4 * v6);
 	v44 = v9;
 	v45 = v8;
@@ -1051,8 +1051,8 @@ void __fastcall scrollrt_draw_clipped_e_flag(BYTE *pBuff, int x, int y, int a4, 
 	lpi_old = level_piece_id;
 
 	level_piece_id = dPiece[x][y];
-	light_table_index = dTransVal[x][y];
-	cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+	light_table_index = dLight[x][y];
+	cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 	pMap = dpiece_defs_map_1[IsometricCoord(x, y)];
 
 	dst = pBuff;
@@ -1107,10 +1107,10 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 	if(some_flag) {
 		if(y >= 0 && y < MAXDUNY && x >= 0 && x < MAXDUNX) {
 			level_piece_id = dPiece[x][y];
-			light_table_index = dTransVal[x][y];
+			light_table_index = dLight[x][y];
 			if(level_piece_id != 0) {
 				dst = &gpBuffer[sx - (768 * 32 - 32) + screen_y_times_768[sy]];
-				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 				for(i = 0; i < (MicroTileLen >> 1) - 1; i++) {
 					if(a6 <= i) {
 						level_cel_block = pMap[2 * i + 3];
@@ -1140,10 +1140,10 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 		}
 		if(y < MAXDUNY && x >= 0) {
 			level_piece_id = dPiece[x][y];
-			light_table_index = dTransVal[x][y];
+			light_table_index = dLight[x][y];
 			if(level_piece_id != 0) {
 				dst = &gpBuffer[sx - 768 * 32 + screen_y_times_768[sy]];
-				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 				i = 0;
 				while(i < (MicroTileLen >> 1) - 1) {
 					if(a6 <= i) {
@@ -1172,10 +1172,10 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 
 	if(some_flag && (DWORD)y < MAXDUNY && (DWORD)x < MAXDUNX) {
 		level_piece_id = dPiece[x][y];
-		light_table_index = dTransVal[x][y];
+		light_table_index = dLight[x][y];
 		if(level_piece_id != 0) {
 			dst = &gpBuffer[sx - 768 * 32 + screen_y_times_768[sy]];
-			cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+			cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 			for(i = 0; i < (MicroTileLen >> 1) - 1; i++) {
 				if(a6 <= i) {
 					level_cel_block = pMap[2 * i + 2];
@@ -1255,7 +1255,7 @@ void __fastcall scrollrt_draw_clipped_dungeon_2(char *buffer, int x, int y, int 
 	v10 = dPlayer[0][v8 - 1];
 	v51 = dPlayer[0][v8];
 	v49 = dArch[0][v8];
-	v11 = dung_map[0][v8];
+	v11 = dTransVal[0][v8];
 	v12 = (int *)((char *)dMonster + 4 * v8);
 	v47 = v11;
 	v48 = v10;
@@ -1451,9 +1451,9 @@ void __fastcall scrollrt_draw_clipped_e_flag_2(BYTE *pBuff, int x, int y, int a4
 	lpi_old = level_piece_id;
 
 	level_piece_id = dPiece[x][y];
-	light_table_index = dTransVal[x][y];
+	light_table_index = dLight[x][y];
 	dst = &pBuff[768 * 32 * a4];
-	cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+	cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 	pMap = dpiece_defs_map_1[IsometricCoord(x, y)];
 
 	switch(a4) {
@@ -1529,10 +1529,10 @@ void __fastcall scrollrt_draw_upper(int x, int y, int sx, int sy, int a5, int a6
 	if(some_flag) {
 		if(y >= 0 && y < MAXDUNY && x >= 0 && x < MAXDUNX) {
 			level_piece_id = dPiece[x][y];
-			light_table_index = dTransVal[x][y];
+			light_table_index = dLight[x][y];
 			if(level_piece_id != 0) {
 				dst = &gpBuffer[sx + 32 + screen_y_times_768[sy]];
-				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 				if(a6 >= 0) {
 					level_cel_block = pMap[1];
 					if(level_cel_block != 0) {
@@ -1577,10 +1577,10 @@ void __fastcall scrollrt_draw_upper(int x, int y, int sx, int sy, int a5, int a6
 	for(j = 0; j < a5; j++) {
 		if(y >= 0 && y < MAXDUNY && x >= 0 && x < MAXDUNX) {
 			level_piece_id = dPiece[x][y];
-			light_table_index = dTransVal[x][y];
+			light_table_index = dLight[x][y];
 			if(level_piece_id != 0) {
 				dst = &gpBuffer[sx + screen_y_times_768[sy]];
-				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+				cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 				arch_draw_type = 1;
 				level_cel_block = pMap[0];
 				if(level_cel_block != 0) {
@@ -1618,10 +1618,10 @@ void __fastcall scrollrt_draw_upper(int x, int y, int sx, int sy, int a5, int a6
 
 	if(some_flag && y >= 0 && y < MAXDUNY && x >= 0 && x < MAXDUNX) {
 		level_piece_id = dPiece[x][y];
-		light_table_index = dTransVal[x][y];
+		light_table_index = dLight[x][y];
 		if(level_piece_id != 0) {
 			dst = &gpBuffer[sx + screen_y_times_768[sy]];
-			cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+			cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 			arch_draw_type = 1;
 			if(a6 >= 0) {
 				level_cel_block = pMap[0];
@@ -1682,7 +1682,7 @@ void __fastcall scrollrt_draw_dungeon(BYTE *pBuff, int sx, int sy, int a4, int a
 	bItem = dItem[sx][sy];
 	bPlr = dPlayer[sx][sy];
 	bArch = dArch[sx][sy];
-	bMap = dung_map[sx][sy];
+	bMap = dTransVal[sx][sy];
 	nMon = dMonster[sx][sy];
 
 	/// ASSERT: assert((DWORD)(sy-1) < MAXDUNY);
@@ -1712,7 +1712,7 @@ void __fastcall scrollrt_draw_dungeon(BYTE *pBuff, int sx, int sy, int a4, int a
 						Cl2DecodeLightTbl(px, dy, pDeadGuy->_deadData[dd], pDeadGuy->_deadFrame, pDeadGuy->_deadWidth, 0, a5);
 					}
 				} else {
-					// TermMsg("Unclipped dead: frame %d of %d, deadnum==%d", nCel, pFrameTable[0], (bDead & 0x1F) - 1);
+					// app_fatal("Unclipped dead: frame %d of %d, deadnum==%d", nCel, pFrameTable[0], (bDead & 0x1F) - 1);
 				}
 			}
 		}
@@ -1736,10 +1736,10 @@ void __fastcall scrollrt_draw_dungeon(BYTE *pBuff, int sx, int sy, int a4, int a
 						}
 						CelDecodeHdrLightOnly(px, dy, pItem->_iAnimData, pItem->_iAnimFrame, pItem->_iAnimWidth, 0, a5);
 					} else {
-						// TermMsg("Draw \"%s\" Item 1: frame %d of %d, item type==%d", pItem->_iIName, nCel, pFrameTable[0], pItem->_itype);
+						// app_fatal("Draw \"%s\" Item 1: frame %d of %d, item type==%d", pItem->_iIName, nCel, pFrameTable[0], pItem->_itype);
 					}
 				} else {
-					// TermMsg("Draw Item \"%s\" 1: NULL Cel Buffer", pItem->_iIName);
+					// app_fatal("Draw Item \"%s\" 1: NULL Cel Buffer", pItem->_iIName);
 				}
 			}
 		}
@@ -1758,7 +1758,7 @@ void __fastcall scrollrt_draw_dungeon(BYTE *pBuff, int sx, int sy, int a4, int a
 				scrollrt_draw_e_flag(pBuff - 64, sx - 1, sy + 1, a4, a5, dx - 64, dy);
 			}
 		} else {
-			// TermMsg("draw player: tried to draw illegal player %d", p);
+			// app_fatal("draw player: tried to draw illegal player %d", p);
 		}
 	}
 	if((bFlag & 0x10) && ((bFlag & 0x40) || plr[myplr]._pInfraFlag) && negMon < 0) {
@@ -1777,11 +1777,11 @@ void __fastcall scrollrt_draw_dungeon(BYTE *pBuff, int sx, int sy, int a4, int a
 						scrollrt_draw_e_flag(pBuff - 64, sx - 1, sy + 1, a4, a5, dx - 64, dy);
 					}
 				} else {
-					// TermMsg("Draw Monster \"%s\": uninitialized monster", pMonster->mName);
+					// app_fatal("Draw Monster \"%s\": uninitialized monster", pMonster->mName);
 				}
 			}
 		} else {
-			// TermMsg("Draw Monster: tried to draw illegal monster %d", draw_monster_num);
+			// app_fatal("Draw Monster: tried to draw illegal monster %d", draw_monster_num);
 		}
 	}
 	if(bFlag & 4) {
@@ -1801,7 +1801,7 @@ void __fastcall scrollrt_draw_dungeon(BYTE *pBuff, int sx, int sy, int a4, int a
 				scrollrt_draw_e_flag(pBuff - 64, sx - 1, sy + 1, a4, a5, dx - 64, dy);
 			}
 		} else {
-			// TermMsg("draw player: tried to draw illegal player %d", p);
+			// app_fatal("draw player: tried to draw illegal player %d", p);
 		}
 	}
 	if(nMon > 0 && ((bFlag & 0x40) || plr[myplr]._pInfraFlag)) {
@@ -1820,11 +1820,11 @@ void __fastcall scrollrt_draw_dungeon(BYTE *pBuff, int sx, int sy, int a4, int a
 						scrollrt_draw_e_flag(pBuff - 64, sx - 1, sy + 1, a4, a5, dx - 64, dy);
 					}
 				} else {
-					// TermMsg("Draw Monster \"%s\": uninitialized monster", pMonster->mName);
+					// app_fatal("Draw Monster \"%s\": uninitialized monster", pMonster->mName);
 				}
 			}
 		} else {
-			// TermMsg("Draw Monster: tried to draw illegal monster %d", draw_monster_num);
+			// app_fatal("Draw Monster: tried to draw illegal monster %d", draw_monster_num);
 		}
 	}
 	if(bFlag & 1) {
@@ -1849,10 +1849,10 @@ void __fastcall scrollrt_draw_dungeon(BYTE *pBuff, int sx, int sy, int a4, int a
 						}
 						CelDecodeHdrLightOnly(px, dy, pItem->_iAnimData, pItem->_iAnimFrame, pItem->_iAnimWidth, 0, a5);
 					} else {
-						// TermMsg("Draw \"%s\" Item 2: frame %d of %d, item type==%d", pItem->_iIName, nCel, pFrameTable[0], pItem->_itype);
+						// app_fatal("Draw \"%s\" Item 2: frame %d of %d, item type==%d", pItem->_iIName, nCel, pFrameTable[0], pItem->_itype);
 					}
 				} else {
-					// TermMsg("Draw Item \"%s\" 2: NULL Cel Buffer", pItem->_iIName);
+					// app_fatal("Draw Item \"%s\" 2: NULL Cel Buffer", pItem->_iIName);
 				}
 			}
 		}
@@ -1989,9 +1989,9 @@ void __fastcall scrollrt_draw_e_flag(BYTE *pBuff, int x, int y, int a4, int a5, 
 	lpi_old = level_piece_id;
 
 	level_piece_id = dPiece[x][y];
-	light_table_index = dTransVal[x][y];
+	light_table_index = dLight[x][y];
 	dst = pBuff;
-	cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dung_map[x][y]]);
+	cel_transparency_active = (unsigned char)(nTransTable[level_piece_id] & TransList[dTransVal[x][y]]);
 	pMap = dpiece_defs_map_1[IsometricCoord(x, y)];
 
 	arch_draw_type = 1;

--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -122,7 +122,7 @@ void __fastcall DRLG_SetMapTrans(char *sFileName)
 
 	for (j = 0; j < y; j++) {
 		for (i = 0; i < x; i++) {
-			dung_map[16 + i][16 + j] = *d;
+			dTransVal[16 + i][16 + j] = *d;
 			d += 2;
 		}
 	}

--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -64,15 +64,15 @@ BOOLEAN __fastcall TFit_Shrine(int i)
 	v6 = 0;
 	while (1) {
 		v3 = v2 + 112 * v7;
-		if (dung_map[0][v3] != v1) { /* check */
+		if (dTransVal[0][v3] != v1) { /* check */
 			goto LABEL_20;
 		}
 		v4 = dPiece[0][v3 - 1]; // *(_DWORD *)&dflags[39][4 * v3 + 36];
 		if (nTrapTable[v4]
 		    && !nSolidTable[dPiece[-1][v3]] // !nSolidTable[*(_DWORD *)&dflags[28][4 * v3 + 32]]
 		    && !nSolidTable[dPiece[1][v3]]
-		    && dung_map[-1][v3] == v1 // block_lvid[v3 + 1940] == v1
-		    && dung_map[1][v3] == v1
+		    && dTransVal[-1][v3] == v1 // block_lvid[v3 + 1940] == v1
+		    && dTransVal[1][v3] == v1
 		    && !dObject[-1][v3 - 1]
 		    && !dObject[0][v3 + 111]) {
 			v6 = 1;
@@ -83,8 +83,8 @@ BOOLEAN __fastcall TFit_Shrine(int i)
 		if (!nTrapTable[dPiece[-1][v3]] // !nTrapTable[*(_DWORD *)&dflags[28][4 * v3 + 32]]
 		    || nSolidTable[v4]
 		    || nSolidTable[dPiece[0][v3 + 1]]
-		    || dung_map[0][v3 - 1] != v1 // *(&byte_5B78EB + v3) != v1
-		    || dung_map[0][v3 + 1] != v1
+		    || dTransVal[0][v3 - 1] != v1 // *(&byte_5B78EB + v3) != v1
+		    || dTransVal[0][v3 + 1] != v1
 		    || dObject[-1][v3 - 1]
 		    || dObject[-1][v3 + 1]) /* check */
 		{
@@ -137,7 +137,7 @@ BOOLEAN __fastcall TFit_Obj5(int t)
 	v11 = v5;
 	while (1) {
 		v6 = v3 + 112 * v2;
-		if (dung_map[0][v6] == v5 && !nSolidTable[dPiece[0][v6]]) {
+		if (dTransVal[0][v6] == v5 && !nSolidTable[dPiece[0][v6]]) {
 			v12 = 1;
 			v7 = 0;
 			do {
@@ -149,7 +149,7 @@ BOOLEAN __fastcall TFit_Obj5(int t)
 					v12 = 0;
 				}
 				v5 = v11;
-				if (dung_map[0][v8] != v11) {
+				if (dTransVal[0][v8] != v11) {
 					v12 = 0;
 				}
 				++v7;
@@ -227,7 +227,7 @@ BOOL __fastcall CheckThemeObj3(int xp, int yp, int t, int f)
 			return FALSE;
 		if (nSolidTable[dPiece[xp + trm3x[i]][yp + trm3y[i]]])
 			return FALSE;
-		if (dung_map[xp + trm3x[i]][yp + trm3y[i]] != themes[t].ttval)
+		if (dTransVal[xp + trm3x[i]][yp + trm3y[i]] != themes[t].ttval)
 			return FALSE;
 		if (dObject[xp + trm3x[i]][yp + trm3y[i]])
 			return FALSE;
@@ -454,7 +454,7 @@ BOOLEAN __fastcall CheckThemeRoom(int tv)
 			v5 = 0;
 			v6 = v4;
 			do {
-				if (dung_map[0][v6] == tv) {
+				if (dTransVal[0][v6] == tv) {
 					if (dFlags[0][v6] & DFLAG_POPULATED) {
 						return 0;
 					}
@@ -470,7 +470,7 @@ BOOLEAN __fastcall CheckThemeRoom(int tv)
 			v8 = &dPiece[-1][111];
 		LABEL_16:
 			v12 = 0;
-			v9 = &dung_map[-1][v7 + 111];
+			v9 = &dTransVal[-1][v7 + 111];
 			v10 = v8;
 			while (v9[1] != tv
 			    || nSolidTable[v10[1]]
@@ -493,7 +493,7 @@ BOOLEAN __fastcall CheckThemeRoom(int tv)
 		}
 	} else {
 		v2 = &trigs[0]._ty;
-		while (dung_map[*(v2 - 1)][*v2] != tv) {
+		while (dTransVal[*(v2 - 1)][*v2] != tv) {
 			++v1;
 			v2 += 4;
 			if (v1 >= trigflag[4]) {
@@ -630,7 +630,7 @@ void __cdecl HoldThemeRooms()
 			for (i = 0; i < numthemes; i++) {
 				for (y = 0; y < MAXDUNY; y++) {
 					for (x = 0; x < MAXDUNX; x++) {
-						if (dung_map[x][y] == (char)themes[i].ttval) {
+						if (dTransVal[x][y] == (char)themes[i].ttval) {
 							dFlags[x][y] |= DFLAG_POPULATED;
 						}
 					}
@@ -663,7 +663,7 @@ void __fastcall PlaceThemeMonsts(int t, int f)
 	mtype = scattertypes[random(0, numscattypes)];
 	for (yp = 0; yp < MAXDUNY; yp++) {
 		for (xp = 0; xp < MAXDUNX; xp++) {
-			if (dung_map[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]] && dItem[xp][yp] == 0 && dObject[xp][yp] == 0) {
+			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]] && dItem[xp][yp] == 0 && dObject[xp][yp] == 0) {
 				if (random(0, f) == 0) {
 					AddMonster(xp, yp, random(0, 8), mtype, 1);
 				}
@@ -684,7 +684,7 @@ void __fastcall Theme_Barrel(int t)
 
 	for (yp = 0; yp < MAXDUNY; yp++) {
 		for (xp = 0; xp < MAXDUNX; xp++) {
-			if (dung_map[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
+			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (random(0, barrnd[leveltype - 1]) == 0) {
 					r = random(0, barrnd[leveltype - 1]) != 0;
 					r += OBJ_BARREL;
@@ -732,7 +732,7 @@ void __fastcall Theme_MonstPit(int t)
 	iyp = 0;
 	if (r > 0) {
 		while (TRUE) {
-			if (dung_map[ixp][iyp] == themes[t].ttval && !nSolidTable[dPiece[ixp][iyp]]) {
+			if (dTransVal[ixp][iyp] == themes[t].ttval && !nSolidTable[dPiece[ixp][iyp]]) {
 				--r;
 			}
 			if (r <= 0) {
@@ -820,7 +820,7 @@ void __fastcall Theme_Treasure(int t)
 	GetRndSeed();
 	for (yp = 0; yp < MAXDUNY; yp++) {
 		for (xp = 0; xp < MAXDUNX; xp++) {
-			if (dung_map[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
+			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				int rv = random(0, treasrnd[leveltype - 1]);
 				// BUGFIX: the `2*` in `2*random(0, treasrnd...) == 0` has no effect, should probably be `random(0, 2*treasrnd...) == 0`
 				if ((2 * random(0, treasrnd[leveltype - 1])) == 0) {
@@ -899,7 +899,7 @@ void __fastcall Theme_Torture(int t)
 
 	for (yp = 1; yp < MAXDUNY - 1; yp++) {
 		for (xp = 1; xp < MAXDUNX - 1; xp++) {
-			if (dung_map[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
+			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (CheckThemeObj3(xp, yp, t, -1)) {
 					if (random(0, tortrnd[leveltype - 1]) == 0) {
 						AddObject(OBJ_TNUDEM2, xp, yp);
@@ -936,7 +936,7 @@ void __fastcall Theme_Decap(int t)
 
 	for (yp = 1; yp < MAXDUNY - 1; yp++) {
 		for (xp = 1; xp < MAXDUNX - 1; xp++) {
-			if (dung_map[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
+			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (CheckThemeObj3(xp, yp, t, -1)) {
 					if (random(0, decaprnd[leveltype - 1]) == 0) {
 						AddObject(OBJ_DECAP, xp, yp);
@@ -977,7 +977,7 @@ void __fastcall Theme_ArmorStand(int t)
 	}
 	for (yp = 0; yp < MAXDUNY; yp++) {
 		for (xp = 0; xp < MAXDUNX; xp++) {
-			if (dung_map[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
+			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (CheckThemeObj3(xp, yp, t, -1)) {
 					if (random(0, armorrnd[leveltype - 1]) == 0) {
 						AddObject(OBJ_ARMORSTANDN, xp, yp);
@@ -1002,7 +1002,7 @@ void __fastcall Theme_GoatShrine(int t)
 	AddObject(OBJ_GOATSHRINE, themex, themey);
 	for (yy = themey - 1; yy <= themey + 1; yy++) {
 		for (xx = themex - 1; xx <= themex + 1; xx++) {
-			if (dung_map[xx][yy] == themes[t].ttval && !nSolidTable[dPiece[xx][yy]] && (xx != themex || yy != themey)) {
+			if (dTransVal[xx][yy] == themes[t].ttval && !nSolidTable[dPiece[xx][yy]] && (xx != themex || yy != themey)) {
 				AddMonster(xx, yy, DIR_SW, themeVar1, 1);
 			}
 		}
@@ -1060,7 +1060,7 @@ void __fastcall Theme_BrnCross(int t)
 
 	for (yp = 0; yp < MAXDUNY; yp++) {
 		for (xp = 0; xp < MAXDUNX; xp++) {
-			if (dung_map[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
+			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (CheckThemeObj3(xp, yp, t, -1)) {
 					if (random(0, bcrossrnd[leveltype - 1]) == 0) {
 						AddObject(OBJ_TBCROSS, xp, yp);
@@ -1089,7 +1089,7 @@ void __fastcall Theme_WeaponRack(int t)
 	}
 	for (yp = 0; yp < MAXDUNY; yp++) {
 		for (xp = 0; xp < MAXDUNX; xp++) {
-			if (dung_map[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
+			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (CheckThemeObj3(xp, yp, t, -1)) {
 					if (random(0, weaponrnd[leveltype - 1]) == 0) {
 						AddObject(OBJ_WEAPONRACKN, xp, yp);
@@ -1109,8 +1109,8 @@ void __cdecl UpdateL4Trans()
 
 	for (j = 0; j < MAXDUNY; j++) {
 		for (i = 0; i < MAXDUNX; i++) {
-			if (dung_map[i][j]) {
-				dung_map[i][j] = 1;
+			if (dTransVal[i][j]) {
+				dTransVal[i][j] = 1;
 			}
 		}
 	}

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -1305,7 +1305,7 @@ void __fastcall CreateTown(int entry)
 	}
 
 	T_Pass3();
-	memset(dTransVal, 0, sizeof(dTransVal));
+	memset(dLight, 0, sizeof(dLight));
 	memset(dFlags, 0, sizeof(dFlags));
 	memset(dPlayer, 0, sizeof(dPlayer));
 	memset(dMonster, 0, sizeof(dMonster));


### PR DESCRIPTION
This corrects a few names. The PSX does not have the light map, but I had it named as the trans value. Should be easier to understand now.
```
char *pLightTbl -> BYTE *pLightTbl
dTransVal -> dLight
dTransVal2 -> dPreLight
dung_map -> dTransVal
```