### PR TITLE
Palette fix for newer Windows

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -171,7 +171,7 @@ void run_game_loop(unsigned int uMsg)
 			gbGameLoopStartup = 0;
 			DrawAndBlit();
 		}
-#ifdef SLEEP
+#ifdef SLEEPFIX
 		Sleep(1);
 #endif
 	}

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -67,6 +67,15 @@ void dx_init(HWND hWnd)
 	v3 = dx_DirectDrawCreate(v2, &lpDDInterface, NULL);
 	if (v3)
 		ErrDlg(IDD_DIALOG1, v3, "C:\\Src\\Diablo\\Source\\dx.cpp", 149);
+
+#ifdef COLORFIX
+#ifdef __DDRAWI_INCLUDED__
+	((LPDDRAWI_DIRECTDRAW_INT)lpDDInterface)->lpLcl->dwAppHackFlags |= 0x800;
+#else
+	((DWORD **)lpDDInterface)[1][18] |= 0x800;
+#endif
+#endif
+
 	fullscreen = 1;
 #ifdef __cplusplus
 	v4 = lpDDInterface->SetCooperativeLevel(v1, DDSCL_EXCLUSIVE | DDSCL_ALLOWREBOOT | DDSCL_FULLSCREEN);

--- a/types.h
+++ b/types.h
@@ -48,13 +48,19 @@
 
 // If defined, use copy protection [Default -> Defined]
 //#define COPYPROT
+
 // If defined, don't reload for debuggers [Default -> Undefined]
 // Note that with patch 1.03 the command line was hosed, this is required to pass arguments to the game
 #ifdef _DEBUG
 #define DEBUGGER
 #endif
+
 // If defined, don't fry the CPU [Default -> Undefined]
-#define SLEEP
+#define SLEEPFIX
+
+// If defined, fix palette glitch in Windows Vista+ [Default -> Undefined]
+//#define COLORFIX
+
 // If defined, use standard memcpy() in place of qmemcpy() [Default -> Undefined]
 // Will be replaced with [rep movsd] if optimization is used
 #define FAST_MEMCPY


### PR DESCRIPTION
Added an optional fix for the palette glitch. This is especially helpful since a few others and I are using Windows 7/8. It is turned off by default since it can cause issues with wrappers and WINE.