### PR TITLE
Preliminary support for fixed header files

### DIFF
--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 char sz_error_buf[256];
 BOOL terminating;

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 // BUGFIX: only the first 256 elements are ever read
 WORD automaptype[512];

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 void CaptureScreen()
 {

--- a/Source/codec.cpp
+++ b/Source/codec.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int codec_decode(void *pbSrcDst, int size, char *pszPassword)
 {

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 char sgbNextTalkSave; // weak
 char sgbTalkSavePos;  // weak

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int cursH;      // weak
 int icursH28;   // idb

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 // unused, this was probably for blood boil/burn
 int spurtndx;

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 void *pSquareCel;
 char dMonsDbg[NUMLEVELS][MAXDUNX][MAXDUNY];

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1,6 +1,6 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
+#include "../DiabloUI/diabloui.h"
 
 HWND ghMainWnd;
 int glMid1Seed[NUMLEVELS];

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -2,6 +2,82 @@
 #ifndef __DIABLO_H__
 #define __DIABLO_H__
 
+#include "../types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "appfat.h"
+#include "automap.h"
+#include "capture.h"
+#include "codec.h"
+#include "control.h"
+#include "cursor.h"
+#include "dead.h"
+#include "debug.h"
+#include "doom.h"
+#include "drlg_l1.h"
+#include "drlg_l2.h"
+#include "drlg_l3.h"
+#include "drlg_l4.h"
+#include "dthread.h"
+#include "dx.h"
+#include "effects.h"
+#include "encrypt.h"
+#include "engine.h"
+#include "error.h"
+#include "fault.h"
+#include "gamemenu.h"
+#include "gendung.h"
+#include "gmenu.h"
+#include "help.h"
+#include "init.h"
+#include "interfac.h"
+#include "inv.h"
+#include "items.h"
+#include "lighting.h"
+#include "loadsave.h"
+#include "logging.h"
+#include "mainmenu.h"
+#include "minitext.h"
+#include "missiles.h"
+#include "monster.h"
+#include "movie.h"
+#include "mpqapi.h"
+#include "msg.h"
+#include "msgcmd.h"
+#include "multi.h"
+#include "nthread.h"
+#include "objects.h"
+#include "pack.h"
+#include "palette.h"
+#include "path.h"
+#include "pfile.h"
+#include "player.h"
+#include "plrmsg.h"
+#include "portal.h"
+#include "quests.h"
+#include "restrict.h"
+#include "scrollrt.h"
+#include "setmaps.h"
+#include "sha.h"
+#include "sound.h"
+#include "spells.h"
+#include "stores.h"
+#include "sync.h"
+#include "textdat.h" // check file name
+#include "themes.h"
+#include "tmsg.h"
+#include "town.h"
+#include "towners.h"
+#include "track.h"
+#include "trigs.h"
+#include "wave.h"
+#include "render.h" // linked last, likely .s/.asm
+#ifdef __cplusplus
+}
+#endif
+
 extern HWND ghMainWnd;
 extern int glMid1Seed[NUMLEVELS];
 extern int glMid2Seed[NUMLEVELS];

--- a/Source/doom.cpp
+++ b/Source/doom.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int doom_quest_time;
 int doom_stars_drawn;

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 char L5dungeon[80][80];
 unsigned char L5dflags[DMAXX][DMAXY];

--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int nSx1;
 int nSx2; // weak

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 char lavapool;  // weak
 int abyssx;     // weak

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int diabquad1x; // weak
 int diabquad1y; // weak

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 #ifdef __cplusplus
 static CCritSect sgMemCrit;

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 BYTE *sgpBackBuf;
 LPDIRECTDRAW lpDDInterface;

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 int sfxdelay; // weak
 int sfxdnum;

--- a/Source/encrypt.cpp
+++ b/Source/encrypt.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/PKWare/pkware.h"
 
 DWORD hashtable[1280];
 

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 #if (_MSC_VER >= 800) && (_MSC_VER <= 1200)
 #pragma warning(disable : 4731) // frame pointer register 'ebp' modified by inline assembly code

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 char msgtable[MAX_SEND_STR_LEN];
 char msgdelay;

--- a/Source/fault.cpp
+++ b/Source/fault.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter;
 

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 TMenuItem sgSingleMenu[6] = {
 	// clang-format off

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 WORD level_frame_types[MAXTILES];
 int themeCount;

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 void *optbar_cel;
 BOOLEAN byte_634464; // weak

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int help_select_line; // weak
 int dword_634494;     // weak

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -1,6 +1,6 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
+#include "../DiabloUI/diabloui.h"
 
 _SNETVERSIONDATA fileinfo;
 int gbActive; // weak

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 void *sgpBackCel;
 int sgdwProgress;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 BOOL invflag;
 void *pInvCels;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int itemactive[MAXITEMS];
 int uitemflag;

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 LightListStruct VisionList[MAXVISION];
 unsigned char lightactive[MAXLIGHTS];

--- a/Source/list.h
+++ b/Source/list.h
@@ -6,6 +6,8 @@
 #include <stddef.h> // for offsetof
 #include <typeinfo> // for typeid
 
+#include "../3rdParty/Storm/Source/storm.h"
+
 #ifdef _MSC_VER
 #pragma warning (disable : 4291) // no matching operator delete found
 #endif

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 unsigned char *tbuff;
 

--- a/Source/logging.cpp
+++ b/Source/logging.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 #ifdef __cplusplus
 static CCritSect sgMemCrit;

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -1,6 +1,6 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
+#include "../DiabloUI/diabloui.h"
 
 char gszHero[16];
 

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int qtexty; // weak
 char *qtextptr;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int missileactive[MAXMISSILES];
 int missileavail[MAXMISSILES];

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 // Tracks which missile files are already loaded
 int MissileFileFlag;

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 BYTE movie_playing;
 BOOL loop_movie;

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 int sgdwMpqOffset; // idb
 char mpq_buf[4096];

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1,6 +1,6 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
+#include "../DiabloUI/diabloui.h"
 
 static DWORD sgdwOwnerWait;
 static DWORD sgdwRecvOffset;

--- a/Source/msgcmd.cpp
+++ b/Source/msgcmd.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 #include "list.h"
 
 #define COMMAND_LEN 128

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -1,6 +1,6 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
+#include "../DiabloUI/diabloui.h"
 
 BOOLEAN gbSomebodyWonGameKludge; // weak
 TBuffer sgHiPriBuf;

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 char byte_679704; // weak
 int gdwMsgLenTbl[MAX_PLRS];

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int trapid;  // weak
 int trapdir; // weak

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 void PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield)
 {

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 PALETTEENTRY logical_palette[256];
 PALETTEENTRY system_palette[256];

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 // preallocated nodes, search is terminated after 300 nodes are visited
 PATHNODE path_nodes[MAXPATHNODES];

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -1,6 +1,6 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
+#include "../DiabloUI/diabloui.h"
 
 #define PASSWORD_SINGLE "xrgyrkj1"
 #define PASSWORD_MULTI "szqnlsk1"

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 int plr_lframe_size;
 int plr_wframe_size;

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 static unsigned char plr_msg_slot;
 _plrmsg plr_msgs[PMSG_COUNT];

--- a/Source/portal.cpp
+++ b/Source/portal.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 PortalStruct portal[MAXPORTAL];
 int portalindex;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int qtopline; // idb
 BOOL questlog;

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 #include "_asm.cpp"
 
 int WorldBoolFlag = 0;

--- a/Source/restrict.cpp
+++ b/Source/restrict.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 BOOL SystemSupported()
 {

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 int light_table_index; // weak
 int PitchTbl[1024];

--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 // BUGFIX: constant data should be const
 unsigned char SkelKingTrans1[8] = {

--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 SHA1Context sgSHA1[3];
 

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 LPDIRECTSOUNDBUFFER DSBs[8];
 LPDIRECTSOUND sglpDS;

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 SpellData spelldata[MAX_SPELLS] = {
 	// clang-format off

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int stextup;    // weak
 int storenumh;  // weak

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 WORD sync_word_6AA708[MAXMONSTERS];
 int sgnMonsters;

--- a/Source/textdat.cpp
+++ b/Source/textdat.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 /* todo: move text out of struct */
 

--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int numthemes; // idb
 BOOL armorFlag;

--- a/Source/tmsg.cpp
+++ b/Source/tmsg.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 static TMsg *sgpTimedMsgHead;
 

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 void town_clear_upper_buf(BYTE *pBuff)
 {

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int storeflag; // weak
 int sgnCowMsg;

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 static BYTE sgbIsScrolling;
 static DWORD sgdwLastWalk;

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -1,6 +1,4 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
 
 int trigflag_0;
 int trigflag_1;

--- a/Source/wave.cpp
+++ b/Source/wave.cpp
@@ -1,6 +1,5 @@
-//HEADER_GOES_HERE
-
-#include "../types.h"
+#include "diablo.h"
+#include "../3rdParty/Storm/Source/storm.h"
 
 BOOL WCloseFile(HANDLE file)
 {

--- a/types.h
+++ b/types.h
@@ -42,10 +42,6 @@
 #include "enums.h"
 #include "structs.h"
 
-#include "DiabloUI/diabloui.h"
-#include "3rdParty/Storm/Source/storm.h"
-#include "3rdParty/PKWare/pkware.h"
-
 // If defined, use copy protection [Default -> Defined]
 //#define COPYPROT
 
@@ -60,85 +56,5 @@
 
 // If defined, fix palette glitch in Windows Vista+ [Default -> Undefined]
 //#define COLORFIX
-
-// If defined, use standard memcpy() in place of qmemcpy() [Default -> Undefined]
-// Will be replaced with [rep movsd] if optimization is used
-#define FAST_MEMCPY
-
-// header files
-#ifdef __cplusplus
-extern "C" {
-#endif
-#include "Source/appfat.h"
-#include "Source/automap.h"
-#include "Source/capture.h"
-#include "Source/codec.h"
-#include "Source/control.h"
-#include "Source/cursor.h"
-#include "Source/dead.h"
-#include "Source/debug.h"
-#include "Source/diablo.h"
-#include "Source/doom.h"
-#include "Source/drlg_l1.h"
-#include "Source/drlg_l2.h"
-#include "Source/drlg_l3.h"
-#include "Source/drlg_l4.h"
-#include "Source/dthread.h"
-#include "Source/dx.h"
-#include "Source/effects.h"
-#include "Source/encrypt.h"
-#include "Source/engine.h"
-#include "Source/error.h"
-#include "Source/fault.h"
-#include "Source/gamemenu.h"
-#include "Source/gendung.h"
-#include "Source/gmenu.h"
-#include "Source/help.h"
-#include "Source/init.h"
-#include "Source/interfac.h"
-#include "Source/inv.h"
-#include "Source/items.h"
-#include "Source/lighting.h"
-#include "Source/loadsave.h"
-#include "Source/logging.h"
-#include "Source/mainmenu.h"
-#include "Source/minitext.h"
-#include "Source/missiles.h"
-#include "Source/monster.h"
-#include "Source/movie.h"
-#include "Source/mpqapi.h"
-#include "Source/msg.h"
-#include "Source/msgcmd.h"
-#include "Source/multi.h"
-#include "Source/nthread.h"
-#include "Source/objects.h"
-#include "Source/pack.h"
-#include "Source/palette.h"
-#include "Source/path.h"
-#include "Source/pfile.h"
-#include "Source/player.h"
-#include "Source/plrmsg.h"
-#include "Source/portal.h"
-#include "Source/quests.h"
-#include "Source/restrict.h"
-#include "Source/scrollrt.h"
-#include "Source/setmaps.h"
-#include "Source/sha.h"
-#include "Source/sound.h"
-#include "Source/spells.h"
-#include "Source/stores.h"
-#include "Source/sync.h"
-#include "Source/textdat.h" // check file name
-#include "Source/themes.h"
-#include "Source/tmsg.h"
-#include "Source/town.h"
-#include "Source/towners.h"
-#include "Source/track.h"
-#include "Source/trigs.h"
-#include "Source/wave.h"
-#include "Source/render.h" // linked last, likely .s/.asm
-#ifdef __cplusplus
-}
-#endif
 
 #endif


### PR DESCRIPTION
Basically the project has more header files than needed. In most cases, only a handful of functions from a certain file are public. The idea is to move everything into the main file `diablo.h`. Now, only files that have the CPP_INIT include `storm.h`. Eventually, most publics should be put into `diablo.h` so that most header files can be deleted. Especially for the DRLG files where only two functions are public.

That is all ;)