### PR TITLE
Clean up codec_encode, prettify codec_get_encoded_len (bin exact)

### DIFF
--- a/Source/codec.cpp
+++ b/Source/codec.cpp
@@ -80,10 +80,10 @@ void codec_init_key(int unused, char *pszPassword)
 // 4035DB: using guessed type char var_58[64];
 // 4035DB: using guessed type char dst[20];
 
-int codec_get_encoded_len(int dwSrcBytes)
+DWORD codec_get_encoded_len(DWORD dwSrcBytes)
 {
-	if (dwSrcBytes & 0x3F)
-		dwSrcBytes += 64 - (dwSrcBytes & 0x3F);
+	if (dwSrcBytes % 64 != 0)
+		dwSrcBytes += 64 - (dwSrcBytes % 64);
 	return dwSrcBytes + 8;
 }
 

--- a/Source/codec.h
+++ b/Source/codec.h
@@ -5,6 +5,6 @@
 int codec_decode(BYTE *pbSrcDst, DWORD size, char *pszPassword);
 void codec_init_key(int unused, char *pszPassword);
 DWORD codec_get_encoded_len(DWORD dwSrcBytes);
-void codec_encode(void *pbSrcDst, int size, int size_64, char *pszPassword);
+void codec_encode(BYTE* pbSrcDst, DWORD size, int size_64, char *pszPassword);
 
 #endif /* __CODEC_H__ */

--- a/Source/codec.h
+++ b/Source/codec.h
@@ -4,7 +4,7 @@
 
 int codec_decode(BYTE *pbSrcDst, DWORD size, char *pszPassword);
 void codec_init_key(int unused, char *pszPassword);
-int codec_get_encoded_len(int dwSrcBytes);
+DWORD codec_get_encoded_len(DWORD dwSrcBytes);
 void codec_encode(void *pbSrcDst, int size, int size_64, char *pszPassword);
 
 #endif /* __CODEC_H__ */


### PR DESCRIPTION
These casts in `codec_encode` are a bit unseemly, maybe it was a cast to some helper structure, but could be prettified later.

Callers of `codec_get_encoded_len` doesn't seem to be affected by its change.

Fixes #226 
