### PR TITLE
Correct size of ThemeGoodIn

### DIFF
--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -2,7 +2,7 @@
 
 int numthemes; // idb
 BOOL armorFlag;
-WORD ThemeGoodIn[4];
+BOOL ThemeGoodIn[4];
 BOOL weaponFlag;
 BOOL treasureFlag;
 BOOL mFountainFlag;
@@ -412,8 +412,8 @@ void InitThemes()
 		return;
 
 	if (leveltype == DTYPE_CATHEDRAL) {
-		for (i = 0; i < sizeof(ThemeGoodIn); i++)
-			ThemeGoodIn[i] = 0;
+		for (i = 0; i < sizeof(ThemeGoodIn) / sizeof(ThemeGoodIn[0]); i++)
+			ThemeGoodIn[i] = FALSE;
 
 		for (i = 0; i < 256 && numthemes < MAXTHEMES; i++) {
 			if (CheckThemeRoom(i)) {

--- a/Source/themes.h
+++ b/Source/themes.h
@@ -4,7 +4,7 @@
 
 extern int numthemes; // idb
 extern BOOL armorFlag;
-extern WORD ThemeGoodIn[4];
+extern BOOL ThemeGoodIn[4];
 extern BOOL weaponFlag;
 extern BOOL treasureFlag;
 extern BOOL mFountainFlag;


### PR DESCRIPTION
This is still bin exact but fixes issues with modern compilers.

This is a bit odd since ThemeGoodIn is completely unused except for setting it to 0 here, possibly this is a bug in vanilla and should actually be operating on `ThemeGood`