### PR TITLE
Fix min diff in AddVision.

### DIFF
--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -1156,9 +1156,7 @@ void InitVision()
 
 int AddVision(int x, int y, int r, BOOL mine)
 {
-	int vid;
-
-	vid = r;
+	int vid; // BUGFIX: if numvision >= MAXVISION behavior is undefined
 
 	if (numvision < MAXVISION) {
 		VisionList[numvision]._lx = x;


### PR DESCRIPTION
.Returning `r` in this case makes no sense - as it turns out it's actually result of undefined behavior.