### PR TITLE
Clean up M_CheckEFLag, M_DiabloDeath, fix PrepDoEnding (bin exact)

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1215,25 +1215,28 @@ int M_GetDir(int i)
 
 void M_CheckEFlag(int i)
 {
-	int v1;        // ecx
-	int v2;        // edi
-	char *v3;      // eax
-	signed int v4; // edx
+	int f, j;
+	int x, y;
+	WORD *m;
 
-	v1 = i;
-	v2 = 0;
-	v3 = (char *)dpiece_defs_map_2 + 32 * (112 * (monster[v1]._mx - 1) + monster[v1]._my + 1);
-	if (v3 < (char *)dpiece_defs_map_2)
-		goto LABEL_9;
-	v4 = 2;
-	do
-		v2 |= *(unsigned short *)&v3[2 * v4++];
-	while (v4 < 10);
-	if (v2 | dArch[monster[v1]._mx - 1][monster[v1]._my + 1])
-		monster[v1]._meflag = 1;
-	else
-	LABEL_9:
-		monster[v1]._meflag = 0;
+	x = monster[i]._mx - 1;
+	y = monster[i]._my + 1;
+	f = 0;
+	m = dpiece_defs_map_2[x][y].mt;
+	if (m >= dpiece_defs_map_2[0][0].mt) {
+		for (j = 2; j < 10; j++) {
+			f |= m[j];
+		}
+	} else {
+		monster[i]._meflag = FALSE;
+		return;
+	}
+
+	if (f | dArch[x][y])
+		monster[i]._meflag = TRUE;
+	else {
+		monster[i]._meflag = FALSE;
+	}
 }
 
 void M_StartStand(int i, int md)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2686,7 +2686,7 @@ void PrepDoEnding()
 
 	for (i = 0; i < MAX_PLRS; i++) {
 		plr[i]._pmode = PM_QUIT;
-		plr[i]._pBlockFlag = TRUE;
+		plr[i]._pInvincible = TRUE;
 		if (gbMaxPlayers > 1) {
 			if (plr[i]._pHitPoints >> 6 == 0)
 				plr[i]._pHitPoints = 64;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -7,7 +7,7 @@ int MissileFileFlag;
 int monstkills[MAXMONSTERS];
 int monstactive[MAXMONSTERS];
 int nummonsters;
-int sgbSaveSoundOn; // weak
+BOOLEAN sgbSaveSoundOn;
 MonsterStruct monster[MAXMONSTERS];
 int totalmonsters; // weak
 CMonster Monsters[16];
@@ -1539,72 +1539,53 @@ void M_StartHit(int i, int pnum, int dam)
 
 void M_DiabloDeath(int i, BOOL sendmsg)
 {
-	int v2;     // esi
-	int v3;     // edi
-	int v4;     // eax
-	int v5;     // ebx
-	int v6;     // esi
-	int v7;     // ecx
-	int v8;     // eax
-	int v9;     // esi
-	int v10;    // eax
-	double v11; // st7
-	int v12;    // eax
-	int v13;    // ecx
-	int v14;    // esi
-	int v15;    // [esp+8h] [ebp-8h]
-	int j;      // [esp+Ch] [ebp-4h]
-	int v17;    // [esp+Ch] [ebp-4h]
+	MonsterStruct *Monst, *pmonster;
+	int dist;
+	int j, k;
+	int _moldx, _moldy;
 
-	v15 = i;
-	v2 = sendmsg;
-	v3 = i;
+	Monst = monster + i;
 	PlaySFX(USFX_DIABLOD);
 	quests[QTYPE_MOD]._qactive = 3;
-	if (v2)
-		NetSendCmdQuest(TRUE, 5u);
+	if (sendmsg)
+		NetSendCmdQuest(TRUE, QTYPE_MOD);
 	gbProcessPlayers = FALSE;
-	_LOBYTE(sgbSaveSoundOn) = gbSoundOn;
-	v4 = 0;
-	for (j = 0; j < nummonsters; ++j) {
-		v5 = monstactive[v4];
-		if (v5 != v15 && monster[v3]._msquelch) {
-			v6 = v5;
-			NewMonsterAnim(monstactive[v4], &monster[v5].MType->Anims[MA_DEATH], monster[v5]._mdir);
-			v7 = monster[v5]._moldy;
-			monster[v6]._mxoff = 0;
-			monster[v6]._myoff = 0;
-			monster[v6]._mVar1 = 0;
-			v8 = monster[v5]._moldx;
-			monster[v6]._my = v7;
-			monster[v6]._mfuty = v7;
-			monster[v6]._mmode = MM_DEATH;
-			monster[v6]._mx = v8;
-			monster[v6]._mfutx = v8;
-			M_CheckEFlag(v5);
-			M_ClearSquares(v5);
-			dMonster[monster[v6]._mx][monster[v6]._my] = v5 + 1;
-		}
-		v4 = j + 1;
+	sgbSaveSoundOn = gbSoundOn;
+	for (j = 0; j < nummonsters; j++) {
+		k = monstactive[j];
+		if (k == i || monster[i]._msquelch == 0)
+			continue;
+
+		pmonster = monster + k;
+		NewMonsterAnim(k, pmonster->MType->Anims + MA_DEATH, pmonster->_mdir);
+		monster[k]._mxoff = 0;
+		monster[k]._myoff = 0;
+		monster[k]._mVar1 = 0;
+		_moldx = monster[k]._moldx;
+		_moldy = monster[k]._moldy;
+		monster[k]._my = _moldy;
+		monster[k]._mfuty = _moldy;
+		monster[k]._mmode = MM_DEATH;
+		monster[k]._mx = _moldx;
+		monster[k]._mfutx = _moldx;
+		M_CheckEFlag(k);
+		M_ClearSquares(k);
+		dMonster[pmonster->_mx][pmonster->_my] = k + 1;
 	}
-	AddLight(monster[v3]._mx, monster[v3]._my, 8);
-	DoVision(monster[v3]._mx, monster[v3]._my, 8, 0, 1);
-	v9 = abs(ViewY - monster[v3]._my);
-	if (abs(ViewX - monster[v3]._mx) <= v9)
-		v10 = ViewY - monster[v3]._my;
+	AddLight(Monst->_mx, Monst->_my, 8);
+	DoVision(Monst->_mx, Monst->_my, 8, FALSE, TRUE);
+	if (abs(ViewX - Monst->_mx) > abs(ViewY - Monst->_my))
+		dist = abs (ViewX - Monst->_mx);
 	else
-		v10 = ViewX - monster[v3]._mx;
-	v17 = abs(v10);
-	if (v17 > 20)
-		v17 = 20;
-	v11 = (double)v17;
-	v12 = ViewX << 16;
-	v13 = monster[v3]._mx << 16;
-	monster[v3]._mVar3 = ViewX << 16;
-	v14 = ViewY << 16;
-	monster[v3]._mVar4 = ViewY << 16;
-	monster[v3]._mVar5 = (signed __int64)((double)(v12 - v13) / v11);
-	monster[v3]._mVar6 = (signed __int64)((double)(v14 - (monster[v3]._my << 16)) / v11);
+		dist = abs (ViewY - Monst->_my);
+	if (dist > 20)
+		dist = 20;
+	j = ViewX << 16;
+	k = ViewY << 16;
+	Monst->_mVar3 = j;
+	Monst->_mVar4 = k;
+	Monst->_mVar5 = (int) ((j - (Monst->_mx << 16)) / (double)dist);
+	Monst->_mVar6 = (int) ((k - (Monst->_my << 16)) / (double)dist);
 }
 // 64D32C: using guessed type int sgbSaveSoundOn;
 
@@ -6554,3 +6535,4 @@ void decode_enemy(int m, int enemy)
 		monster[m]._menemyy = monster[enemy]._mfuty;
 	}
 }
+

--- a/structs.h
+++ b/structs.h
@@ -566,7 +566,7 @@ typedef struct MonsterStruct { // note: missing field _mAFNum
 	int _mAnimCnt;
 	int _mAnimLen;
 	int _mAnimFrame;
-	int _meflag;
+	BOOL _meflag;
 	BOOL _mDelFlag;
 	int _mVar1;
 	int _mVar2;


### PR DESCRIPTION
`if` in M_CheckEFLag looks pretty stupid but it also looks that way in assembly, maybe it looked a bit better in original code but I decided to stop at bin exactness for now.

`PrepDoEnding` seemed to have incorrect offset and should feature line `plr[i]._pInvincible = TRUE;` which seem to make more sense.

`M_DiabloDeath` clearly tells that `sgbSaveSoundOn` is `BYTE`, changing which doesn't seem to affect bin exactness of `PrepDoEnding` which is the only function using it. Also one of the rare function using `double`s.