### PR TITLE
Implement debug seed sync

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -1,5 +1,13 @@
 #include "diablo.h"
 
+#ifdef _DEBUG
+BOOL update_seed_check = FALSE;
+#endif
+
+int seed_index;
+int level_seeds[NUMLEVELS];
+int seed_table[4096];
+
 void *pSquareCel;
 char dMonsDbg[NUMLEVELS][MAXDUNX][MAXDUNY];
 char dFlagDbg[NUMLEVELS][MAXDUNX][MAXDUNY];
@@ -14,6 +22,58 @@ void FreeDebugGFX()
 {
 	MemFreeDbg(pSquareCel);
 }
+
+#ifdef _DEBUG
+void init_seed_desync()
+{
+	int i;
+
+	for(i = 0; i < 4096; i++) {
+		seed_table[i] = -1;
+	}
+
+	seed_index = 0;
+
+	for(i = 0; i < NUMLEVELS; i++) {
+		level_seeds[i] = 0;
+	}
+}
+
+void seed_desync_index_get()
+{
+	if(currlevel == 0) {
+		return;
+	}
+
+	update_seed_check = TRUE;
+	seed_index = level_seeds[currlevel];
+}
+
+void seed_desync_index_set()
+{
+	if(currlevel == 0) {
+		return;
+	}
+
+	update_seed_check = FALSE;
+	level_seeds[currlevel + 1] = seed_index;
+}
+
+void seed_desync_check(int seed)
+{
+	if(!update_seed_check || seed_index == 4096 || currlevel == 0) {
+		return;
+	}
+
+	if(seed_table[seed_index] == -1) {
+		seed_table[seed_index] = seed;
+	} else if(seed != seed_table[seed_index]) {
+		app_fatal("Seeds desynced");
+	}
+
+	seed_index++;
+}
+#endif
 
 void CheckDungeonClear()
 {

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -8,6 +8,12 @@ extern char dFlagDbg[NUMLEVELS][MAXDUNX][MAXDUNY];
 
 void LoadDebugGFX();
 void FreeDebugGFX();
+#ifdef _DEBUG
+void init_seed_desync();
+void seed_desync_index_get();
+void seed_desync_index_set();
+void seed_desync_check(int seed);
+#endif
 void CheckDungeonClear();
 #ifdef _DEBUG
 void GiveGoldCheat();


### PR DESCRIPTION
This adds the unused memory for seed checking in `debug.cpp` and their associated functions. As the functions have no call, it would be interesting to figure out where they go and if they work. This fixes #382, unused memory in `path.cpp` was added awhile back.