### PR TITLE
Change PKWare to static library

### DIFF
--- a/3rdParty/PKWare/Makefile
+++ b/3rdParty/PKWare/Makefile
@@ -1,0 +1,59 @@
+VC5_DIR ?= $(HOME)/DevStudio_5.10/VC
+
+# The $(VS6_DIR) directory is a copy of the "Microsoft Visual Studio" directory.
+#
+# To get a working setup on Linux or other "portable" copies of VS,
+# the following DLLs have to be copied to the
+# $(VS6_DIR)/VC98/Bin directory.
+#
+#     - $(VS6_DIR)/Common/MSDev98/Bin/MSPDB60.DLL
+#
+# And to the $(VC5_DIR)/bin directory.
+#
+#     - $(VC5_DIR)/SharedIDE/bin/MSDIS100.DLL
+#     - $(VC5_DIR)/SharedIDE/bin/MSPDB50.DLL
+VS6_DIR ?= $(HOME)/VS6
+
+VC6_DIR     = $(VS6_DIR)/VC98
+
+VC6_BIN_DIR = $(VC6_DIR)/Bin
+VC6_INC_DIR = $(VC6_DIR)/Include
+VC6_LIB_DIR = $(VC6_DIR)/Lib
+
+VC5_LIB_DIR = $(VC5_DIR)/lib
+
+IDE_DIR ?= $(VS6_DIR)/Common/MSDev98
+IDE_BIN_DIR = $(IDE_DIR)/bin
+ifeq ($(OS),Windows_NT)
+	CL = $(VC6_BIN_DIR)/CL.EXE
+	RC = $(IDE_BIN_DIR)/RC.EXE
+	VC5_LINK = $(VC5_DIR)/bin/link.exe
+	VC6_LINK = $(VC6_BIN_DIR)/link.exe
+else
+	CL = wine $(VC6_BIN_DIR)/CL.EXE
+	RC = wine $(IDE_BIN_DIR)/RC.EXE
+	VC5_LINK = wine $(VC5_DIR)/bin/link.exe
+	VC6_LINK = wine $(VC6_BIN_DIR)/link.exe
+endif
+
+CFLAGS=/nologo /c /GX /W3 /O1 /I $(VC6_INC_DIR) /FD /MT /D "NDEBUG" /D "WIN32" /D "_WINDOWS" /YX /Gm /Zi
+LINKFLAGS=/nologo /subsystem:windows /machine:I386 /incremental:no
+
+VC_LINK=$(VC5_LINK)
+LINKFLAGS+= /LIBPATH:$(VC5_LIB_DIR)
+
+all: pkware.lib
+
+PKWARE_SRC=$(sort $(wildcard *.cpp))
+PKWARE_OBJS=$(PKWARE_SRC:.cpp=.obj)
+
+pkware.lib: $(PKWARE_OBJS)
+	$(VC_LINK) -lib /OUT:$@ $^ /nologo
+
+%.obj: %.cpp
+	$(CL) $(CFLAGS) /Fo$@ $<
+
+clean:
+	@$(RM) -v $(PKWARE_OBJS) pkware.lib vc60.{idb,pch,pdb}
+
+.PHONY: clean all

--- a/3rdParty/PKWare/Pkware.dsp
+++ b/3rdParty/PKWare/Pkware.dsp
@@ -1,0 +1,100 @@
+# Microsoft Developer Studio Project File - Name="Pkware" - Package Owner=<4>
+# Microsoft Developer Studio Generated Build File, Format Version 6.00
+# ** DO NOT EDIT **
+
+# TARGTYPE "Win32 (x86) Static Library" 0x0104
+
+CFG=Pkware - Win32 Debug
+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
+!MESSAGE use the Export Makefile command and run
+!MESSAGE 
+!MESSAGE NMAKE /f "Pkware.mak".
+!MESSAGE 
+!MESSAGE You can specify a configuration when running NMAKE
+!MESSAGE by defining the macro CFG on the command line. For example:
+!MESSAGE 
+!MESSAGE NMAKE /f "Pkware.mak" CFG="Pkware - Win32 Debug"
+!MESSAGE 
+!MESSAGE Possible choices for configuration are:
+!MESSAGE 
+!MESSAGE "Pkware - Win32 Release" (based on "Win32 (x86) Static Library")
+!MESSAGE "Pkware - Win32 Debug" (based on "Win32 (x86) Static Library")
+!MESSAGE 
+
+# Begin Project
+# PROP AllowPerConfigDependencies 0
+# PROP Scc_ProjName ""
+# PROP Scc_LocalPath ""
+CPP=cl.exe
+RSC=rc.exe
+
+!IF  "$(CFG)" == "Pkware - Win32 Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "WinRel"
+# PROP BASE Intermediate_Dir "WinRel"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "WinRel"
+# PROP Intermediate_Dir "WinRel"
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /YX /FD /c
+# ADD CPP /nologo /MT /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /YX /FD /c
+# ADD BASE RSC /l 0x409 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LIB32=link.exe -lib
+# ADD BASE LIB32 /nologo
+# ADD LIB32 /nologo
+
+!ELSEIF  "$(CFG)" == "Pkware - Win32 Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "WinDebug"
+# PROP BASE Intermediate_Dir "WinDebug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "WinDebug"
+# PROP Intermediate_Dir "WinDebug"
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /YX /FD /GZ /c
+# ADD CPP /nologo /MTd /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /YX /FD /GZ /c
+# ADD BASE RSC /l 0x409 /d "_DEBUG"
+# ADD RSC /l 0x409 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LIB32=link.exe -lib
+# ADD BASE LIB32 /nologo
+# ADD LIB32 /nologo
+
+!ENDIF 
+
+# Begin Target
+
+# Name "Pkware - Win32 Release"
+# Name "Pkware - Win32 Debug"
+# Begin Group "Source Files"
+
+# PROP Default_Filter "cpp;c;cxx;rc;def;r;odl;idl;hpj;bat"
+# Begin Source File
+
+SOURCE=.\explode.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\implode.cpp
+# End Source File
+# End Group
+# Begin Group "Header Files"
+
+# PROP Default_Filter "h;hpp;hxx;hm;inl"
+# End Group
+# End Target
+# End Project

--- a/Diablo.dsp
+++ b/Diablo.dsp
@@ -54,7 +54,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /machine:I386
-# ADD LINK32 DiabloUI/WinRel/DiabloUI.lib 3rdParty/Storm/Source/WinRel/Storm.lib kernel32.lib user32.lib gdi32.lib advapi32.lib shell32.lib version.lib /nologo /subsystem:windows /machine:I386
+# ADD LINK32 kernel32.lib user32.lib gdi32.lib advapi32.lib shell32.lib version.lib /nologo /subsystem:windows /machine:I386
 
 !ELSEIF  "$(CFG)" == "Diablo - Win32 Debug"
 
@@ -107,8 +107,8 @@ BSC32=bscmake.exe
 # ADD BASE BSC32 /nologo
 # ADD BSC32 /nologo
 LINK32=link.exe
-# ADD BASE LINK32 DiabloUI/WinRel/DiabloUI.lib 3rdParty/Storm/Source/WinRel/Storm.lib kernel32.lib user32.lib gdi32.lib advapi32.lib shell32.lib version.lib /nologo /subsystem:windows /machine:I386
-# ADD LINK32 DiabloUI/WinRel/DiabloUI.lib 3rdParty/Storm/Source/WinRel/Storm.lib kernel32.lib user32.lib gdi32.lib advapi32.lib shell32.lib version.lib /nologo /subsystem:windows /debug /machine:I386
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib advapi32.lib shell32.lib version.lib /nologo /subsystem:windows /machine:I386
+# ADD LINK32 DiabloUI/WinRel/diabloui.lib 3rdParty/Storm/Source/WinRel/storm.lib kernel32.lib user32.lib gdi32.lib advapi32.lib shell32.lib version.lib 3rdParty/PKWare/WinRel/pkware.lib /nologo /subsystem:windows /debug /machine:I386
 
 !ENDIF
 
@@ -720,18 +720,6 @@ SOURCE=.\Source\wave.h
 # Begin Source File
 
 SOURCE=.\resource.h
-# End Source File
-# End Group
-# Begin Group "PKWare"
-
-# PROP Default_Filter "cpp;c;cxx;rc;def;r;odl;idl;hpj;bat"
-# Begin Source File
-
-SOURCE=.\3rdParty\PKWare\explode.cpp
-# End Source File
-# Begin Source File
-
-SOURCE=.\3rdParty\PKWare\implode.cpp
 # End Source File
 # End Group
 # End Target

--- a/Diablo.dsw
+++ b/Diablo.dsw
@@ -17,6 +17,9 @@ Package=<4>
     Begin Project Dependency
     Project_Dep_Name Storm
     End Project Dependency
+    Begin Project Dependency
+    Project_Dep_Name Pkware
+    End Project Dependency
 }}}
 
 ###############################################################################
@@ -32,6 +35,18 @@ Package=<4>
     Begin Project Dependency
     Project_Dep_Name Storm
     End Project Dependency
+}}}
+
+###############################################################################
+
+Project: "Pkware"=".\3rdParty\PKWare\Pkware.dsp" - Package Owner=<4>
+
+Package=<5>
+{{{
+}}}
+
+Package=<4>
+{{{
 }}}
 
 ###############################################################################

--- a/DiabloUI/DiabloUI.dsp
+++ b/DiabloUI/DiabloUI.dsp
@@ -40,6 +40,7 @@ RSC=rc.exe
 # PROP Use_Debug_Libraries 0
 # PROP Output_Dir "WinRel"
 # PROP Intermediate_Dir "WinRel"
+# PROP Ignore_Export_Lib 0
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /MT /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /YX /FD /c
 # ADD CPP /nologo /MT /W3 /GX /O1 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /YX /FD /c
@@ -52,7 +53,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /machine:I386
-# ADD LINK32 ../3rdParty/Storm/Source/WinRel/Storm.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /machine:I386 /def:"diabloui.def"
+# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /machine:I386 /def:"diabloui.def"
 
 !ELSEIF  "$(CFG)" == "DiabloUI - Win32 Debug"
 
@@ -65,6 +66,7 @@ LINK32=link.exe
 # PROP Use_Debug_Libraries 1
 # PROP Output_Dir "WinDebug"
 # PROP Intermediate_Dir "WinDebug"
+# PROP Ignore_Export_Lib 0
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /MTd /W3 /Gm /GX /Zi /Od /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /YX /FD /c
 # ADD CPP /nologo /MTd /W3 /Gm /GX /Zi /O1 /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /YX /FD /c
@@ -77,7 +79,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /debug /machine:I386 /pdbtype:sept
-# ADD LINK32 ../3rdParty/Storm/Source/WinDebug/Storm.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /debug /machine:I386 /def:"diabloui.def" /pdbtype:sept
+# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /debug /machine:I386 /def:"diabloui.def" /pdbtype:sept
 
 !ENDIF 
 

--- a/MakefileVC
+++ b/MakefileVC
@@ -57,17 +57,17 @@ DIABLO_SRC=$(sort $(filter-out Source/_asm.cpp Source/_render.cpp Source/render.
 DIABLO_SRC += Source/render.cpp
 OBJS=$(DIABLO_SRC:.cpp=.obj)
 
-PKWARE_SRC=$(sort $(wildcard 3rdParty/PKWare/*.cpp))
-PKWARE_OBJS=$(PKWARE_SRC:.cpp=.obj)
-
-Diablo.exe: main_files $(PKWARE_OBJS) diablo.res DiabloUI/diabloui.lib 3rdParty/Storm/storm.lib
-	$(VC_LINK) /OUT:$@ $(LINKFLAGS) $(OBJS) $(PKWARE_OBJS) diablo.res DiabloUI/diabloui.lib 3rdParty/Storm/storm.lib kernel32.lib user32.lib gdi32.lib advapi32.lib shell32.lib version.lib
+Diablo.exe: main_files diablo.res DiabloUI/diabloui.lib 3rdParty/Storm/storm.lib 3rdParty/PKWare/pkware.lib
+	$(VC_LINK) /OUT:$@ $(LINKFLAGS) $(OBJS) diablo.res DiabloUI/diabloui.lib 3rdParty/Storm/storm.lib kernel32.lib user32.lib gdi32.lib advapi32.lib shell32.lib version.lib 3rdParty/PKWare/pkware.lib
 
 DiabloUI/diabloui.lib:
 	make -C DiabloUI
 
 3rdParty/Storm/storm.lib:
 	make -C 3rdParty/Storm
+
+3rdParty/PKWare/pkware.lib:
+	make -C 3rdParty/PKWare
 
 # compiles all main source files with once compiler call
 main_files:
@@ -80,6 +80,6 @@ diablo.res: Diablo.rc
 	$(RC) /i $(VC6_INC_DIR) /i $(VC6_DIR)/MFC/Include /l 0x409 /fo $@ $<
 
 clean:
-	@$(RM) -v $(OBJS) $(PKWARE_OBJS)
+	@$(RM) -v $(OBJS)
 
 .PHONY: clean all


### PR DESCRIPTION
The Pkware functions are at the end of the exe in the original, so it was a static library rather than included in the project. The rich header also says 72 .C files and we are sitting at 75, so this puts us at 73. I'm pretty sure the last file is `render.cpp`, which most likely used a `.s/.asm` file extension and was compiled with MASM. Unfortunately, I'm not sure how to integrate that in such a way it's compatible with modern compilers and VC6 at the same time.

This also removes the PKWare functions from the comparer and "fixes" the diff.

Edit: also before I forget, this hasn't been done for the Mingw makefile or VS2017. If anyone wants to update those, would be nice.