### PR TITLE
Fix merged function `sound_update`

### DIFF
--- a/3rdParty/Storm/Source/storm.cpp
+++ b/3rdParty/Storm/Source/storm.cpp
@@ -67,7 +67,7 @@ BOOL STORMAPI SFileCloseFile(HANDLE hFile) rBool;
 BOOL STORMAPI SFileDdaBeginEx(HANDLE hFile, DWORD flags, DWORD mask, unsigned __int32 lDistanceToMove, signed __int32 volume, signed int a6, int a7) rBool;
 BOOL STORMAPI SFileDdaDestroy() rBool;
 BOOL STORMAPI SFileDdaEnd(HANDLE hFile) rBool;
-BOOL STORMAPI SFileDdaGetPos(HANDLE hFile, int *current, int *end) rBool;
+BOOL STORMAPI SFileDdaGetPos(HANDLE hFile, DWORD *current, DWORD *end) rBool;
 
 BOOL STORMAPI SFileDdaInitialize(HANDLE directsound) rBool;
 BOOL STORMAPI SFileDdaSetVolume(HANDLE hFile, signed int bigvolume, signed int volume) rBool;

--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -497,7 +497,7 @@ BOOL STORMAPI SFileCloseFile(HANDLE hFile);
 BOOL STORMAPI SFileDdaBeginEx(HANDLE hFile, DWORD flags, DWORD mask, unsigned __int32 lDistanceToMove, signed __int32 volume, signed int pan, int a7);
 BOOL STORMAPI SFileDdaDestroy();
 BOOL STORMAPI SFileDdaEnd(HANDLE hFile);
-BOOL STORMAPI SFileDdaGetPos(HANDLE hFile, int *current, int *end);
+BOOL STORMAPI SFileDdaGetPos(HANDLE hFile, DWORD *current, DWORD *end);
 
 BOOL STORMAPI SFileDdaInitialize(HANDLE directsound);
 BOOL STORMAPI SFileDdaSetVolume(HANDLE hFile, signed int bigvolume, signed int volume);

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1144,13 +1144,18 @@ void sound_stop()
 
 void sound_update()
 {
-	int current, end;
-
 	if (!gbSndInited) {
 		return;
 	}
 
 	snd_update(FALSE);
+	effects_update();
+}
+
+void effects_update()
+{
+	DWORD current, end;
+
 	if (sfx_stream != NULL && SFileDdaGetPos(sfx_stream, &current, &end) && current >= end) {
 		sfx_stop();
 	}

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -21,6 +21,7 @@ void PlaySfxLoc(int psfx, int x, int y);
 void FreeMonsterSnd();
 void sound_stop();
 void sound_update();
+void effects_update();
 void effects_cleanup_sfx();
 void stream_update();
 void priv_sound_init(UCHAR bLoadMask);


### PR DESCRIPTION
This fixes the function `effects_update` which got merged with `sound_update` due to the return using a `jmp` to the function. Also fixes the storm DDA function.