### PR TITLE
Add unused special CEL for town

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -71,7 +71,7 @@ void FreeGameMem()
 	MemFreeDbg(pDungeonCels);
 	MemFreeDbg(pMegaTiles);
 	MemFreeDbg(pLevelPieces);
-	MemFreeDbg(level_special_cel);
+	MemFreeDbg(pSpecialCels);
 	MemFreeDbg(pSpeedCels);
 
 	FreeMissiles();
@@ -1570,31 +1570,31 @@ void LoadLvlGFX()
 		pDungeonCels = LoadFileInMem("Levels\\TownData\\Town.CEL", 0);
 		pMegaTiles = LoadFileInMem("Levels\\TownData\\Town.TIL", 0);
 		pLevelPieces = LoadFileInMem("Levels\\TownData\\Town.MIN", 0);
-		level_special_cel = LoadFileInMem("Levels\\TownData\\TownS.CEL", 0);
+		pSpecialCels = LoadFileInMem("Levels\\TownData\\TownS.CEL", 0);
 		break;
 	case DTYPE_CATHEDRAL:
 		pDungeonCels = LoadFileInMem("Levels\\L1Data\\L1.CEL", 0);
 		pMegaTiles = LoadFileInMem("Levels\\L1Data\\L1.TIL", 0);
 		pLevelPieces = LoadFileInMem("Levels\\L1Data\\L1.MIN", 0);
-		level_special_cel = LoadFileInMem("Levels\\L1Data\\L1S.CEL", 0);
+		pSpecialCels = LoadFileInMem("Levels\\L1Data\\L1S.CEL", 0);
 		break;
 	case DTYPE_CATACOMBS:
 		pDungeonCels = LoadFileInMem("Levels\\L2Data\\L2.CEL", 0);
 		pMegaTiles = LoadFileInMem("Levels\\L2Data\\L2.TIL", 0);
 		pLevelPieces = LoadFileInMem("Levels\\L2Data\\L2.MIN", 0);
-		level_special_cel = LoadFileInMem("Levels\\L2Data\\L2S.CEL", 0);
+		pSpecialCels = LoadFileInMem("Levels\\L2Data\\L2S.CEL", 0);
 		break;
 	case DTYPE_CAVES:
 		pDungeonCels = LoadFileInMem("Levels\\L3Data\\L3.CEL", 0);
 		pMegaTiles = LoadFileInMem("Levels\\L3Data\\L3.TIL", 0);
 		pLevelPieces = LoadFileInMem("Levels\\L3Data\\L3.MIN", 0);
-		level_special_cel = LoadFileInMem("Levels\\L1Data\\L1S.CEL", 0);
+		pSpecialCels = LoadFileInMem("Levels\\L1Data\\L1S.CEL", 0);
 		break;
 	case DTYPE_HELL:
 		pDungeonCels = LoadFileInMem("Levels\\L4Data\\L4.CEL", 0);
 		pMegaTiles = LoadFileInMem("Levels\\L4Data\\L4.TIL", 0);
 		pLevelPieces = LoadFileInMem("Levels\\L4Data\\L4.MIN", 0);
-		level_special_cel = LoadFileInMem("Levels\\L2Data\\L2S.CEL", 0);
+		pSpecialCels = LoadFileInMem("Levels\\L2Data\\L2S.CEL", 0);
 		break;
 	default:
 		app_fatal("LoadLvlGFX");

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -43,7 +43,7 @@ int scr_pix_width;  // weak
 int scr_pix_height; // weak
 char dArch[MAXDUNX][MAXDUNY];
 char nBlockTable[2049];
-void *level_special_cel;
+BYTE *pSpecialCels;
 char dFlags[MAXDUNX][MAXDUNY];
 char dItem[MAXDUNX][MAXDUNY];
 BYTE setlvlnum;

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -45,7 +45,7 @@ extern int scr_pix_width;  // weak
 extern int scr_pix_height; // weak
 extern char dArch[MAXDUNX][MAXDUNY];
 extern char nBlockTable[2049];
-extern void *level_special_cel;
+extern BYTE *pSpecialCels;
 extern char dFlags[MAXDUNX][MAXDUNY];
 extern char dItem[MAXDUNX][MAXDUNY];
 extern BYTE setlvlnum;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -888,7 +888,7 @@ void scrollrt_draw_clipped_dungeon(BYTE *pBuff, int sx, int sy, int dx, int dy, 
 	}
 	if(bArch != 0) {
 		cel_transparency_active = (unsigned char)TransList[bMap];
-		Cel2DecodeLightTrans(pBuff, (BYTE *)level_special_cel, bArch, 64, 0, 8);
+		Cel2DecodeLightTrans(pBuff, pSpecialCels, bArch, 64, 0, 8);
 	}
 }
 
@@ -1352,7 +1352,7 @@ void scrollrt_draw_clipped_dungeon_2(BYTE *pBuff, int sx, int sy, int skipChunks
 	}
 	if(bArch != 0) {
 		cel_transparency_active = (unsigned char)TransList[bMap];
-		Cel2DecodeLightTrans(pBuff, (BYTE *)level_special_cel, bArch, 64, CelSkip, 8);
+		Cel2DecodeLightTrans(pBuff, pSpecialCels, bArch, 64, CelSkip, 8);
 	}
 }
 
@@ -1766,7 +1766,7 @@ void scrollrt_draw_dungeon(BYTE *pBuff, int sx, int sy, int capChunks, int CelCa
 	}
 	if (bArch != 0) {
 		cel_transparency_active = (unsigned char)TransList[bMap];
-		CelDecodeHdrLightTrans(pBuff, (BYTE *)level_special_cel, bArch, 64, 0, CelCap);
+		CelDecodeHdrLightTrans(pBuff, pSpecialCels, bArch, 64, 0, CelCap);
 	}
 }
 

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -138,6 +138,230 @@ void town_clear_low_buf(BYTE *pBuff)
 #endif
 }
 
+void town_special_lower(BYTE *pBuff, int nCel)
+{
+#if 0
+	int w;
+	BYTE *end;
+
+#ifdef USE_ASM
+	__asm {
+		mov		ebx, level_special_cel
+		mov		eax, nCel
+		shl		eax, 2
+		add		ebx, eax
+		mov		eax, [ebx+4]
+		sub		eax, [ebx]
+		mov		end, eax
+		mov		esi, level_special_cel
+		add		esi, [ebx]
+		mov		edi, pBuff
+		mov		eax, 768 + 64
+		mov		w, eax
+		mov		ebx, end
+		add		ebx, esi
+	label1:
+		mov		edx, 64
+	label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		label7
+		sub		edx, eax
+		cmp		edi, gpBufEnd
+		jb		label3
+		add		esi, eax
+		add		edi, eax
+		jmp		label6
+	label3:
+		mov		ecx, eax
+		shr		ecx, 1
+		jnb		label4
+		movsb
+		jecxz	label6
+	label4:
+		shr		ecx, 1
+		jnb		label5
+		movsw
+		jecxz	label6
+	label5:
+		rep movsd
+	label6:
+		or		edx, edx
+		jz		label8
+		jmp		label2
+	label7:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		label2
+	label8:
+		sub		edi, w
+		cmp		ebx, esi
+		jnz		label1
+	}
+#else
+	BYTE width;
+	BYTE *src, *dst;
+	DWORD *pFrameTable;
+
+	pFrameTable = (DWORD *)level_special_cel;
+	src = &level_special_cel[pFrameTable[nCel]];
+	dst = pBuff;
+	end = &src[pFrameTable[nCel + 1] - pFrameTable[nCel]];
+
+	for(; src != end; dst -= 768 + 64) {
+		for(w = 64; w;) {
+			width = *src++;
+			if(!(width & 0x80)) {
+				w -= width;
+				if(dst < gpBufEnd) {
+					if(width & 1) {
+						dst[0] = src[0];
+						src++;
+						dst++;
+					}
+					width >>= 1;
+					if(width & 1) {
+						dst[0] = src[0];
+						dst[1] = src[1];
+						src += 2;
+						dst += 2;
+					}
+					width >>= 1;
+					for(; width; width--) {
+						dst[0] = src[0];
+						dst[1] = src[1];
+						dst[2] = src[2];
+						dst[3] = src[3];
+						src += 4;
+						dst += 4;
+					}
+				} else {
+					src += width;
+					dst += width;
+				}
+			} else {
+				width = -(char)width;
+				dst += width;
+				w -= width;
+			}
+		}
+	}
+#endif
+#endif
+}
+
+void town_special_upper(BYTE *pBuff, int nCel)
+{
+#if 0
+	int w;
+	BYTE *end;
+
+#ifdef USE_ASM
+	__asm {
+		mov		ebx, level_special_cel
+		mov		eax, nCel
+		shl		eax, 2
+		add		ebx, eax
+		mov		eax, [ebx+4]
+		sub		eax, [ebx]
+		mov		end, eax
+		mov		esi, level_special_cel
+		add		esi, [ebx]
+		mov		edi, pBuff
+		mov		eax, 768 + 64
+		mov		w, eax
+		mov		ebx, end
+		add		ebx, esi
+	label1:
+		mov		edx, 64
+	label2:
+		xor		eax, eax
+		lodsb
+		or		al, al
+		js		label6
+		sub		edx, eax
+		cmp		edi, gpBufEnd
+		jb		label8
+		mov		ecx, eax
+		shr		ecx, 1
+		jnb		label3
+		movsb
+		jecxz	label5
+	label3:
+		shr		ecx, 1
+		jnb		label4
+		movsw
+		jecxz	label5
+	label4:
+		rep movsd
+	label5:
+		or		edx, edx
+		jz		label7
+		jmp		label2
+	label6:
+		neg		al
+		add		edi, eax
+		sub		edx, eax
+		jnz		label2
+	label7:
+		sub		edi, w
+		cmp		ebx, esi
+		jnz		label1
+	label8:
+		nop
+	}
+#else
+	BYTE width;
+	BYTE *src, *dst;
+	DWORD *pFrameTable;
+
+	pFrameTable = (DWORD *)level_special_cel;
+	src = &level_special_cel[pFrameTable[nCel]];
+	dst = pBuff;
+	end = &src[pFrameTable[nCel + 1] - pFrameTable[nCel]];
+
+	for(; src != end; dst -= 768 + 64) {
+		for(w = 64; w;) {
+			width = *src++;
+			if(!(width & 0x80)) {
+				w -= width;
+				if(dst < gpBufEnd) {
+					return;
+				}
+				if(width & 1) {
+					dst[0] = src[0];
+					src++;
+					dst++;
+				}
+				width >>= 1;
+				if(width & 1) {
+					dst[0] = src[0];
+					dst[1] = src[1];
+					src += 2;
+					dst += 2;
+				}
+				width >>= 1;
+				for(; width; width--) {
+					dst[0] = src[0];
+					dst[1] = src[1];
+					dst[2] = src[2];
+					dst[3] = src[3];
+					src += 4;
+					dst += 4;
+				}
+			} else {
+				width = -(char)width;
+				dst += width;
+				w -= width;
+			}
+		}
+	}
+#endif
+#endif
+}
+
 void town_draw_clipped_e_flag(BYTE *pBuff, int x, int y, int sx, int sy)
 {
 	int i;
@@ -224,6 +448,9 @@ void town_draw_clipped_town(BYTE *pBuff, int x, int y, int sx, int sy, BOOL some
 	}
 	if (dFlags[x][y] & DFLAG_MISSILE) {
 		DrawClippedMissile(x, y, sx, sy, 0, 8, 0);
+	}
+	if(dArch[x][y] != 0) {
+		town_special_lower(pBuff, dArch[x][y]);
 	}
 }
 
@@ -403,6 +630,9 @@ void town_draw_clipped_town_2(BYTE *pBuff, int x, int y, int a4, int a5, int sx,
 	}
 	if (dFlags[x][y] & DFLAG_MISSILE) {
 		DrawClippedMissile(x, y, sx, sy, a5, 8, 0);
+	}
+	if(dArch[x][y] != 0) {
+		town_special_lower(&pBuff[PitchTbl[16 * a5]], dArch[x][y]);
 	}
 }
 
@@ -594,6 +824,9 @@ void town_draw_town_all(BYTE *pBuff, int x, int y, int a4, int dir, int sx, int 
 	}
 	if (dFlags[x][y] & DFLAG_MISSILE) {
 		DrawMissile(x, y, sx, sy, 0, dir, 0);
+	}
+	if(dArch[x][y] != 0) {
+		town_special_upper(pBuff, dArch[x][y]);
 	}
 }
 

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -146,14 +146,14 @@ void town_special_lower(BYTE *pBuff, int nCel)
 
 #ifdef USE_ASM
 	__asm {
-		mov		ebx, level_special_cel
+		mov		ebx, pSpecialCels
 		mov		eax, nCel
 		shl		eax, 2
 		add		ebx, eax
 		mov		eax, [ebx+4]
 		sub		eax, [ebx]
 		mov		end, eax
-		mov		esi, level_special_cel
+		mov		esi, pSpecialCels
 		add		esi, [ebx]
 		mov		edi, pBuff
 		mov		eax, 768 + 64
@@ -205,8 +205,8 @@ void town_special_lower(BYTE *pBuff, int nCel)
 	BYTE *src, *dst;
 	DWORD *pFrameTable;
 
-	pFrameTable = (DWORD *)level_special_cel;
-	src = &level_special_cel[pFrameTable[nCel]];
+	pFrameTable = (DWORD *)pSpecialCels;
+	src = &pSpecialCels[pFrameTable[nCel]];
 	dst = pBuff;
 	end = &src[pFrameTable[nCel + 1] - pFrameTable[nCel]];
 
@@ -260,14 +260,14 @@ void town_special_upper(BYTE *pBuff, int nCel)
 
 #ifdef USE_ASM
 	__asm {
-		mov		ebx, level_special_cel
+		mov		ebx, pSpecialCels
 		mov		eax, nCel
 		shl		eax, 2
 		add		ebx, eax
 		mov		eax, [ebx+4]
 		sub		eax, [ebx]
 		mov		end, eax
-		mov		esi, level_special_cel
+		mov		esi, pSpecialCels
 		add		esi, [ebx]
 		mov		edi, pBuff
 		mov		eax, 768 + 64
@@ -317,8 +317,8 @@ void town_special_upper(BYTE *pBuff, int nCel)
 	BYTE *src, *dst;
 	DWORD *pFrameTable;
 
-	pFrameTable = (DWORD *)level_special_cel;
-	src = &level_special_cel[pFrameTable[nCel]];
+	pFrameTable = (DWORD *)pSpecialCels;
+	src = &pSpecialCels[pFrameTable[nCel]];
 	dst = pBuff;
 	end = &src[pFrameTable[nCel + 1] - pFrameTable[nCel]];
 

--- a/Source/town.h
+++ b/Source/town.h
@@ -4,6 +4,8 @@
 
 void town_clear_upper_buf(BYTE *pBuff);
 void town_clear_low_buf(BYTE *pBuff);
+void town_special_lower(BYTE *pBuff, int nCel);
+void town_special_upper(BYTE *pBuff, int nCel);
 void town_draw_clipped_e_flag(BYTE *pBuff, int x, int y, int sx, int sy);
 void town_draw_clipped_town(BYTE *pBuff, int x, int y, int sx, int sy, BOOL some_flag);
 void town_draw_lower(int x, int y, int sx, int sy, int a5, int some_flag);


### PR DESCRIPTION
In all patches except 1.09, there exists function calls to two disabled functions. These are responsible for drawing special cels `TownS.CEL` which seems to only contain trees. If you enable them, you can see that trees draw correctly above the player, but it's somewhat glitchy. These functions will be completely optimized away in 1.09 but will have a null call in older versions of VC.
![DIABLO_20190521_102516](https://user-images.githubusercontent.com/15209402/58088909-44695300-7b89-11e9-8206-2e6ddbb2fe0f.png)
