### PR TITLE
multi_player_joins bin exact

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -926,7 +926,7 @@ BOOL multi_upgrade(int *pfExitProgram)
 	return result;
 }
 
-void __fastcall multi_player_joins(int pnum, TCmdPlrInfoHdr *cmd, int a3)
+void multi_player_joins(int pnum, TCmdPlrInfoHdr *cmd, int a3)
 {
 	char *msg;
 

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -4,7 +4,7 @@
 
 extern BOOLEAN gbSomebodyWonGameKludge; // weak
 extern char szPlayerDescript[128];
-extern short sgwPackPlrOffsetTbl[MAX_PLRS];
+extern WORD sgwPackPlrOffsetTbl[MAX_PLRS];
 extern PkPlayerStruct netplr[MAX_PLRS];
 extern BOOL gbShouldValidatePackage;
 extern BYTE gbActivePlayers;


### PR DESCRIPTION
changed short sgwPackPlrOffsetTbl[MAX_PLRS]; to WORD, it didn't seem to affect bin exactness in any of the functions that used it and removed casting to WORD in multi_player_joins