### PR TITLE
ForceQuests [bin exact]

### DIFF
--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -235,7 +235,7 @@ BOOL __cdecl ForceQuests()
 			}
 		}
 	}
-	
+
 	return FALSE;
 }
 // 679660: using guessed type char gbMaxPlayers;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -210,33 +210,36 @@ LABEL_29:
 // 679660: using guessed type char gbMaxPlayers;
 // 69BE90: using guessed type int qline;
 
-BOOLEAN __cdecl ForceQuests()
+BOOL __cdecl ForceQuests()
 {
-	QuestStruct *v0; // eax
-	int v1;          // esi
-	int v2;          // edi
-	int v3;          // edx
+	int i, j, qx, qy, ql;
+	unsigned char *_qslvl;
 
-	if (gbMaxPlayers != 1)
-		return 0;
-	v0 = (QuestStruct *)((char *)quests + 12);
-	while (v0 == (QuestStruct *)&quests[15]._qslvl || currlevel != v0[-1]._qslvl || !v0->_qlevel) {
-	LABEL_10:
-		++v0;
-		if ((signed int)v0 >= (signed int)&quests[MAXQUESTS]._qslvl) /* fix */
-			return 0;
+	if (gbMaxPlayers != 1) {
+		return FALSE;
 	}
-	v1 = *(_DWORD *)&v0[-1]._qvar2;
-	v2 = v0[-1]._qlog;
-	v3 = 0;
-	while (v1 + questxoff[v3] != cursmx || v2 + questyoff[v3] != cursmy) {
-		if (++v3 >= 7)
-			goto LABEL_10;
+
+	for (i = 0; i < MAXQUESTS; i++) {
+
+		_qslvl = &quests[i]._qslvl;
+		
+		if (_qslvl != &quests[MAXQUESTS - 1]._qslvl && currlevel == quests[i]._qlevel && *_qslvl) {
+			ql = quests[quests[i]._qidx]._qslvl;
+			qx = quests[i]._qtx;
+			qy = quests[i]._qty;
+
+			for (j = 0; j < 7; j++) {
+				if (qx + questxoff[j] == cursmx && qy + questyoff[j] == cursmy) {
+					sprintf(infostr, "To %s", questtrigstr[ql - 1]);
+					cursmx = qx;
+					cursmy = qy;
+					return TRUE;
+				}
+			}
+		}
 	}
-	sprintf(infostr, "To %s", questtrigstr[(unsigned char)quests[(unsigned char)v0->_qtype]._qslvl - 1]);
-	cursmx = v1;
-	cursmy = v2;
-	return 1;
+
+	return FALSE;
 }
 // 679660: using guessed type char gbMaxPlayers;
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -213,24 +213,21 @@ LABEL_29:
 BOOL __cdecl ForceQuests()
 {
 	int i, j, qx, qy, ql;
-	unsigned char *_qslvl;
 
 	if (gbMaxPlayers != 1) {
 		return FALSE;
 	}
 
 	for (i = 0; i < MAXQUESTS; i++) {
-
-		_qslvl = &quests[i]._qslvl;
 		
-		if (_qslvl != &quests[MAXQUESTS - 1]._qslvl && currlevel == quests[i]._qlevel && *_qslvl) {
-			ql = quests[quests[i]._qidx]._qslvl;
+		if (i != QTYPE_VB && currlevel == quests[i]._qlevel && quests[i]._qslvl != 0) {
+			ql = quests[quests[i]._qidx]._qslvl - 1;
 			qx = quests[i]._qtx;
 			qy = quests[i]._qty;
 
 			for (j = 0; j < 7; j++) {
 				if (qx + questxoff[j] == cursmx && qy + questyoff[j] == cursmy) {
-					sprintf(infostr, "To %s", questtrigstr[ql - 1]);
+					sprintf(infostr, "To %s", questtrigstr[ql]);
 					cursmx = qx;
 					cursmy = qy;
 					return TRUE;
@@ -238,7 +235,7 @@ BOOL __cdecl ForceQuests()
 			}
 		}
 	}
-
+	
 	return FALSE;
 }
 // 679660: using guessed type char gbMaxPlayers;

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -18,7 +18,7 @@ extern int ReturnLvl;  // idb
 
 void __cdecl InitQuests();
 void __cdecl CheckQuests();
-BOOLEAN __cdecl ForceQuests();
+BOOL __cdecl ForceQuests();
 BOOL __fastcall QuestStatus(int i);
 void __fastcall CheckQuestKill(int m, BOOL sendmsg);
 void __cdecl DrawButcher();


### PR DESCRIPTION
The function isn't bin exact (the original size is 0xA2 and I currently have it to 0xA1), the problem stems from the fact that a different register is being used for the inner loop (lines 18-21 and lines 29/30):
![image](https://user-images.githubusercontent.com/46401660/55667645-45efed80-585f-11e9-884c-11a652d40441.png)

And the compiler adds a dec as well. I have tried the following:

1) Changing the signedness of the inner loop counter.
2) Changing the order of the qtx, qty assignments.
3) Changing qty's type to unsigned in the structure.

However nothing seems to produce the same assembly output in the original. Is there anything I could be overlooking here?
