### PR TITLE
Fix crash with mute button

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -2964,7 +2964,7 @@ void control_release_talk_btn()
 				++v2;
 			} while (v2 < 4);
 			if (v2 <= 4)
-				tempstr[v2 + 255] = tempstr[v2 + 255] == 0;
+				byte_4B894C[v2 - 1] = byte_4B894C[v2 - 1] == 0;
 		}
 	}
 }


### PR DESCRIPTION
Because data is not lined up with the original, this caused a buffer overflow and would crash multiplayer when hitting the mute button. Subtraction in arrays is very common for this...
Fixes #632 