### PR TITLE
Fix StartGoldDrop

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -2231,9 +2231,9 @@ void StartGoldDrop()
 {
 	initialDropGoldIndex = pcursinvitem;
 	if (pcursinvitem <= 46)
-		initialDropGoldValue = plr[myplr].InvBody[pcursinvitem]._ivalue;
+		initialDropGoldValue = plr[myplr].InvList[pcursinvitem - 7]._ivalue;
 	else
-		initialDropGoldValue = plr[myplr].InvBody[pcursinvitem]._iMaxDur;
+		initialDropGoldValue = plr[myplr].SpdList[pcursinvitem - 47]._ivalue;
 	dropGoldFlag = TRUE;
 	dropGoldValue = 0;
 	if (talkflag)


### PR DESCRIPTION
This function was bin exact, however the arrays were wrong due to subtraction and the compiler knowing the address.