### PR TITLE
Implement breakpoint handler

### DIFF
--- a/Source/appfat.h
+++ b/Source/appfat.h
@@ -6,6 +6,10 @@ extern char sz_error_buf[256];
 extern int terminating;       // weak
 extern int cleanup_thread_id; // weak
 
+void TriggerBreak();
+#ifdef _DEBUG
+LONG __stdcall BreakFilter(PEXCEPTION_POINTERS pExc);
+#endif
 char *GetErrorStr(DWORD error_code);
 void TraceErrorDD(HRESULT hError, char *pszBuffer, DWORD dwMaxChars);
 void TraceErrorDS(HRESULT hError, char *pszBuffer, DWORD dwMaxChars);

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -59,7 +59,7 @@ void dx_init(HWND hWnd)
 		hDDVal = lpDDInterface->lpVtbl->SetCooperativeLevel(lpDDInterface, hWnd, DDSCL_NORMAL | DDSCL_ALLOWREBOOT);
 #endif
 		if(hDDVal == DDERR_EXCLUSIVEMODEALREADYSET) {
-			break_exception();
+			TriggerBreak();
 		} else if(hDDVal != DD_OK) {
 			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Diablo\\Direct\\dx.cpp", 155);
 		}
@@ -71,7 +71,7 @@ void dx_init(HWND hWnd)
 		hDDVal = lpDDInterface->lpVtbl->SetCooperativeLevel(lpDDInterface, hWnd, DDSCL_EXCLUSIVE | DDSCL_ALLOWREBOOT | DDSCL_FULLSCREEN);
 #endif
 		if(hDDVal == DDERR_EXCLUSIVEMODEALREADYSET) {
-			break_exception();
+			TriggerBreak();
 		} else if(hDDVal != DD_OK) {
 			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 170);
 		}

--- a/Source/fault.cpp
+++ b/Source/fault.cpp
@@ -32,17 +32,6 @@ LPTOP_LEVEL_EXCEPTION_FILTER __cdecl fault_cleanup_filter()
 	return fault_reset_filter(&fault_unused);
 }
 
-void break_exception()
-{
-/*
-	LPTOP_LEVEL_EXCEPTION_FILTER pFilter;
-
-	pFilter = SetUnhandledExceptionFilter(TopLevelExceptionFilter);
-	__asm int 3
-	SetUnhandledExceptionFilter(pFilter);
-*/
-}
-
 LONG __stdcall TopLevelExceptionFilter(PEXCEPTION_POINTERS ExceptionInfo)
 {
 	PEXCEPTION_RECORD xcpt;

--- a/Source/fault.h
+++ b/Source/fault.h
@@ -13,7 +13,6 @@ extern LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter;
 void fault_init_filter();
 void fault_cleanup_filter_atexit();
 LPTOP_LEVEL_EXCEPTION_FILTER __cdecl fault_cleanup_filter();
-void break_exception();
 LONG __stdcall TopLevelExceptionFilter(PEXCEPTION_POINTERS ExceptionInfo);
 void fault_hex_format(BYTE *ptr, unsigned int numBytes);
 void fault_unknown_module(LPCVOID lpAddress, LPSTR lpModuleName, int iMaxLength, int *sectionNum, int *sectionOffset);


### PR DESCRIPTION
The breakpoint handler is now fully functional, also added the missing call to `app_fatal`. The functions have been moved to the top of `appfat.cpp`, where they were located in the debug release.

Also note that older versions of VC seem to be lacking several intrinsics, hence why you see `__debugbreak();` only used for newer compilers.