### PR TITLE
Fix sync.cpp names p1

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1304,7 +1304,7 @@ void __fastcall DeltaImportJunk(BYTE *src)
 
 int __fastcall On_SYNCDATA(void *packet, int pnum)
 {
-	return SyncData(pnum, (TSyncHeader *)packet);
+	return sync_update(pnum, (TSyncHeader *)packet);
 }
 
 int __fastcall On_WALKXY(TCmdLoc *pCmd, int pnum)

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -745,7 +745,7 @@ int __fastcall NetInit(int bSinglePlayer, int *pfExitProgram)
 		buffer_init(&sgHiPriBuf);
 		buffer_init(&sgLoPriBuf);
 		dword_678628 = 0;
-		sync_clear_pkt();
+		sync_init();
 		nthread_start(sgbPlayerTurnBitTbl[myplr]);
 		dthread_start();
 		MI_Dummy(0); /* v5 */

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -2,10 +2,10 @@
 #ifndef __SYNC_H__
 #define __SYNC_H__
 
-extern short sync_word_6AA708[MAXMONSTERS];
-extern int syncmonsters; // weak
-extern short sync_word_6AA89C[MAXMONSTERS];
-extern int syncitems;
+extern WORD sync_word_6AA708[MAXMONSTERS];
+extern int sgnMonsters; // weak
+extern WORD sgwLRU[MAXMONSTERS];
+extern int sgnSyncItem;
 
 int __fastcall sync_all_monsters(TSyncHeader *packet, int size);
 void __cdecl sync_one_monster();
@@ -13,8 +13,8 @@ int __fastcall sync_monster_active(TSyncMonster *packet);
 void __fastcall sync_monster_pos(TSyncMonster *packet, int mon_id);
 int __fastcall sync_monster_active2(TSyncMonster *packet);
 void __fastcall SyncPlrInv(TSyncHeader *pSync);
-int __fastcall SyncData(int pnum, TSyncHeader *packet);
-void __fastcall sync_monster_data(int pnum, TSyncMonster *packet);
-void __cdecl sync_clear_pkt();
+int __fastcall sync_update(int pnum, TSyncHeader *packet);
+void __fastcall sync_monster(int pnum, TSyncMonster *packet);
+void __cdecl sync_init();
 
 #endif /* __SYNC_H__ */


### PR DESCRIPTION
Corrects a few names from PSX symbol no 3. Unfortunately the symbol is still missing a few functions, so some of them remain guesses.