### PR TITLE
Add missing functions for MI_Dummy

### DIFF
--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -59,7 +59,7 @@ void dx_init(HWND hWnd)
 		hDDVal = lpDDInterface->lpVtbl->SetCooperativeLevel(lpDDInterface, hWnd, DDSCL_NORMAL | DDSCL_ALLOWREBOOT);
 #endif
 		if(hDDVal == DDERR_EXCLUSIVEMODEALREADYSET) {
-			MI_Dummy2(); /* break_exception(); */
+			break_exception();
 		} else if(hDDVal != DD_OK) {
 			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Diablo\\Direct\\dx.cpp", 155);
 		}
@@ -71,7 +71,7 @@ void dx_init(HWND hWnd)
 		hDDVal = lpDDInterface->lpVtbl->SetCooperativeLevel(lpDDInterface, hWnd, DDSCL_EXCLUSIVE | DDSCL_ALLOWREBOOT | DDSCL_FULLSCREEN);
 #endif
 		if(hDDVal == DDERR_EXCLUSIVEMODEALREADYSET) {
-			MI_Dummy2(); /* break_exception(); */
+			break_exception();
 		} else if(hDDVal != DD_OK) {
 			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 170);
 		}

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -2392,6 +2392,21 @@ int random(BYTE idx, int v)
 	return (GetRndSeed() >> 16) % v;
 }
 
+void engine_debug_trap(BOOL show_cursor)
+{
+/*
+	TMemBlock *pCurr;
+
+	sgMemCrit.Enter();
+	while(sgpMemBlock != NULL) {
+		pCurr = sgpMemBlock->pNext;
+		SMemFree(sgpMemBlock, "C:\\Diablo\\Direct\\ENGINE.CPP", 1970);
+		sgpMemBlock = pCurr;
+	}
+	sgMemCrit.Leave();
+*/
+}
+
 unsigned char *DiabloAllocPtr(int dwBytes)
 {
 	BYTE *buf;

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -40,6 +40,7 @@ int GetDirection(int x1, int y1, int x2, int y2);
 void SetRndSeed(int s);
 int GetRndSeed();
 int random(BYTE idx, int v);
+void engine_debug_trap(BOOL show_cursor);
 unsigned char *DiabloAllocPtr(int dwBytes);
 void mem_free_dbg(void *p);
 BYTE *LoadFileInMem(char *pszName, int *pdwFileLen);

--- a/Source/fault.cpp
+++ b/Source/fault.cpp
@@ -32,6 +32,17 @@ LPTOP_LEVEL_EXCEPTION_FILTER __cdecl fault_cleanup_filter()
 	return fault_reset_filter(&fault_unused);
 }
 
+void break_exception()
+{
+/*
+	LPTOP_LEVEL_EXCEPTION_FILTER pFilter;
+
+	pFilter = SetUnhandledExceptionFilter(TopLevelExceptionFilter);
+	__asm int 3
+	SetUnhandledExceptionFilter(pFilter);
+*/
+}
+
 LONG __stdcall TopLevelExceptionFilter(PEXCEPTION_POINTERS ExceptionInfo)
 {
 	PEXCEPTION_RECORD xcpt;

--- a/Source/fault.h
+++ b/Source/fault.h
@@ -13,6 +13,7 @@ extern LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter;
 void fault_init_filter();
 void fault_cleanup_filter_atexit();
 LPTOP_LEVEL_EXCEPTION_FILTER __cdecl fault_cleanup_filter();
+void break_exception();
 LONG __stdcall TopLevelExceptionFilter(PEXCEPTION_POINTERS ExceptionInfo);
 void fault_hex_format(BYTE *ptr, unsigned int numBytes);
 void fault_unknown_module(LPCVOID lpAddress, LPSTR lpModuleName, int iMaxLength, int *sectionNum, int *sectionOffset);

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -43,7 +43,7 @@ void init_cleanup(BOOL show_cursor)
 	sound_cleanup();
 	NetClose();
 	dx_cleanup();
-	MI_Dummy(show_cursor);
+	engine_debug_trap(show_cursor);
 	StormDestroy();
 
 	if (show_cursor)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2841,11 +2841,6 @@ void MI_Dummy(int i)
 	return;
 }
 
-void MI_Dummy2()
-{
-	return;
-}
-
 void MI_Golem(int i)
 {
 	int CrawlNum[6] = { 0, 3, 12, 45, 94, 159 };

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -98,7 +98,6 @@ void AddDiabApoca(int mi, int sx, int sy, int dx, int dy, int midir, char mienem
 int AddMissile(int sx, int sy, int dx, int dy, int midir, int mitype, char micaster, int id, int midam, int spllvl);
 int Sentfire(int i, int sx, int sy);
 void MI_Dummy(int i);
-void MI_Dummy2();
 void MI_Golem(int i);
 void MI_SetManashield(int i);
 void MI_LArrow(int i);

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -97,8 +97,22 @@ void mpqapi_xor_buf(char *pbData)
 	} while (v3);
 }
 
-void mpqapi_update_multi_creation_time(DWORD dwChar)
+void mpqapi_store_default_time(DWORD dwChar)
 {
+/*
+	DWORD idx;
+	char dst[160];
+
+	if(gbMaxPlayers == 1) {
+		return;
+	}
+
+	/// ASSERT: assert(dwChar < MAX_CHARACTERS);
+	idx = 16 * dwChar;
+	mpqapi_reg_load_modification_time(dst, sizeof(dst));
+	*(_DWORD *)&dst[idx + 4] = 0x78341348; // dwHighDateTime
+	mpqapi_reg_store_modification_time(dst, sizeof(dst));
+*/
 }
 
 BOOLEAN mpqapi_reg_store_modification_time(char *pbData, DWORD dwLen)

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -10,7 +10,7 @@ BOOL mpqapi_set_hidden(const char *pszArchive, BOOL hidden);
 void mpqapi_store_creation_time(const char *pszArchive, int dwChar);
 BOOL mpqapi_reg_load_modification_time(char *dst, int size);
 void mpqapi_xor_buf(char *pbData);
-void mpqapi_update_multi_creation_time(DWORD dwChar);
+void mpqapi_store_default_time(DWORD dwChar);
 BOOLEAN mpqapi_reg_store_modification_time(char *pbData, DWORD dwLen);
 _BLOCKENTRY *j_mpqapi_remove_hash_entry(char *pszName);
 void mpqapi_remove_hash_entry(const char *pszName);

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -732,7 +732,7 @@ BOOL NetInit(BOOL bSinglePlayer, BOOL *pfExitProgram)
 		sync_init();
 		nthread_start(sgbPlayerTurnBitTbl[myplr]);
 		dthread_start();
-		dummy_nop_used_in_NetInit();
+		tmsg_start();
 		sgdwGameLoops = 0;
 		sgbSentThisCycle = 0;
 		gbDeltaSender = myplr;
@@ -766,10 +766,6 @@ BOOL NetInit(BOOL bSinglePlayer, BOOL *pfExitProgram)
 // 678640: using guessed type char byte_678640;
 // 6796E4: using guessed type char gbDeltaSender;
 // 6796E8: using guessed type int sgbNetInited;
-
-void dummy_nop_used_in_NetInit()
-{
-}
 
 void buffer_init(TBuffer *pBuf)
 {

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -43,7 +43,6 @@ void NetClose();
 char multi_event_handler(int a1);
 void __stdcall multi_handle_events(_SNETEVENT *pEvt);
 BOOL NetInit(BOOL bSinglePlayer, BOOL *pfExitProgram);
-void dummy_nop_used_in_NetInit();
 void buffer_init(TBuffer *pBuf);
 void multi_send_pinfo(int pnum, char cmd);
 int InitNewSeed(int newseed);

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -104,7 +104,7 @@ BOOL pfile_open_archive(BOOL a1, unsigned int save_num)
 		return TRUE;
 
 	if (a1 && gbMaxPlayers > 1)
-		mpqapi_update_multi_creation_time(save_num);
+		mpqapi_store_default_time(save_num);
 	return FALSE;
 }
 

--- a/Source/tmsg.cpp
+++ b/Source/tmsg.cpp
@@ -36,6 +36,11 @@ void tmsg_add(BYTE *pbMsg, BYTE bLen)
 	*tail = msg;
 }
 
+void tmsg_start()
+{
+	/// ASSERT: assert(! sgpTimedMsgHead);
+}
+
 void *tmsg_cleanup()
 {
 	while (sgpTimedMsgHead) {

--- a/Source/tmsg.h
+++ b/Source/tmsg.h
@@ -4,6 +4,7 @@
 
 int tmsg_get(BYTE *pbMsg, DWORD dwMaxLen);
 void tmsg_add(BYTE *pbMsg, BYTE bLen);
+void tmsg_start();
 void *tmsg_cleanup();
 
 #endif /* __TMSG_H__ */


### PR DESCRIPTION
Pretty self explanatory. The code for the engine_debug_trap isn't fully implemented. There are a few other functions used for creating a table of memory headers to check and validate freeing the pointers upon leaving, to make sure there are no memory leaks.

I'm not 100% sure which file `break_exception` should go to, in the debug release it appears to be part of `appfat.cpp`. But given that there was no `fault.cpp` then, it seems likely to be moved there.