### PR TITLE
Make delta_quest_inited bin exact.

### DIFF
--- a/structs.h
+++ b/structs.h
@@ -940,7 +940,7 @@ typedef struct DPortal {
 } DPortal;
 
 typedef struct MultiQuests {
-	char qstate;
+	BYTE qstate;
 	BYTE qlog;
 	BYTE qvar1;
 } MultiQuests;


### PR DESCRIPTION
Not obvious to naked eye mistake here since `qstate` is signed. 

There's also an open question should `qstate` be `unsigned` or not, in this case `-1` seems to be clearly imply something akin to uninitialized, however it's assigned to `_qactive` which is currently `unsigned` (though reasons for its unsigndness are not entrirely clear)

Fixes #581 as I checked.

Also a small advertisment of modern static analyzer tools (in this case clang-tidy) which tells you that something fishy is going on instantly:
![image](https://user-images.githubusercontent.com/2133957/58745819-014b9180-845f-11e9-89da-1af553322413.png)

