### PR TITLE
Add support for 32-bit colors

### DIFF
--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -76,17 +76,17 @@ void dx_init(HWND hWnd)
 			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 170);
 		}
 #ifdef __cplusplus
-		hDDVal = lpDDInterface->SetDisplayMode(SCREEN_WIDTH, SCREEN_HEIGHT, 8);
+		hDDVal = lpDDInterface->SetDisplayMode(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_BPP);
 #else
-		hDDVal = lpDDInterface->lpVtbl->SetDisplayMode(lpDDInterface, SCREEN_WIDTH, SCREEN_HEIGHT, 8);
+		hDDVal = lpDDInterface->lpVtbl->SetDisplayMode(lpDDInterface, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_BPP);
 #endif
 		if(hDDVal != DD_OK) {
 			winw = GetSystemMetrics(SM_CXSCREEN);
 			winh = GetSystemMetrics(SM_CYSCREEN);
 #ifdef __cplusplus
-			hDDVal = lpDDInterface->SetDisplayMode(winw, winh, 8);
+			hDDVal = lpDDInterface->SetDisplayMode(winw, winh, SCREEN_BPP);
 #else
-			hDDVal = lpDDInterface->lpVtbl->SetDisplayMode(lpDDInterface, winw, winh, 8);
+			hDDVal = lpDDInterface->lpVtbl->SetDisplayMode(lpDDInterface, winw, winh, SCREEN_BPP);
 #endif
 			if(hDDVal != DD_OK) {
 				ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 183);

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -37,8 +37,10 @@ void palette_init()
 #else
 	error_code = lpDDSPrimary->lpVtbl->SetPalette(lpDDSPrimary, lpDDPalette);
 #endif
+#ifndef RGBMODE
 	if (error_code)
 		ErrDlg(IDD_DIALOG8, error_code, "C:\\Src\\Diablo\\Source\\PALETTE.CPP", 146);
+#endif
 }
 
 void LoadGamma()

--- a/defs.h
+++ b/defs.h
@@ -87,8 +87,18 @@
 
 #define SCREEN_WIDTH	640
 #define SCREEN_HEIGHT	480
-#define BUFFER_WIDTH	768
-#define BUFFER_HEIGHT	656
+
+// If defined, use 32-bit colors instead of 8-bit [Default -> Undefined]
+//#define RGBMODE
+
+#ifndef RGBMODE
+#define SCREEN_BPP		8
+#else
+#define SCREEN_BPP		32
+#endif
+
+#define BUFFER_WIDTH	(64 + SCREEN_WIDTH + 64)
+#define BUFFER_HEIGHT	(160 + SCREEN_HEIGHT + 16)
 #define TILE_SIZE		32
 
 #define SCREENXY(x, y)	((x) + 64 + (((y) + 160) * 768))


### PR DESCRIPTION
This adds an optional "hack" to run the game in 32-bit mode instead of 8-bit. It works by converting the palette to raw RGB during blitting. The error checking for `SetPalette` is disabled in RGB mode because you cannot set a palette unless using 8-bit. Running the game in RGB fixes a lot of issues with newer computers. It also means windowed mode works properly (if you set the correct window size).

The downside? The game doesn't blit all parts of the screen at once, and during the loading screen the game loads a new palette. This means when you load a new level the panel will be black. It can be fixed by drinking a potion or hovering over the panel. Copying pixels is also much slower in RGB, but this can *probably* be solved by created two buffers and using a `BlitFast` to copy the 8-bit to 32-bit buffer.

Here is a screenshot of Diablo running in windowed mode using command line `-x`. It is running *without* a wrapper using RGB mode on Windows 7. ;)


![Capture](https://user-images.githubusercontent.com/15209402/56701375-72f82900-66c4-11e9-8852-7adce9a78b26.PNG)
