### PR TITLE
Remove alignment hack

### DIFF
--- a/Source/debug.h
+++ b/Source/debug.h
@@ -9,7 +9,7 @@ extern char dFlagDbg[NUMLEVELS][MAXDUNX][MAXDUNY];
 void LoadDebugGFX();
 void FreeDebugGFX();
 void CheckDungeonClear();
-//#ifdef _DEBUG // SpawnHealer is only bin exact with the following defined
+#ifdef _DEBUG
 void GiveGoldCheat();
 void StoresCheat();
 void TakeGoldCheat();
@@ -21,6 +21,6 @@ void PrintDebugQuest();
 void PrintDebugMonster(int m);
 void GetDebugMonster();
 void NextDebugMonster();
-//#endif
+#endif
 
 #endif /* __DEBUG_H__ */

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -156,7 +156,7 @@ extern int diablo_inf; // weak
 /* rdata */
 
 extern BOOL fullscreen;
-//#ifdef _DEBUG // SpawnHealer is only bin exact with the following defined
+#ifdef _DEBUG
 extern int showintrodebug;
 extern int questdebug;
 extern int debug_mode_key_s;
@@ -173,7 +173,7 @@ extern int frameflag;
 extern int frameend;
 extern int framerate;
 extern int framestart;
-//#endif
+#endif
 extern BOOL FriendlyMode;
 extern char *spszMsgTbl[4];    // weak
 extern char *spszMsgKeyTbl[4]; // weak


### PR DESCRIPTION
8bc995e68190691f6309b8ee6359a5f16a407fc2 has added enough to the headers that functions like `DRLG_L3` and `SpawnHealer` where no longer bin exact, reverting the extra headers hack in diablo.h and debug.h results in both again being bin exact.