### PR TITLE
Fix SaveItemPower generating +damage from enemies items instead of -damage.

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1471,10 +1471,10 @@ void SaveItemPower(int i, int power, int param1, int param2, int minval, int max
 		item[i]._iPLDex -= r;
 		item[i]._iPLVit -= r;
 		break;
-	case IPL_GETHIT:
+	case IPL_GETHIT_CURSE:
 		item[i]._iPLGetHit += r;
 		break;
-	case IPL_GETHIT_CURSE:
+	case IPL_GETHIT:
 		item[i]._iPLGetHit -= r;
 		break;
 	case IPL_LIFE:


### PR DESCRIPTION
This case is a bit trickier since both versions are bin exact by current definition. Logically it's easy that `IPL_GETHIT` should get `_iPLGetHit` negative and cursed version positive since it's printed as `%+i damage from enemies` and by looking at how it applied later. Another evidence is that cases are now properly ordered after this change.

Sadly in this case only jump tables are different. Also comparing jump tables is not an easy task it seems by the way since their alignment may depend on function alignment also.

Found by @Manuel-K