### PR TITLE
Bugfix note to M2MStartKill

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1696,6 +1696,8 @@ void M2MStartKill(int i, int mid)
 
 	if ((DWORD)i >= MAXMONSTERS) {
 		app_fatal("M2MStartKill: Invalid monster (attacker) %d", i);
+	}
+	if ((DWORD)i >= MAXMONSTERS) { /// BUGFIX: should check `mid`
 		app_fatal("M2MStartKill: Invalid monster (killed) %d", mid);
 	}
 	if (!monster[i].MType)


### PR DESCRIPTION
The assert checks, meant to help catch bugs, are bugged themselves. Ohhh joy. This is the case in a few other functions in monster.cpp where consecutive app_fatal's check the wrong argument.