### PR TITLE
CreateRndUseful: Fix mistake leading to incorrect handling of item ids.

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2182,10 +2182,10 @@ void CreateRndUseful(int pnum, int x, int y, BOOL sendmsg)
 	int ii;
 
 	if (numitems < MAXITEMS) {
-		ii = itemactive[0];
+		ii = itemavail[0];
 		GetSuperItemSpace(x, y, ii);
-		itemactive[0] = itemactive[MAXITEMS - numitems - 1];
-		itemavail[numitems] = ii;
+		itemavail[0] = itemavail[MAXITEMS - numitems - 1];
+		itemactive[numitems] = ii;
 		SetupAllUseful(ii, GetRndSeed(), currlevel);
 		if (sendmsg) {
 			NetSendCmdDItem(FALSE, ii);


### PR DESCRIPTION
I don't think needs to be proven that it's correct way since the addition of item is done in several function in `items.cpp`. For example line `itemavail[0] = itemavail[MAXITEMS - numitems - 1]` is used 12 times in the source besides this case.

Once again, thanks to @Manuel-K for finding the bug.