### PR TITLE
Fix broken game menu

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -664,7 +664,7 @@ LRESULT CALLBACK GM_Game(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	case WM_MOUSEMOVE:
 		MouseX = LOWORD(lParam);
 		MouseY = HIWORD(lParam);
-		gmenu_on_mouse_move(LOWORD(lParam));
+		gmenu_on_mouse_move();
 		return 0;
 	case WM_LBUTTONDOWN:
 		MouseX = LOWORD(lParam);

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -26,12 +26,12 @@ TMenuItem sgMultiMenu[5] = {
 TMenuItem sgOptionMenu[6] = {
 	// clang-format off
 	//   dwFlags, pszStr,          fnMenu
-	{ 0xC0000000, NULL,            (void(__cdecl *)(void)) & gamemenu_music_volume },
-	{ 0xC0000000, NULL,            (void(__cdecl *)(void)) & gamemenu_sound_volume },
-	{ 0xC0000000, "Gamma",         (void(__cdecl *)(void)) & gamemenu_gamma        },
-	{ 0x80000000, NULL,            &gamemenu_color_cycling                         },
-	{ 0x80000000, "Previous Menu", &gamemenu_previous                              },
-	{ 0x80000000, NULL,            NULL                                            }
+	{ 0xC0000000, NULL,            &gamemenu_music_volume  },
+	{ 0xC0000000, NULL,            &gamemenu_sound_volume  },
+	{ 0xC0000000, "Gamma",         &gamemenu_gamma         },
+	{ 0x80000000, NULL,            &gamemenu_color_cycling },
+	{ 0x80000000, "Previous Menu", &j_gamemenu_previous    },
+	{ 0x80000000, NULL,            NULL                    }
 	// clang-format on
 };
 char *music_toggle_names[] = { "Music", "Music Disabled" };
@@ -40,7 +40,7 @@ char *color_cycling_toggle_names[] = { "Color Cycling Off", "Color Cycling On" }
 
 void __cdecl gamemenu_previous()
 {
-	void(__cdecl * proc)();
+	void(__fastcall * proc)(TMenuItem *);
 	TMenuItem *item;
 
 	if (gbMaxPlayers == 1) {
@@ -54,7 +54,7 @@ void __cdecl gamemenu_previous()
 	PressEscKey();
 }
 
-void __cdecl gamemenu_enable_single()
+void __fastcall gamemenu_enable_single(TMenuItem *a1)
 {
 	BOOL enable;
 
@@ -67,7 +67,7 @@ void __cdecl gamemenu_enable_single()
 	gmenu_enable(sgSingleMenu, enable);
 }
 
-void __cdecl gamemenu_enable_multi()
+void __fastcall gamemenu_enable_multi(TMenuItem *a1)
 {
 	gmenu_enable(&sgMultiMenu[2], deathflag);
 }
@@ -85,7 +85,12 @@ void __cdecl gamemenu_handle_previous()
 		gamemenu_previous();
 }
 
-void __cdecl gamemenu_new_game()
+void __fastcall j_gamemenu_previous(BOOL a1)
+{
+	gamemenu_previous();
+}
+
+void __fastcall gamemenu_new_game(BOOL a1)
 {
 	int i;
 
@@ -102,13 +107,13 @@ void __cdecl gamemenu_new_game()
 }
 // 52571C: using guessed type int drawpanflag;
 
-void __cdecl gamemenu_quit_game()
+void __fastcall gamemenu_quit_game(BOOL a1)
 {
-	gamemenu_new_game();
+	gamemenu_new_game(a1);
 	gbRunGameResult = FALSE;
 }
 
-void __cdecl gamemenu_load_game()
+void __fastcall gamemenu_load_game(BOOL a1)
 {
 	WNDPROC saveProc = SetWindowProc(DisableInputWndProc);
 	gamemenu_off();
@@ -129,7 +134,7 @@ void __cdecl gamemenu_load_game()
 }
 // 52571C: using guessed type int drawpanflag;
 
-void __cdecl gamemenu_save_game()
+void __fastcall gamemenu_save_game(BOOL a1)
 {
 	if (pcurs == CURSOR_HAND) {
 		if (plr[myplr]._pmode == PM_DEATH || deathflag) {
@@ -152,12 +157,12 @@ void __cdecl gamemenu_save_game()
 }
 // 52571C: using guessed type int drawpanflag;
 
-void __cdecl gamemenu_restart_town()
+void __fastcall gamemenu_restart_town(BOOL a1)
 {
 	NetSendCmd(TRUE, CMD_RETOWN);
 }
 
-void __cdecl gamemenu_options()
+void __fastcall gamemenu_options(BOOL a1)
 {
 	gamemenu_get_music();
 	gamemenu_get_sound();
@@ -200,9 +205,10 @@ void __cdecl gamemenu_get_gamma()
 	gmenu_slider_1(&sgOptionMenu[2], 30, 100, UpdateGamma(0));
 }
 
-void __fastcall gamemenu_music_volume(int volume)
+void __fastcall gamemenu_music_volume(BOOL a1)
 {
-	if (volume) {
+	int volume;
+	if (a1) {
 		if (gbMusicOn) {
 			gbMusicOn = FALSE;
 			music_stop();
@@ -246,9 +252,10 @@ int __fastcall gamemenu_slider_music_sound(TMenuItem *menu_item)
 	return gmenu_slider_get(menu_item, VOLUME_MIN, VOLUME_MAX);
 }
 
-void __fastcall gamemenu_sound_volume(int volume)
+void __fastcall gamemenu_sound_volume(BOOL a1)
 {
-	if (volume) {
+	int volume;
+	if (a1) {
 		if (gbSoundOn) {
 			gbSoundOn = FALSE;
 			FreeMonsterSnd();
@@ -273,9 +280,10 @@ void __fastcall gamemenu_sound_volume(int volume)
 	gamemenu_get_sound();
 }
 
-void __fastcall gamemenu_gamma(int gamma)
+void __fastcall gamemenu_gamma(BOOL a1)
 {
-	if (gamma) {
+	int gamma;
+	if (a1) {
 		if (UpdateGamma(0) == 30)
 			gamma = 100;
 		else
@@ -293,7 +301,7 @@ int __cdecl gamemenu_slider_gamma()
 	return gmenu_slider_get(&sgOptionMenu[2], 30, 100);
 }
 
-void __cdecl gamemenu_color_cycling()
+void __fastcall gamemenu_color_cycling(BOOL a1)
 {
 	palette_set_color_cycling(palette_get_colour_cycling() == 0);
 	sgOptionMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];

--- a/Source/gamemenu.h
+++ b/Source/gamemenu.h
@@ -3,27 +3,28 @@
 #define __GAMEMENU_H__
 
 void __cdecl gamemenu_previous();
-void __cdecl gamemenu_enable_single();
-void __cdecl gamemenu_enable_multi();
+void __fastcall gamemenu_enable_single(TMenuItem *a1);
+void __fastcall gamemenu_enable_multi(TMenuItem *a1);
 void __cdecl gamemenu_off();
 void __cdecl gamemenu_handle_previous();
-void __cdecl gamemenu_new_game();
-void __cdecl gamemenu_quit_game();
-void __cdecl gamemenu_load_game(); // should have 1-2 args
-void __cdecl gamemenu_save_game(); // should have 1-2 args
-void __cdecl gamemenu_restart_town();
-void __cdecl gamemenu_options();
+void __fastcall j_gamemenu_previous(BOOL a1);
+void __fastcall gamemenu_new_game(BOOL a1);
+void __fastcall gamemenu_quit_game(BOOL a1);
+void __fastcall gamemenu_load_game(BOOL a1);
+void __fastcall gamemenu_save_game(BOOL a1);
+void __fastcall gamemenu_restart_town(BOOL a1);
+void __fastcall gamemenu_options(BOOL a1);
 void __cdecl gamemenu_get_music();
 void __fastcall gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int gamma);
 void __cdecl gamemenu_get_sound();
 void __cdecl gamemenu_get_color_cycling();
 void __cdecl gamemenu_get_gamma();
-void __fastcall gamemenu_music_volume(int a1);
+void __fastcall gamemenu_music_volume(BOOL a1);
 int __fastcall gamemenu_slider_music_sound(TMenuItem *menu_item);
-void __fastcall gamemenu_sound_volume(int a1);
-void __fastcall gamemenu_gamma(int a1);
+void __fastcall gamemenu_sound_volume(BOOL a1);
+void __fastcall gamemenu_gamma(BOOL a1);
 int __cdecl gamemenu_slider_gamma();
-void __cdecl gamemenu_color_cycling();
+void __fastcall gamemenu_color_cycling(BOOL a1);
 
 /* rdata */
 extern char *music_toggle_names[];

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -9,7 +9,7 @@ TMenuItem *sgpCurrItem;
 void *BigTGold_cel;
 int dword_634474; // weak
 char byte_634478; // weak
-void(__cdecl *dword_63447C)();
+void(__fastcall *dword_63447C)(TMenuItem *);
 TMenuItem *dword_634480; // idb
 void *option_cel;
 void *sgpLogo;
@@ -114,11 +114,11 @@ BOOL __cdecl gmenu_exception()
 	return dword_634480 != 0;
 }
 
-void __fastcall gmenu_call_proc(TMenuItem *pItem, void(__cdecl *gmFunc)())
+void __fastcall gmenu_call_proc(TMenuItem *pItem, void(__fastcall *gmFunc)(TMenuItem *))
 {
 	TMenuItem *v2;         // eax
 	int v3;                // ecx
-	void(__cdecl * *v4)(); // edx
+	void(__fastcall * *v4)(BOOL); // edx
 
 	PauseMode = 0;
 	byte_634464 = 0;
@@ -126,7 +126,7 @@ void __fastcall gmenu_call_proc(TMenuItem *pItem, void(__cdecl *gmFunc)())
 	dword_63447C = gmFunc;
 	dword_634480 = pItem;
 	if (gmFunc) {
-		gmFunc();
+		gmFunc(dword_634480);
 		v2 = dword_634480;
 	}
 	v3 = 0;
@@ -189,7 +189,7 @@ void __cdecl gmenu_draw()
 
 	if (dword_634480) {
 		if (dword_63447C)
-			dword_63447C();
+			dword_63447C(dword_634480);
 		CelDecodeOnly(236, 262, (BYTE *)sgpLogo, 1, 296);
 		v0 = 320;
 		for (i = dword_634480; i->fnMenu; v0 += 45) {
@@ -293,7 +293,7 @@ BOOL __fastcall gmenu_presskeys(int a1)
 	case VK_RETURN:
 		if ((sgpCurrItem->dwFlags & 0x80000000) != 0) {
 			PlaySFX(IS_TITLEMOV);
-			((void(__fastcall *)(signed int))sgpCurrItem->fnMenu)(1);
+			sgpCurrItem->fnMenu(TRUE);
 		}
 		break;
 	case VK_ESCAPE:
@@ -339,24 +339,21 @@ void __fastcall gmenu_left_right(int a1)
 		_LOWORD(v1) = v1 & 0xF000;
 		sgpCurrItem->dwFlags = v1;
 		sgpCurrItem->dwFlags |= v3;
-		((void(__fastcall *)(_DWORD))sgpCurrItem->fnMenu)(0);
+		sgpCurrItem->fnMenu(FALSE);
 	}
 }
 
-int __fastcall gmenu_on_mouse_move(LPARAM lParam)
+BOOL __cdecl gmenu_on_mouse_move()
 {
-	int v2; // edx
 	int a1; // [esp+0h] [ebp-4h]
 
-	a1 = lParam;
 	if (!byte_634464)
 		return 0;
 	gmenu_valid_mouse_pos(&a1);
-	v2 = a1 * ((sgpCurrItem->dwFlags >> 12) & 0xFFF) % 256;
 	a1 = a1 * ((sgpCurrItem->dwFlags >> 12) & 0xFFF) / 256;
 	_LOWORD(sgpCurrItem->dwFlags) &= 0xF000u;
 	sgpCurrItem->dwFlags |= a1;
-	((void(__fastcall *)(_DWORD, int))sgpCurrItem->fnMenu)(0, v2);
+	sgpCurrItem->fnMenu(FALSE);
 	return 1;
 }
 // 41A37A: could not find valid save-restore pair for esi
@@ -402,9 +399,9 @@ int __fastcall gmenu_left_mouse(int a1)
 						PlaySFX(IS_TITLEMOV);
 						if (v4->dwFlags & 0x40000000) {
 							byte_634464 = gmenu_valid_mouse_pos(&a1a);
-							gmenu_on_mouse_move(a1); /* v6 */
+							gmenu_on_mouse_move();
 						} else {
-							((void(__fastcall *)(signed int))sgpCurrItem->fnMenu)(1);
+							sgpCurrItem->fnMenu(TRUE);
 						}
 					}
 				}

--- a/Source/gmenu.h
+++ b/Source/gmenu.h
@@ -8,7 +8,7 @@ extern void *PentSpin_cel;
 extern void *BigTGold_cel;
 extern int dword_634474; // weak
 extern char byte_634478; // weak
-extern void(__cdecl *dword_63447C)();
+extern void(__fastcall *dword_63447C)(TMenuItem *);
 extern TMenuItem *dword_634480; // idb
 extern void *option_cel;
 extern int dword_63448C; // weak
@@ -18,7 +18,7 @@ void __fastcall gmenu_print_text(int x, int y, char *pszStr);
 void __cdecl FreeGMenu();
 void __cdecl gmenu_init_menu();
 BOOL __cdecl gmenu_exception();
-void __fastcall gmenu_call_proc(TMenuItem *pItem, void(__cdecl *gmFunc)());
+void __fastcall gmenu_call_proc(TMenuItem *pItem, void(__fastcall *gmFunc)(TMenuItem *));
 void __fastcall gmenu_up_down(int a1);
 void __cdecl gmenu_draw();
 void __fastcall gmenu_draw_menu_item(TMenuItem *pItem, int a2);
@@ -26,7 +26,7 @@ void __fastcall gmenu_clear_buffer(int x, int y, int width, int height);
 int __fastcall gmenu_get_lfont(TMenuItem *pItem);
 BOOL __fastcall gmenu_presskeys(int a1);
 void __fastcall gmenu_left_right(int a1);
-int __fastcall gmenu_on_mouse_move(LPARAM lParam);
+BOOL __cdecl gmenu_on_mouse_move();
 BOOLEAN __fastcall gmenu_valid_mouse_pos(int *plOffset);
 int __fastcall gmenu_left_mouse(int a1);
 void __fastcall gmenu_enable(TMenuItem *pMenuItem, BOOL enable);

--- a/structs.h
+++ b/structs.h
@@ -991,7 +991,7 @@ typedef struct QuestData {
 typedef struct TMenuItem {
 	unsigned int dwFlags;
 	char *pszStr;
-	void(__cdecl *fnMenu)(); /* fix, should have one arg */
+	void(__fastcall *fnMenu)(BOOL); /* fix, should have one arg */
 } TMenuItem;
 
 // TPDEF PTR FCN VOID TMenuUpdateFcn


### PR DESCRIPTION
Takes care of the missing args for some of the game menu functions. Should hopefully fix any potential crashes when compiled under x64 or using non-fastcall conventions.