### PR TITLE
Remove more garbage

### DIFF
--- a/DiabloUI/_temp_data.cpp
+++ b/DiabloUI/_temp_data.cpp
@@ -136,7 +136,7 @@ HGDIOBJ dword_10029420;                                         // idb
 HGDIOBJ dword_10029424;                                         // idb
 BYTE *dword_10029428;                                           // idb
 void *dword_1002942C;                                           // idb
-int(__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD); // weak
+int(__stdcall *dword_10029430)(DWORD, DWORD, DWORD, DWORD); // weak
 void *dword_10029434;                                           // idb
 int dword_10029438[4];                                          // weak
 char nullcharacter;                                             /* check */

--- a/DiabloUI/_temp_funcs.h
+++ b/DiabloUI/_temp_funcs.h
@@ -15,56 +15,56 @@ void __fastcall artfont_PrintFontStr(char *str, DWORD **pSurface, int sx, int sy
 
 signed int bn_prof_100014E8();
 //const char *UiProfileGetString();
-//BOOL __stdcall UiProfileCallback(int a1, int a2, int a3, int a4, LPARAM a5, int a6, int a7, int a8, int (__stdcall *a9)(_DWORD, _DWORD, _DWORD, _DWORD));
+//BOOL __stdcall UiProfileCallback(int a1, int a2, int a3, int a4, LPARAM a5, int a6, int a7, int a8, int (__stdcall *a9)(DWORD, DWORD, DWORD, DWORD));
 HGDIOBJ __stdcall bn_prof_1000155F(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 void UNKCALL bn_prof_100016DD(HWND arg);
 void __fastcall bn_prof_100018CE(int a1, int a2);
-int __fastcall bn_prof_10001938(HDC a1, _DWORD *a2, char *a3, int a4, int a5);
+int __fastcall bn_prof_10001938(HDC a1, DWORD *a2, char *a3, int a4, int a5);
 int __fastcall bn_prof_10001A10(HWND a1, HWND a2);
 HINSTANCE __fastcall bn_prof_10001B0A(HWND a1, const CHAR *a2);
 HWND UNKCALL bn_prof_10001C0E(HWND hWnd);
-void __fastcall bn_prof_10001CB9(_DWORD *a1, int a2, void(__fastcall *a3)(_BYTE *, _DWORD, int), int a4);
+void __fastcall bn_prof_10001CB9(DWORD *a1, int a2, void(__fastcall *a3)(BYTE *, DWORD, int), int a4);
 BOOL UNKCALL bn_prof_10001CF3(HWND hWnd);
 HFONT __fastcall bn_prof_10001D81(HWND hWnd, int a2, int a3);
 void UNKCALL bn_prof_10001E34(void *arg);
 void __fastcall bn_prof_10001E4C(char *a1, LPARAM lParam, HWND hDlg);
-void __fastcall bn_prof_10001ED0(char *a1, _BYTE *a2, int a3);
+void __fastcall bn_prof_10001ED0(char *a1, BYTE *a2, int a3);
 void *bn_prof_10001F29();
 BYTE *bn_prof_10001F84();
 //int __stdcall UiProfileDraw(int, int, int, int, HGDIOBJ ho, int, int, int, int, int, int); // idb
 BOOL bn_prof_100021C4();
 void *bn_prof_10002247();
 int j_bn_prof_10002282();
-_DWORD *bn_prof_10002282();
+DWORD *bn_prof_10002282();
 void __cdecl bn_prof_10002298();         // idb
 int UNKCALL bn_prof_100022A2(HWND hWnd); // idb
 int UNKCALL bn_prof_10002353(HGDIOBJ h); // idb
 HGDIOBJ bn_prof_100023D8();
-_DWORD *__fastcall bn_prof_10002410(HDC hdc, _DWORD *a2);
-signed int __fastcall bn_prof_10002456(int a1, const CHAR *a2, char a3, _DWORD *a4);
+DWORD *__fastcall bn_prof_10002410(HDC hdc, DWORD *a2);
+signed int __fastcall bn_prof_10002456(int a1, const CHAR *a2, char a3, DWORD *a4);
 signed int bn_prof_100026B9();
-signed int UNKCALL bn_prof_100026C4(_DWORD *arg);
-void UNKCALL bn_prof_100026F0(_DWORD *arg);
-int UNKCALL bn_prof_10002749(_DWORD *arg, _DWORD *location);
-_DWORD *UNKCALL bn_prof_10002782(int *arg, int a2, int a3, char a4);
-_DWORD *UNKCALL bn_prof_100027CE(_DWORD *arg);
-void UNKCALL bn_prof_100027D8(_DWORD *arg);
-_DWORD *UNKCALL bn_prof_1000280C(int *arg, _DWORD *a2, int a3, _DWORD *a4);
-void UNKCALL bn_prof_1000287D(_DWORD *arg);
-void UNKCALL bn_prof_10002890(_DWORD *arg);
+signed int UNKCALL bn_prof_100026C4(DWORD *arg);
+void UNKCALL bn_prof_100026F0(DWORD *arg);
+int UNKCALL bn_prof_10002749(DWORD *arg, DWORD *location);
+DWORD *UNKCALL bn_prof_10002782(int *arg, int a2, int a3, char a4);
+DWORD *UNKCALL bn_prof_100027CE(DWORD *arg);
+void UNKCALL bn_prof_100027D8(DWORD *arg);
+DWORD *UNKCALL bn_prof_1000280C(int *arg, DWORD *a2, int a3, DWORD *a4);
+void UNKCALL bn_prof_1000287D(DWORD *arg);
+void UNKCALL bn_prof_10002890(DWORD *arg);
 
-void UNKCALL BNetGW_100028C2(_DWORD *arg);
-void UNKCALL BNetGW_100029BF(_DWORD *arg, int a2);
-void *UNKCALL BNetGW_10002A07(_DWORD *arg);
-_DWORD *UNKCALL BNetGW_10002A84(_DWORD *arg, signed int a2);
+void UNKCALL BNetGW_100028C2(DWORD *arg);
+void UNKCALL BNetGW_100029BF(DWORD *arg, int a2);
+void *UNKCALL BNetGW_10002A07(DWORD *arg);
+DWORD *UNKCALL BNetGW_10002A84(DWORD *arg, signed int a2);
 signed int BNetGW_10002AE5();
-int UNKCALL BNetGW_10002AF0(_DWORD *arg, char *a2);
-_BYTE *UNKCALL BNetGW_10002B21(_DWORD *arg, signed int a2);
-void UNKCALL BNetGW_10002B51(_DWORD *arg, signed int a2);
+int UNKCALL BNetGW_10002AF0(DWORD *arg, char *a2);
+BYTE *UNKCALL BNetGW_10002B21(DWORD *arg, signed int a2);
+void UNKCALL BNetGW_10002B51(DWORD *arg, signed int a2);
 char *UNKCALL BNetGW_10002B78(void *arg, char *a2);
-char *UNKCALL BNetGW_10002C23(_DWORD *arg);
-int UNKCALL BNetGW_10002C51(_DWORD *arg);
-int UNKCALL BNetGW_10002DBF(_DWORD *arg);
+char *UNKCALL BNetGW_10002C23(DWORD *arg);
+int UNKCALL BNetGW_10002C51(DWORD *arg);
+int UNKCALL BNetGW_10002DBF(DWORD *arg);
 char *__stdcall BNetGW_10002DEB(char *a1, unsigned int a2);
 char *__stdcall BNetGW_10002E0B(char *a1, unsigned int a2);
 
@@ -77,7 +77,7 @@ BOOL __stdcall UiGetDataCallback(int game_type, int data_code, void *a3, int a4,
 BOOL __stdcall UiSoundCallback(int a1, int type, int a3);
 BOOL __stdcall UiAuthCallback(int a1, char *a2, char *a3, char a4, char *a5, LPSTR lpBuffer, int cchBufferMax);
 BOOL __stdcall UiDrawDescCallback(int arg0, COLORREF color, LPCSTR lpString, char *a4, int a5, UINT align, time_t a7, HDC *a8);
-BOOL __stdcall UiCategoryCallback(int a1, int a2, int a3, int a4, int a5, _DWORD *a6, _DWORD *a7);
+BOOL __stdcall UiCategoryCallback(int a1, int a2, int a3, int a4, int a5, DWORD *a6, DWORD *a7);
 int __fastcall Connect_GetRankFromLevel(char *str);
 BOOL __fastcall Connect_DiffFromString(char *str, _gamedata *gamedata, int a3, int a4);
 void __fastcall Connect_SetDiffString(_gamedata *gamedata, const char *str1, char *str2, char *str3, int size);
@@ -165,7 +165,7 @@ void __cdecl j_DiabloUI_cpp_init();
 void __cdecl DiabloUI_cpp_init();
 
 signed int DirLink_10005CFA();
-BOOL __fastcall DirLink_10005D05(int a1, int a2, int a3, _DWORD *a4, int a5, int playerid);
+BOOL __fastcall DirLink_10005D05(int a1, int a2, int a3, DWORD *a4, int a5, int playerid);
 int __stdcall DirLink_10005D63(HWND hWnd, UINT Msg, WPARAM wParam, unsigned int lParam);
 int __fastcall DirLink_10005EB2(HWND hDlg, int a2);
 int UNKCALL DirLink_10005F1F(HWND hDlg); // idb
@@ -301,7 +301,7 @@ signed int Modem_10008648();
 int Modem_10008653();
 int Modem_10008659();
 int UNKCALL Modem_1000865F(char *); // idb
-BOOL __fastcall Modem_10008680(int a1, int a2, int a3, _DWORD *a4, int a5, int playerid);
+BOOL __fastcall Modem_10008680(int a1, int a2, int a3, DWORD *a4, int a5, int playerid);
 int __stdcall Modem_100086DE(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam); // idb
 void **UNKCALL Modem_1000879E(HWND hDlg);
 BOOL UNKCALL Modem_100087DB(HWND hWnd);
@@ -367,7 +367,7 @@ HWND __fastcall SelConn_1000A226(HWND hDlg, int nIDDlgItem);
 HWND UNKCALL SelConn_1000A3E2(HWND hDlg);
 int SelConn_1000A3FF();
 void UNKCALL SelConn_1000A43A(HWND hDlg);
-BOOL __fastcall SelConn_1000A4B9(_DWORD *a1);
+BOOL __fastcall SelConn_1000A4B9(DWORD *a1);
 BOOL UNKCALL SelConn_1000A4CD(void *location);
 HWND UNKCALL SelConn_1000A4E4(HWND hWnd, char *a2, int a3);
 signed int __stdcall SelConn_1000A5F3(int a1, char *a2, char *a3, int a4);
@@ -378,7 +378,7 @@ HWND UNKCALL SelConn_1000A866(HWND hWnd);
 HWND UNKCALL SelConn_1000A8D7(HWND hWnd);
 HWND UNKCALL SelConn_1000A948(HWND hWnd);
 int UNKCALL SelConn_1000A9F3(HWND hWnd); // idb
-_DWORD *__fastcall SelConn_1000AA28(int a1);
+DWORD *__fastcall SelConn_1000AA28(int a1);
 HWND UNKCALL SelConn_1000AA3B(HWND hWnd);
 HWND UNKCALL SelConn_1000AAEB(HWND hWnd);
 HWND UNKCALL SelConn_1000AB83(HWND hWnd);
@@ -449,21 +449,21 @@ BOOL __stdcall UiSelHeroSingDialog(BOOL(__stdcall *fninfo)(BOOL(__stdcall *fninf
 
 void *SelIPX_1000C610();
 signed int SelIPX_1000C629();
-BOOL __fastcall SelIPX_1000C634(int a1, int a2, int a3, _DWORD *a4, int a5, int playerid);
+BOOL __fastcall SelIPX_1000C634(int a1, int a2, int a3, DWORD *a4, int a5, int playerid);
 int __stdcall SelIPX_1000C692(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam); // idb
 LONG __fastcall SelIPX_1000C818(HWND hDlg, int nIDDlgItem);
 HWND UNKCALL SelIPX_1000C982(HWND hDlg);
 int SelIPX_1000C99F();
 const char *UNKCALL SelIPX_1000C9DA(HWND hDlg);
-void __fastcall SelIPX_1000CA64(_DWORD *a1);
-_DWORD **__fastcall SelIPX_1000CA71(_DWORD *a1);
+void __fastcall SelIPX_1000CA64(DWORD *a1);
+DWORD **__fastcall SelIPX_1000CA71(DWORD *a1);
 BOOL UNKCALL SelIPX_1000CAC1(void *location);
 void *__stdcall SelIPX_1000CAD5(int a1, char *a2, char *a3);
-_DWORD *__fastcall SelIPX_1000CB50(_DWORD *a1, _DWORD *a2);
-_DWORD *__fastcall SelIPX_1000CB73(_DWORD *a1, int a2);
+DWORD *__fastcall SelIPX_1000CB50(DWORD *a1, DWORD *a2);
+DWORD *__fastcall SelIPX_1000CB73(DWORD *a1, int a2);
 int __fastcall SelIPX_1000CB83(HWND a1, const char *a2);
 int UNKCALL SelIPX_1000CC41(HWND hDlg); // idb
-BOOL __fastcall SelIPX_1000CCC5(_DWORD *a1);
+BOOL __fastcall SelIPX_1000CCC5(DWORD *a1);
 HWND UNKCALL SelIPX_1000CCD9(HWND hWnd);
 HWND UNKCALL SelIPX_1000CD4A(HWND hWnd);
 void UNKCALL SelIPX_1000CEE6(HWND hDlg);
@@ -471,7 +471,7 @@ LRESULT __stdcall SelIPX_1000CF38(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 HWND UNKCALL SelIPX_1000D070(HWND hWnd);
 HWND UNKCALL SelIPX_1000D0E1(HWND hWnd);
 int UNKCALL SelIPX_1000D18C(HWND hWnd); // idb
-_DWORD *__fastcall SelIPX_1000D1C1(int a1);
+DWORD *__fastcall SelIPX_1000D1C1(int a1);
 HWND UNKCALL SelIPX_1000D1D4(HWND hWnd);
 HWND UNKCALL SelIPX_1000D284(HWND hWnd);
 HWND UNKCALL SelIPX_1000D31C(HWND hWnd);
@@ -516,10 +516,10 @@ signed int SelModem_1000E42A();
 int __fastcall SelModem_1000E435(void *a1, int a2, int a3, char *a4, char *a5);
 char *__stdcall SelModem_1000E497(int a1, char *a2, char *a3);
 void *SelModem_1000E4EC();
-_DWORD *__fastcall SelModem_1000E500(int a1, _DWORD *a2);
+DWORD *__fastcall SelModem_1000E500(int a1, DWORD *a2);
 signed int UNKCALL SelModem_1000E505(void *arg);
 signed int SelModem_1000E51E();
-BOOL __fastcall SelModem_1000E553(_DWORD *a1);
+BOOL __fastcall SelModem_1000E553(DWORD *a1);
 BOOL UNKCALL SelModem_1000E567(void *location);
 int __fastcall SelModem_1000E57B(int a1, int a2);
 signed int SelModem_1000E5CC();
@@ -534,7 +534,7 @@ LRESULT __stdcall SelModem_1000EA04(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM l
 HWND UNKCALL SelModem_1000EB2C(HWND hWnd);
 HWND UNKCALL SelModem_1000EB9D(HWND hWnd);
 HWND UNKCALL SelModem_1000EC0E(HWND hWnd);
-_DWORD *__fastcall SelModem_1000EC9F(int a1);
+DWORD *__fastcall SelModem_1000EC9F(int a1);
 HWND UNKCALL SelModem_1000ECB2(HWND hWnd);
 HWND UNKCALL SelModem_1000ED3B(HWND hWnd);
 HWND UNKCALL SelModem_1000EDBC(HWND hWnd);
@@ -549,7 +549,7 @@ HWND __fastcall SelRegn_1000F0D7(HWND hDlg, int nIDDlgItem);
 HWND UNKCALL SelRegn_1000F109(HWND hDlg);
 int SelRegn_1000F126();
 void UNKCALL SelRegn_1000F161(HWND hDlg);
-BOOL __fastcall SelRegn_1000F1D4(_DWORD *a1);
+BOOL __fastcall SelRegn_1000F1D4(DWORD *a1);
 BOOL UNKCALL SelRegn_1000F1E8(void *location);
 HWND UNKCALL SelRegn_1000F1FC(HWND hWnd);
 signed int SelRegn_1000F2ED();
@@ -560,14 +560,14 @@ HWND UNKCALL SelRegn_1000F53C(HWND hWnd);
 HWND UNKCALL SelRegn_1000F5AD(HWND hWnd);
 HWND UNKCALL SelRegn_1000F61E(HWND hWnd);
 int UNKCALL SelRegn_1000F6C9(HWND hWnd); // idb
-_DWORD *__fastcall SelRegn_1000F6FE(int a1);
+DWORD *__fastcall SelRegn_1000F6FE(int a1);
 HWND UNKCALL SelRegn_1000F711(HWND hWnd);
 HWND UNKCALL SelRegn_1000F7C1(HWND hWnd);
 HWND UNKCALL SelRegn_1000F859(HWND hWnd);
 signed int UNKCALL SelRegn_1000F8DD(void *arg);
 signed int SelRegn_1000F8F6();
 HWND __fastcall SelRegn_1000F929(HWND hWnd, int a2, int height);
-//signed int __stdcall UiSelectRegion(_DWORD *a1);
+//signed int __stdcall UiSelectRegion(DWORD *a1);
 
 int __fastcall SelYesNo_YesNoDialog(HWND hWnd, char *dialogstr, char *hero, int nofocus); /* void */
 LRESULT __stdcall SelYesNo_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);

--- a/DiabloUI/bn_prof.cpp
+++ b/DiabloUI/bn_prof.cpp
@@ -18,7 +18,7 @@ int __stdcall UiProfileGetString() { return 0; }
 
 // ref: 0x100014F9
 void __cdecl UiProfileCallback() { return; }
-//BOOL __stdcall UiProfileCallback(int a1, int a2, int a3, int a4, LPARAM a5, int a6, int a7, int a8, int (__stdcall *a9)(_DWORD, _DWORD, _DWORD, _DWORD)) { return 0; }
+//BOOL __stdcall UiProfileCallback(int a1, int a2, int a3, int a4, LPARAM a5, int a6, int a7, int a8, int (__stdcall *a9)(DWORD, DWORD, DWORD, DWORD)) { return 0; }
 /* {
 	const char *v9; // eax
 	int v10; // eax
@@ -31,14 +31,14 @@ void __cdecl UiProfileCallback() { return; }
 	v9 = "DIALOG_PROFILE";
 	if ( !a9 )
 		v9 = "DIALOG_STATIC_PROFILE";
-	v10 = SDlgDialogBoxParam(hInstance, v9, *(_DWORD *)(a3 + 8), bn_prof_1000155F, 0);
+	v10 = SDlgDialogBoxParam(hInstance, v9, *(DWORD *)(a3 + 8), bn_prof_1000155F, 0);
 	return v10 && v10 != -1;
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
 // 10029408: using guessed type int dword_10029408;
 // 10029418: using guessed type int dword_10029418;
 // 1002941C: using guessed type int dword_1002941C;
-// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029430: using guessed type int (__stdcall *dword_10029430)(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000155F
 HGDIOBJ __stdcall bn_prof_1000155F(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
@@ -111,10 +111,10 @@ HGDIOBJ __stdcall bn_prof_1000155F(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 	SetTextColor((HDC)wParam, 0xFFFFu);
 	return GetStockObject(5);
 } */
-// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
-// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010376: using guessed type int __stdcall SDlgEndDialog(DWORD, DWORD);
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
+// 10029430: using guessed type int (__stdcall *dword_10029430)(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x100016DD
 void UNKCALL bn_prof_100016DD(HWND arg) { return; }
@@ -130,7 +130,7 @@ void UNKCALL bn_prof_100016DD(HWND arg) { return; }
 	size_t v9; // eax
 	char *v10; // eax
 	int v11; // ebx
-	_DWORD *v12; // edi
+	DWORD *v12; // edi
 	int v13; // eax
 	int v14; // ebx
 	size_t v15; // [esp+4h] [ebp-28h]
@@ -158,7 +158,7 @@ void UNKCALL bn_prof_100016DD(HWND arg) { return; }
 		v23 = 0;
 		if ( dword_10029408 > 0 )
 		{
-			v19 = v4 - (_DWORD)v3;
+			v19 = v4 - (DWORD)v3;
 			do
 			{
 				v5 = 0;
@@ -208,12 +208,12 @@ LABEL_13:
 		v11 = v1 - 1;
 		if ( v11 >= 0 )
 		{
-			v12 = (_DWORD *)(v22 + 4 * v11);
+			v12 = (DWORD *)(v22 + 4 * v11);
 			v13 = v18 - v22;
 			v14 = v11 + 1;
 			while ( 1 )
 			{
-				SMemFree(*(_DWORD *)((char *)v12 + v13), "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 250, 0);
+				SMemFree(*(DWORD *)((char *)v12 + v13), "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 250, 0);
 				SMemFree(*v12, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 251, 0);
 				--v12;
 				if ( !--v14 )
@@ -225,13 +225,13 @@ LABEL_13:
 		SMemFree(v22, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 254, 0);
 	}
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
 // 1001F380: using guessed type int dword_1001F380[];
 // 10029408: using guessed type int dword_10029408;
 // 10029418: using guessed type int dword_10029418;
 // 1002941C: using guessed type int dword_1002941C;
-// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029430: using guessed type int (__stdcall *dword_10029430)(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x100018CE
 void __fastcall bn_prof_100018CE(int a1, int a2) { return; }
@@ -242,7 +242,7 @@ void __fastcall bn_prof_100018CE(int a1, int a2) { return; }
 	char *v5; // ebx
 
 	v2 = a2;
-	if ( *(_DWORD *)(a2 + 24) && *(_DWORD *)a2 == 5 )
+	if ( *(DWORD *)(a2 + 24) && *(DWORD *)a2 == 5 )
 	{
 		v3 = SendMessageA(*(HWND *)(a2 + 20), 0xEu, 0, 0);
 		v4 = v3 + 1;
@@ -250,16 +250,16 @@ void __fastcall bn_prof_100018CE(int a1, int a2) { return; }
 		{
 			v5 = (char *)SMemAlloc(v3 + 1, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 362, 0);
 			SendMessageA(*(HWND *)(v2 + 20), 0xDu, v4, (LPARAM)v5);
-			bn_prof_10001938(*(HDC *)(v2 + 24), (_DWORD *)(v2 + 28), v5, 0, 0);
+			bn_prof_10001938(*(HDC *)(v2 + 24), (DWORD *)(v2 + 28), v5, 0, 0);
 			SMemFree(v5, "C:\\Src\\Diablo\\DiabloUI\\bn_prof.cpp", 367, 0);
 		}
 	}
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10001938
-int __fastcall bn_prof_10001938(HDC a1, _DWORD *a2, char *a3, int a4, int a5) { return 0; }
+int __fastcall bn_prof_10001938(HDC a1, DWORD *a2, char *a3, int a4, int a5) { return 0; }
 /* {
 	int result; // eax
 	char *v6; // edi
@@ -268,11 +268,11 @@ int __fastcall bn_prof_10001938(HDC a1, _DWORD *a2, char *a3, int a4, int a5) { 
 	char v9; // bl
 	char *v10; // eax
 	RECT rc; // [esp+Ch] [ebp-14h]
-	_DWORD *v12; // [esp+1Ch] [ebp-4h]
+	DWORD *v12; // [esp+1Ch] [ebp-4h]
 	char *v13; // [esp+28h] [ebp+8h]
 
 	result = (int)bn_prof_10002410(a1, a2);
-	v12 = (_DWORD *)result;
+	v12 = (DWORD *)result;
 	if ( result )
 	{
 		v6 = a3;
@@ -304,7 +304,7 @@ int __fastcall bn_prof_10001938(HDC a1, _DWORD *a2, char *a3, int a4, int a5) { 
 				if ( a4 && PtInRect(&rc, *(POINT *)a4) )
 				{
 					if ( a5 )
-						*(_DWORD *)a5 = v8;
+						*(DWORD *)a5 = v8;
 					return 1;
 				}
 				if ( !v6 )
@@ -372,8 +372,8 @@ int __fastcall bn_prof_10001A10(HWND a1, HWND a2) { return 0; }
 	}
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10001B0A
 HINSTANCE __fastcall bn_prof_10001B0A(HWND a1, const CHAR *a2) { return 0; }
@@ -420,7 +420,7 @@ HINSTANCE __fastcall bn_prof_10001B0A(HWND a1, const CHAR *a2) { return 0; }
 	}
 	return result;
 } */
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x10001C0E
 HWND UNKCALL bn_prof_10001C0E(HWND hWnd) { return 0; }
@@ -440,9 +440,9 @@ HWND UNKCALL bn_prof_10001C0E(HWND hWnd) { return 0; }
 	v3 = GetDlgItem(v1, 1126);
 	SendMessageA(v3, 0xCu, 0, v2);
 	bn_prof_10001CB9(
-		(_DWORD *)dword_1002941C,
+		(DWORD *)dword_1002941C,
 		dword_10029418,
-		(void (__fastcall *)(_BYTE *, _DWORD, int))bn_prof_10001ED0,
+		(void (__fastcall *)(BYTE *, DWORD, int))bn_prof_10001ED0,
 		0);
 	bn_prof_10001E34(v1);
 	if ( dword_10029430 )
@@ -461,13 +461,13 @@ HWND UNKCALL bn_prof_10001C0E(HWND hWnd) { return 0; }
 } */
 // 10029418: using guessed type int dword_10029418;
 // 1002941C: using guessed type int dword_1002941C;
-// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029430: using guessed type int (__stdcall *dword_10029430)(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10001CB9
-void __fastcall bn_prof_10001CB9(_DWORD *a1, int a2, void (__fastcall *a3)(_BYTE *, _DWORD, int), int a4) { return; }
+void __fastcall bn_prof_10001CB9(DWORD *a1, int a2, void (__fastcall *a3)(BYTE *, DWORD, int), int a4) { return; }
 /* {
-	_BYTE *v4; // eax
-	_DWORD *v5; // esi
+	BYTE *v4; // eax
+	DWORD *v5; // esi
 	int v6; // edi
 
 	if ( a1 )
@@ -476,18 +476,18 @@ void __fastcall bn_prof_10001CB9(_DWORD *a1, int a2, void (__fastcall *a3)(_BYTE
 		{
 			if ( a3 )
 			{
-				v4 = (_BYTE *)*a1;
-				if ( *(_BYTE *)*a1 )
+				v4 = (BYTE *)*a1;
+				if ( *(BYTE *)*a1 )
 				{
 					v5 = a1;
-					v6 = a2 - (_DWORD)a1;
+					v6 = a2 - (DWORD)a1;
 					do
 					{
-						a3(v4, *(_DWORD *)((char *)v5 + v6), a4);
+						a3(v4, *(DWORD *)((char *)v5 + v6), a4);
 						++v5;
-						v4 = (_BYTE *)*v5;
+						v4 = (BYTE *)*v5;
 					}
-					while ( *(_BYTE *)*v5 );
+					while ( *(BYTE *)*v5 );
 				}
 			}
 		}
@@ -519,10 +519,10 @@ int UNKCALL bn_prof_10001CF3(HWND hWnd) { return 0; }
 	local_10007944(0, 0, "Button", -1, 1, (int)"ui_art\\but_xsm.pcx", &dword_10029428, &v9, 1);
 	return SDlgSetControlBitmaps(v1, &v6, 0, dword_10029428, &v9, 1, -1);
 } */
-// 10010388: using guessed type int __stdcall SDlgSetControlBitmaps(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010388: using guessed type int __stdcall SDlgSetControlBitmaps(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
 // 10029410: using guessed type int dword_10029410;
 // 10029428: using guessed type int dword_10029428;
-// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029430: using guessed type int (__stdcall *dword_10029430)(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10001D81
 HFONT __fastcall bn_prof_10001D81(HWND hWnd, int a2, int a3) { return 0; }
@@ -575,9 +575,9 @@ HFONT __fastcall bn_prof_10001D81(HWND hWnd, int a2, int a3) { return 0; }
 void UNKCALL bn_prof_10001E34(void *arg) { return; }
 /* {
 	bn_prof_10001CB9(
-		(_DWORD *)dword_1002941C,
+		(DWORD *)dword_1002941C,
 		dword_10029418,
-		(void (__fastcall *)(_BYTE *, _DWORD, int))bn_prof_10001E4C,
+		(void (__fastcall *)(BYTE *, DWORD, int))bn_prof_10001E4C,
 		(int)arg);
 } */
 // 10029418: using guessed type int dword_10029418;
@@ -627,14 +627,14 @@ void __fastcall bn_prof_10001E4C(char *a1, LPARAM lParam, HWND hDlg) { return; }
 // 1001F380: using guessed type int dword_1001F380[];
 // 1001F384: using guessed type int dword_1001F384[];
 // 10022258: using guessed type int dword_10022258;
-// 10029430: using guessed type int (__stdcall *dword_10029430)(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10029430: using guessed type int (__stdcall *dword_10029430)(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10001ED0
-void __fastcall bn_prof_10001ED0(char *a1, _BYTE *a2, int a3) { return; }
+void __fastcall bn_prof_10001ED0(char *a1, BYTE *a2, int a3) { return; }
 /* {
 	int v3; // esi
 	bool v4; // zf
-	_BYTE *v5; // edi
+	BYTE *v5; // edi
 	char *v6; // ebp
 	const char **v7; // ebx
 
@@ -685,7 +685,7 @@ void *bn_prof_10001F29() { return 0; }
 	dword_10029434 = 0;
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
 // 10029434: using guessed type int dword_10029434;
 
 // ref: 0x10001F84
@@ -706,7 +706,7 @@ BYTE *bn_prof_10001F84() { return 0; }
 	}
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
 // 10029410: using guessed type int dword_10029410;
 // 10029428: using guessed type int dword_10029428;
 
@@ -837,14 +837,14 @@ void __cdecl UiProfileDraw() { return; }
 	SGdiDeleteObject(v18, v20, v41);
 	return 1;
 } */
-// 1001038E: using guessed type int __fastcall SGdiDeleteObject(_DWORD, _DWORD, _DWORD);
-// 10010394: using guessed type int __stdcall SGdiExtTextOut(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
-// 1001039A: using guessed type int __stdcall SGdiGetTextExtent(_DWORD, _DWORD, _DWORD);
-// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
-// 100103A6: using guessed type int __stdcall SGdiSetPitch(_DWORD);
-// 100103AC: using guessed type int __stdcall SGdiSelectObject(_DWORD);
-// 100103B2: using guessed type int __stdcall SGdiImportFont(_DWORD, _DWORD);
-// 100103B8: using guessed type int __stdcall SBltROP3Clipped(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1001038E: using guessed type int __fastcall SGdiDeleteObject(DWORD, DWORD, DWORD);
+// 10010394: using guessed type int __stdcall SGdiExtTextOut(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
+// 1001039A: using guessed type int __stdcall SGdiGetTextExtent(DWORD, DWORD, DWORD);
+// 100103A0: using guessed type int __stdcall SStrLen(DWORD);
+// 100103A6: using guessed type int __stdcall SGdiSetPitch(DWORD);
+// 100103AC: using guessed type int __stdcall SGdiSelectObject(DWORD);
+// 100103B2: using guessed type int __stdcall SGdiImportFont(DWORD, DWORD);
+// 100103B8: using guessed type int __stdcall SBltROP3Clipped(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002940C: using guessed type int dword_1002940C;
 // 10029414: using guessed type int dword_10029414;
 // 1002942C: using guessed type int dword_1002942C;
@@ -867,8 +867,8 @@ int bn_prof_100021C4() { return 0; }
 	dword_10029414 = v2;
 	return SBmpLoadImage("ui_Art\\profilebkg.pcx", 0, dword_1002942C, v0, &v3, &v2, 0);
 } */
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 100103BE: using guessed type int __stdcall SBmpLoadImage(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
+// 100103BE: using guessed type int __stdcall SBmpLoadImage(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002940C: using guessed type int dword_1002940C;
 // 10029414: using guessed type int dword_10029414;
 // 1002942C: using guessed type int dword_1002942C;
@@ -888,7 +888,7 @@ void *bn_prof_10002247() { return 0; }
 	}
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
 // 1002940C: using guessed type int dword_1002940C;
 // 10029414: using guessed type int dword_10029414;
 // 1002942C: using guessed type int dword_1002942C;
@@ -901,10 +901,10 @@ int j_bn_prof_10002282() { return 0; }
 } */
 
 // ref: 0x10002282
-_DWORD *bn_prof_10002282() { return 0; }
+DWORD *bn_prof_10002282() { return 0; }
 /* {
-	_DWORD *result; // eax
-	_DWORD *v1; // edx
+	DWORD *result; // eax
+	DWORD *v1; // edx
 
 	result = dword_10029460;
 	v1 = &dword_10029460[1];
@@ -1011,21 +1011,21 @@ HGDIOBJ bn_prof_100023D8() { return 0; }
 		v1 = dword_10029460[2];
 		if ( v1 <= 0 )
 			break;
-		bn_prof_100027D8((_DWORD *)dword_10029460[2]);
+		bn_prof_100027D8((DWORD *)dword_10029460[2]);
 		result = (HGDIOBJ)SMemFree(v1, ".?AU_DRAWTEXT@@", -2, 0);
 	}
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10002410
-_DWORD *__fastcall bn_prof_10002410(HDC hdc, _DWORD *a2) { return 0; }
+DWORD *__fastcall bn_prof_10002410(HDC hdc, DWORD *a2) { return 0; }
 /* {
 	HDC v2; // ebp
-	_DWORD *v3; // esi
-	_DWORD *v4; // eax
-	_DWORD *v5; // ebx
-	_DWORD *v6; // esi
+	DWORD *v3; // esi
+	DWORD *v4; // eax
+	DWORD *v5; // ebx
+	DWORD *v6; // esi
 
 	v2 = hdc;
 	v3 = a2;
@@ -1047,7 +1047,7 @@ _DWORD *__fastcall bn_prof_10002410(HDC hdc, _DWORD *a2) { return 0; }
 } */
 
 // ref: 0x10002456
-signed int __fastcall bn_prof_10002456(int a1, const CHAR *a2, char a3, _DWORD *a4) { return 0; }
+signed int __fastcall bn_prof_10002456(int a1, const CHAR *a2, char a3, DWORD *a4) { return 0; }
 /* {
 	int v4; // esi
 	HGDIOBJ v6; // edi
@@ -1101,18 +1101,18 @@ signed int __fastcall bn_prof_10002456(int a1, const CHAR *a2, char a3, _DWORD *
 		h = SelectObject(*(HDC *)(v4 + 8), v6);
 	if ( a4 )
 	{
-		*a4 = *(_DWORD *)(v4 + 28);
-		a4[1] = *(_DWORD *)(v4 + 32);
+		*a4 = *(DWORD *)(v4 + 28);
+		a4[1] = *(DWORD *)(v4 + 32);
 	}
 	do
 	{
-		while ( cchString > 0 && *(_WORD *)lpszString == 2573 )
+		while ( cchString > 0 && *(WORD *)lpszString == 2573 )
 		{
-			v8 = *(_DWORD *)(v4 + 92);
+			v8 = *(DWORD *)(v4 + 92);
 			cchString -= 2;
-			*(_DWORD *)(v4 + 32) += v8;
+			*(DWORD *)(v4 + 32) += v8;
 			lpszString += 2;
-			*(_DWORD *)(v4 + 28) = 0;
+			*(DWORD *)(v4 + 28) = 0;
 		}
 		if ( !cchString )
 			break;
@@ -1121,7 +1121,7 @@ signed int __fastcall bn_prof_10002456(int a1, const CHAR *a2, char a3, _DWORD *
 			*(HDC *)(v4 + 8),
 			lpszString,
 			cchString,
-			*(_DWORD *)(v4 + 20) - *(_DWORD *)(v4 + 28) - *(_DWORD *)(v4 + 12) - v29 + 1,
+			*(DWORD *)(v4 + 20) - *(DWORD *)(v4 + 28) - *(DWORD *)(v4 + 12) - v29 + 1,
 			&nFit,
 			0,
 			&Size);
@@ -1146,7 +1146,7 @@ LABEL_26:
 						goto LABEL_27;
 					}
 				}
-				if ( *(_DWORD *)(v4 + 28) > 0 )
+				if ( *(DWORD *)(v4 + 28) > 0 )
 				{
 					if ( isspace(lpszString[v9]) )
 						goto LABEL_26;
@@ -1157,7 +1157,7 @@ LABEL_27:
 			v11 = 0;
 			if ( nFit > 0 )
 			{
-				while ( *(_WORD *)&lpszString[v11] != 2573 && lpszString[v11] != 9 )
+				while ( *(WORD *)&lpszString[v11] != 2573 && lpszString[v11] != 9 )
 				{
 					if ( ++v11 >= nFit )
 						goto LABEL_34;
@@ -1167,7 +1167,7 @@ LABEL_27:
 LABEL_34:
 			if ( a4 )
 			{
-				v12 = *(_DWORD *)(v4 + 28);
+				v12 = *(DWORD *)(v4 + 28);
 				if ( v12 < *a4 )
 					*a4 = v12;
 			}
@@ -1175,8 +1175,8 @@ LABEL_34:
 			{
 				ExtTextOutA(
 					*(HDC *)(v4 + 8),
-					*(_DWORD *)(v4 + 28),
-					*(_DWORD *)(v4 + 32),
+					*(DWORD *)(v4 + 28),
+					*(DWORD *)(v4 + 32),
 					4u,
 					(const RECT *)(v4 + 12),
 					lpszString,
@@ -1188,47 +1188,47 @@ LABEL_34:
 			v14 = Size.cx;
 			if ( a4 )
 			{
-				v15 = Size.cx + *(_DWORD *)(v4 + 28);
+				v15 = Size.cx + *(DWORD *)(v4 + 28);
 				if ( v15 > a4[2] )
 					a4[2] = v15;
-				v16 = Size.cy + *(_DWORD *)(v4 + 32);
+				v16 = Size.cy + *(DWORD *)(v4 + 32);
 				if ( v16 > a4[3] )
 					a4[3] = v16;
 			}
 			v17 = nFit;
-			*(_DWORD *)(v4 + 28) += v14;
-			v18 = *(_DWORD *)(v4 + 28);
+			*(DWORD *)(v4 + 28) += v14;
+			v18 = *(DWORD *)(v4 + 28);
 			if ( v17 < cchString )
 			{
 				v19 = &v13[v17];
 				if ( *v19 == 9 )
 				{
 					++nFit;
-					*(_DWORD *)(v4 + 28) = 8 * v29 + v18 - v18 % (8 * v29);
+					*(DWORD *)(v4 + 28) = 8 * v29 + v18 - v18 % (8 * v29);
 				}
 				else
 				{
-					if ( *(_WORD *)v19 == 2573 )
+					if ( *(WORD *)v19 == 2573 )
 						nFit += 2;
-					v20 = *(_DWORD *)(v4 + 92);
-					*(_DWORD *)(v4 + 28) = 0;
-					*(_DWORD *)(v4 + 32) += v20;
+					v20 = *(DWORD *)(v4 + 92);
+					*(DWORD *)(v4 + 28) = 0;
+					*(DWORD *)(v4 + 32) += v20;
 				}
 			}
 			cchString -= nFit;
 			lpszString += nFit;
 			continue;
 		}
-		v10 = *(_DWORD *)(v4 + 92);
-		*(_DWORD *)(v4 + 28) &= nFit;
-		*(_DWORD *)(v4 + 32) += v10;
+		v10 = *(DWORD *)(v4 + 92);
+		*(DWORD *)(v4 + 28) &= nFit;
+		*(DWORD *)(v4 + 32) += v10;
 	}
 	while ( cchString > 0 );
-	if ( *(_DWORD *)(v4 + 28) > *(_DWORD *)(v4 + 20) - *(_DWORD *)(v4 + 12) - v29 + 1 )
+	if ( *(DWORD *)(v4 + 28) > *(DWORD *)(v4 + 20) - *(DWORD *)(v4 + 12) - v29 + 1 )
 	{
-		v21 = *(_DWORD *)(v4 + 92);
-		*(_DWORD *)(v4 + 28) = 0;
-		*(_DWORD *)(v4 + 32) += v21;
+		v21 = *(DWORD *)(v4 + 92);
+		*(DWORD *)(v4 + 28) = 0;
+		*(DWORD *)(v4 + 32) += v21;
 	}
 	if ( h )
 		SelectObject(*(HDC *)(v4 + 8), h);
@@ -1250,7 +1250,7 @@ signed int bn_prof_100026B9() { return 0; }
 // 10029454: using guessed type int dword_10029454;
 
 // ref: 0x100026C4
-signed int UNKCALL bn_prof_100026C4(_DWORD *arg) { return 0; }
+signed int UNKCALL bn_prof_100026C4(DWORD *arg) { return 0; }
 /* {
 	if ( !arg )
 		return 0;
@@ -1259,9 +1259,9 @@ signed int UNKCALL bn_prof_100026C4(_DWORD *arg) { return 0; }
 } */
 
 // ref: 0x100026F0
-void UNKCALL bn_prof_100026F0(_DWORD *arg) { return; }
+void UNKCALL bn_prof_100026F0(DWORD *arg) { return; }
 /* {
-	_DWORD *v1; // esi
+	DWORD *v1; // esi
 
 	v1 = arg;
 	bn_prof_1000287D(arg);
@@ -1269,7 +1269,7 @@ void UNKCALL bn_prof_100026F0(_DWORD *arg) { return; }
 } */
 
 // ref: 0x10002749
-int UNKCALL bn_prof_10002749(char *arg, _DWORD *a2) { return 0; }
+int UNKCALL bn_prof_10002749(char *arg, DWORD *a2) { return 0; }
 /* {
 	int v2; // eax
 	int v3; // eax
@@ -1278,7 +1278,7 @@ int UNKCALL bn_prof_10002749(char *arg, _DWORD *a2) { return 0; }
 	v2 = (int)a2;
 	if ( !a2 )
 		v2 = (int)(arg + 4);
-	v3 = *(_DWORD *)(v2 + 4);
+	v3 = *(DWORD *)(v2 + 4);
 	if ( v3 > 0 )
 		v4 = v3;
 	else
@@ -1287,20 +1287,20 @@ int UNKCALL bn_prof_10002749(char *arg, _DWORD *a2) { return 0; }
 	SMemFree(a2, ".?AU_DRAWTEXT@@", -2, 0);
 	return v4;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10002782
-_DWORD *UNKCALL bn_prof_10002782(int *arg, int a2, int a3, int a4) { return 0; }
+DWORD *UNKCALL bn_prof_10002782(int *arg, int a2, int a3, int a4) { return 0; }
 /* {
 	int v4; // eax
 	int *v5; // edi
-	_DWORD *v6; // eax
-	_DWORD *v7; // esi
+	DWORD *v6; // eax
+	DWORD *v7; // esi
 
 	v4 = a4;
 	LOBYTE(v4) = a4 | 8;
 	v5 = arg;
-	v6 = (_DWORD *)SMemAlloc(a3 + 96, ".?AU_DRAWTEXT@@", -2, v4);
+	v6 = (DWORD *)SMemAlloc(a3 + 96, ".?AU_DRAWTEXT@@", -2, v4);
 	if ( v6 )
 		v7 = bn_prof_100027CE(v6);
 	else
@@ -1309,12 +1309,12 @@ _DWORD *UNKCALL bn_prof_10002782(int *arg, int a2, int a3, int a4) { return 0; }
 		bn_prof_1000280C(v5, v7, a2, 0);
 	return v7;
 } */
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x100027CE
-_DWORD *UNKCALL bn_prof_100027CE(_DWORD *arg) { return 0; }
+DWORD *UNKCALL bn_prof_100027CE(DWORD *arg) { return 0; }
 /* {
-	_DWORD *result; // eax
+	DWORD *result; // eax
 
 	result = arg;
 	*arg = 0;
@@ -1323,9 +1323,9 @@ _DWORD *UNKCALL bn_prof_100027CE(_DWORD *arg) { return 0; }
 } */
 
 // ref: 0x100027D8
-void UNKCALL bn_prof_100027D8(_DWORD *arg) { return; }
+void UNKCALL bn_prof_100027D8(DWORD *arg) { return; }
 /* {
-	_DWORD *v1; // ST00_4
+	DWORD *v1; // ST00_4
 
 	v1 = arg;
 	bn_prof_10002890(arg);
@@ -1333,11 +1333,11 @@ void UNKCALL bn_prof_100027D8(_DWORD *arg) { return; }
 } */
 
 // ref: 0x1000280C
-_DWORD *UNKCALL bn_prof_1000280C(int *arg, _DWORD *a2, int a3, _DWORD *a4) { return 0; }
+DWORD *UNKCALL bn_prof_1000280C(int *arg, DWORD *a2, int a3, DWORD *a4) { return 0; }
 /* {
 	int *v4; // edi
-	_DWORD *v5; // esi
-	_DWORD *result; // eax
+	DWORD *v5; // esi
+	DWORD *result; // eax
 	int v7; // ecx
 	int v8; // edx
 	int v9; // ecx
@@ -1361,37 +1361,37 @@ _DWORD *UNKCALL bn_prof_1000280C(int *arg, _DWORD *a2, int a3, _DWORD *a4) { ret
 		if ( v8 > 0 )
 		{
 			if ( v9 < 0 )
-				v9 = (int)result - *(_DWORD *)(*result + 4);
+				v9 = (int)result - *(DWORD *)(*result + 4);
 			v10 = v9 + v8;
 		}
 		else
 		{
 			v10 = ~v8;
 		}
-		*(_DWORD *)v10 = v5;
+		*(DWORD *)v10 = v5;
 		result[1] = a2;
 	}
 	else if ( a3 == 2 )
 	{
 		v7 = *result;
 		*v5 = *result;
-		v5[1] = *(_DWORD *)(v7 + 4);
-		*(_DWORD *)(v7 + 4) = a2;
+		v5[1] = *(DWORD *)(v7 + 4);
+		*(DWORD *)(v7 + 4) = a2;
 		*result = v5;
 	}
 	return result;
 } */
 
 // ref: 0x1000287D
-void UNKCALL bn_prof_1000287D(_DWORD *arg) { return; }
+void UNKCALL bn_prof_1000287D(DWORD *arg) { return; }
 /* {
-	_DWORD *v1; // esi
-	_DWORD *v2; // ecx
+	DWORD *v1; // esi
+	DWORD *v2; // ecx
 
 	v1 = arg;
 	while ( 1 )
 	{
-		v2 = (_DWORD *)v1[2];
+		v2 = (DWORD *)v1[2];
 		if ( (signed int)v2 <= 0 )
 			break;
 		bn_prof_10002890(v2);
@@ -1399,7 +1399,7 @@ void UNKCALL bn_prof_1000287D(_DWORD *arg) { return; }
 } */
 
 // ref: 0x10002890
-void UNKCALL bn_prof_10002890(_DWORD *arg) { return; }
+void UNKCALL bn_prof_10002890(DWORD *arg) { return; }
 /* {
 	int v1; // esi
 	int v2; // edx
@@ -1410,11 +1410,11 @@ void UNKCALL bn_prof_10002890(_DWORD *arg) { return; }
 	{
 		v2 = arg[1];
 		if ( v2 > 0 )
-			v3 = (int)arg + v2 - *(_DWORD *)(v1 + 4);
+			v3 = (int)arg + v2 - *(DWORD *)(v1 + 4);
 		else
 			v3 = ~v2;
-		*(_DWORD *)v3 = v1;
-		*(_DWORD *)(*arg + 4) = arg[1];
+		*(DWORD *)v3 = v1;
+		*(DWORD *)(*arg + 4) = arg[1];
 		*arg = 0;
 		arg[1] = 0;
 	}

--- a/DiabloUI/bnetgw.cpp
+++ b/DiabloUI/bnetgw.cpp
@@ -1,7 +1,7 @@
 // ref: 0x100028C2
-void UNKCALL BNetGW_100028C2(_DWORD *arg) { return; }
+void UNKCALL BNetGW_100028C2(DWORD *arg) { return; }
 /* {
-	_DWORD *v1; // esi
+	DWORD *v1; // esi
 	bool v2; // zf
 	bool v3; // sf
 	int v4; // edi
@@ -21,7 +21,7 @@ void UNKCALL BNetGW_100028C2(_DWORD *arg) { return; }
 	arg[4] = 0;
 	arg[5] = 0;
 	arg[6] = 0;
-	*(_BYTE *)arg = 0;
+	*(BYTE *)arg = 0;
 	BNetGW_10002C23(arg);
 	if ( !v1[4] )
 		goto LABEL_15;
@@ -72,14 +72,14 @@ LABEL_15:
 		v1[3] = 0;
 	}
 } */
-// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
-// 100103C4: using guessed type int __stdcall SMemZero(_DWORD, _DWORD);
+// 100103A0: using guessed type int __stdcall SStrLen(DWORD);
+// 100103C4: using guessed type int __stdcall SMemZero(DWORD, DWORD);
 // 100103CA: using guessed type int __stdcall SRegDeleteValue(const char *, const char *, unsigned int);
 
 // ref: 0x100029BF
-void UNKCALL BNetGW_100029BF(_DWORD *arg, int a2) { return; }
+void UNKCALL BNetGW_100029BF(DWORD *arg, int a2) { return; }
 /* {
-	_DWORD *v2; // esi
+	DWORD *v2; // esi
 	char *v3; // edi
 	signed int v4; // ebx
 	signed int v5; // ebp
@@ -109,11 +109,11 @@ void UNKCALL BNetGW_100029BF(_DWORD *arg, int a2) { return; }
 } */
 
 // ref: 0x10002A07
-void *UNKCALL BNetGW_10002A07(_DWORD *arg) { return 0; }
+void *UNKCALL BNetGW_10002A07(DWORD *arg) { return 0; }
 /* {
-	_DWORD *v1; // esi
+	DWORD *v1; // esi
 	int v2; // edi
-	_BYTE *v3; // ecx
+	BYTE *v3; // ecx
 	const char *v4; // eax
 	int result; // eax
 
@@ -123,7 +123,7 @@ void *UNKCALL BNetGW_10002A07(_DWORD *arg) { return 0; }
 		v2 = arg[4];
 		if ( v2 )
 		{
-			v3 = (_BYTE *)(v2 + SStrLen(arg[4]) + 1);
+			v3 = (BYTE *)(v2 + SStrLen(arg[4]) + 1);
 			*v3 = v1[3] / 10 + 48;
 			v4 = "Override Battle.net gateways";
 			v3[1] = v1[3] % 10 + 48;
@@ -141,12 +141,12 @@ void *UNKCALL BNetGW_10002A07(_DWORD *arg) { return 0; }
 	}
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
-// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
+// 100103A0: using guessed type int __stdcall SStrLen(DWORD);
 // 100103D0: using guessed type int __stdcall SRegSaveData(const char *, const char *, unsigned int, void *, unsigned int);
 
 // ref: 0x10002A84
-_DWORD *UNKCALL BNetGW_10002A84(_DWORD *arg, signed int a2) { return 0; }
+DWORD *UNKCALL BNetGW_10002A84(DWORD *arg, signed int a2) { return 0; }
 /* {
 	signed int v2; // eax
 	signed int v3; // ebx
@@ -155,9 +155,9 @@ _DWORD *UNKCALL BNetGW_10002A84(_DWORD *arg, signed int a2) { return 0; }
 	bool v6; // sf
 	unsigned char v7; // of
 	int v8; // eax
-	_DWORD *result; // eax
-	_DWORD *v10; // [esp+8h] [ebp-4h]
-	_DWORD *v11; // [esp+14h] [ebp+8h]
+	DWORD *result; // eax
+	DWORD *v10; // [esp+8h] [ebp-4h]
+	DWORD *v11; // [esp+14h] [ebp+8h]
 
 	v10 = arg;
 	if ( !arg[4] )
@@ -168,7 +168,7 @@ _DWORD *UNKCALL BNetGW_10002A84(_DWORD *arg, signed int a2) { return 0; }
 		return arg;
 	v4 = 3 * a2;
 	v5 = 0;
-	v11 = (_DWORD *)arg[4];
+	v11 = (DWORD *)arg[4];
 	if ( 3 * v2 <= 1 )
 	{
 LABEL_7:
@@ -185,7 +185,7 @@ LABEL_7:
 				break;
 			v8 = SStrLen(v11);
 			arg = v10;
-			v11 = (_DWORD *)((char *)v11 + ++v8);
+			v11 = (DWORD *)((char *)v11 + ++v8);
 			v5 += v8;
 			if ( ++v3 >= v4 )
 				goto LABEL_7;
@@ -198,7 +198,7 @@ LABEL_7:
 		return arg;
 	return result;
 } */
-// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+// 100103A0: using guessed type int __stdcall SStrLen(DWORD);
 
 // ref: 0x10002AE5
 signed int BNetGW_10002AE5() { return 0; }
@@ -212,7 +212,7 @@ signed int BNetGW_10002AE5() { return 0; }
 // 10029478: using guessed type int dword_10029478;
 
 // ref: 0x10002AF0
-int UNKCALL BNetGW_10002AF0(_DWORD *arg, char *a2) { return 0; }
+int UNKCALL BNetGW_10002AF0(DWORD *arg, char *a2) { return 0; }
 /* {
 	const char *v2; // eax
 	const char *v3; // esi
@@ -223,17 +223,17 @@ int UNKCALL BNetGW_10002AF0(_DWORD *arg, char *a2) { return 0; }
 		v3 = &v2[SStrLen(v2) + 1];
 	return strtol(v3, &a2, 10);
 } */
-// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+// 100103A0: using guessed type int __stdcall SStrLen(DWORD);
 
 // ref: 0x10002B21
-_BYTE *UNKCALL BNetGW_10002B21(_DWORD *arg, signed int a2) { return 0; }
+BYTE *UNKCALL BNetGW_10002B21(DWORD *arg, signed int a2) { return 0; }
 /* {
-	_DWORD *v2; // eax
-	_BYTE *v3; // esi
+	DWORD *v2; // eax
+	BYTE *v3; // esi
 
 	v2 = BNetGW_10002A84(arg, a2);
 	v3 = v2;
-	if ( *(_BYTE *)v2 )
+	if ( *(BYTE *)v2 )
 	{
 		v3 = (char *)v2 + SStrLen(v2) + 1;
 		if ( *v3 )
@@ -241,10 +241,10 @@ _BYTE *UNKCALL BNetGW_10002B21(_DWORD *arg, signed int a2) { return 0; }
 	}
 	return v3;
 } */
-// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+// 100103A0: using guessed type int __stdcall SStrLen(DWORD);
 
 // ref: 0x10002B51
-void UNKCALL BNetGW_10002B51(_DWORD *arg, signed int a2) { return; }
+void UNKCALL BNetGW_10002B51(DWORD *arg, signed int a2) { return; }
 /* {
 	signed int v2; // eax
 
@@ -262,9 +262,9 @@ void UNKCALL BNetGW_10002B51(_DWORD *arg, signed int a2) { return; }
 } */
 
 // ref: 0x10002B78
-char *UNKCALL BNetGW_10002B78(_DWORD *arg, char *a2) { return 0; }
+char *UNKCALL BNetGW_10002B78(DWORD *arg, char *a2) { return 0; }
 /* {
-	_DWORD *v2; // esi
+	DWORD *v2; // esi
 	char *result; // eax
 	char *v4; // ST08_4
 	void *v5; // eax
@@ -302,14 +302,14 @@ char *UNKCALL BNetGW_10002B78(_DWORD *arg, char *a2) { return 0; }
 	}
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
 // 100103D6: using guessed type int __stdcall SRegLoadData(const char *, const char *, unsigned int, void *, unsigned int, unsigned int *);
 
 // ref: 0x10002C23
-char *UNKCALL BNetGW_10002C23(_DWORD *arg) { return 0; }
+char *UNKCALL BNetGW_10002C23(DWORD *arg) { return 0; }
 /* {
-	_DWORD *v1; // esi
+	DWORD *v1; // esi
 	char *result; // eax
 
 	v1 = arg;
@@ -322,24 +322,24 @@ char *UNKCALL BNetGW_10002C23(_DWORD *arg) { return 0; }
 } */
 
 // ref: 0x10002C51
-int UNKCALL BNetGW_10002C51(_DWORD *arg) { return 0; }
+int UNKCALL BNetGW_10002C51(DWORD *arg) { return 0; }
 /* {
 	int result; // eax
 	char *v2; // edi
 	char *v3; // esi
 	unsigned int v4; // ebx
 	char *v5; // esi
-	_BYTE *v6; // esi
+	BYTE *v6; // esi
 	char *v7; // eax
 	char *v8; // eax
-	_BYTE *v9; // esi
+	BYTE *v9; // esi
 	char *v10; // esi
 	char v11; // al
 	unsigned int v12; // esi
 	char *v13; // [esp+4h] [ebp-10h]
 	int v14; // [esp+8h] [ebp-Ch]
 	int v15; // [esp+Ch] [ebp-8h]
-	_DWORD *v16; // [esp+10h] [ebp-4h]
+	DWORD *v16; // [esp+10h] [ebp-4h]
 
 	v15 = 0;
 	v16 = arg;
@@ -426,20 +426,20 @@ LABEL_8:
 		SMemFree(v14, "C:\\Src\\Diablo\\DiabloUI\\BNetGW.cpp", 429, 0);
 		result = (int)v16;
 		v16[5] = v12;
-		*(_DWORD *)(result + 16) = v13;
-		*(_DWORD *)(result + 24) = 1000;
+		*(DWORD *)(result + 16) = v13;
+		*(DWORD *)(result + 24) = 1000;
 	}
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 100103A0: using guessed type int __stdcall SStrLen(_DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
+// 100103A0: using guessed type int __stdcall SStrLen(DWORD);
 // 100103D0: using guessed type int __stdcall SRegSaveData(const char *, const char *, unsigned int, void *, unsigned int);
 
 // ref: 0x10002DBF
-int UNKCALL BNetGW_10002DBF(_DWORD *arg) { return 0; }
+int UNKCALL BNetGW_10002DBF(DWORD *arg) { return 0; }
 /* {
-	_DWORD *v1; // esi
+	DWORD *v1; // esi
 	int v3; // [esp+4h] [ebp-8h]
 	int v4; // [esp+8h] [ebp-4h]
 
@@ -449,7 +449,7 @@ int UNKCALL BNetGW_10002DBF(_DWORD *arg) { return 0; }
 	*v1 = v4;
 	return v3;
 } */
-// 100103DC: using guessed type int __stdcall SFileLoadFile(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100103DC: using guessed type int __stdcall SFileLoadFile(DWORD, DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10002DEB
 char *__stdcall BNetGW_10002DEB(char *a1, unsigned int a2) { return 0; }

--- a/DiabloUI/connect.cpp
+++ b/DiabloUI/connect.cpp
@@ -79,7 +79,7 @@ BOOL __stdcall UiArtCallback(int game_type, unsigned int art_code, PALETTEENTRY 
 
 	pszFileName[0] = nullcharacter;
 	memset(&pszFileName[1], 0, 0x100u);
-	*(_WORD *)&pszFileName[257] = 0;
+	*(WORD *)&pszFileName[257] = 0;
 	pszFileName[259]            = 0;
 	SStrCopy(pszFileName, "ui_art\\", sizeof(pszFileName));
 	if (game_type == 'BNET') {
@@ -285,7 +285,7 @@ void __cdecl Connect_cpp_init()
 BOOL __stdcall UiGetDataCallback(int game_type, int data_code, void *a3, int a4, int a5)
 {
 	signed int v5; // edi
-	_DWORD *v6;    // esi
+	DWORD *v6;    // esi
 	HCURSOR v7;    // eax
 
 	v5 = 0;
@@ -301,7 +301,7 @@ BOOL __stdcall UiGetDataCallback(int game_type, int data_code, void *a3, int a4,
 			}
 			return 0;
 		case 2:
-			v6 = (unsigned int *)a3;
+			v6 = (DWORD *)a3;
 			v5 = 4;
 			if (!a3)
 				goto LABEL_24;
@@ -310,7 +310,7 @@ BOOL __stdcall UiGetDataCallback(int game_type, int data_code, void *a3, int a4,
 			v7 = LoadCursorA(ghUiInst, "DIABLO_LINKCURSOR");
 			break;
 		case 3:
-			v6 = (unsigned int *)a3;
+			v6 = (DWORD *)a3;
 			v5 = 4;
 			if (!a3)
 				goto LABEL_24;
@@ -319,7 +319,7 @@ BOOL __stdcall UiGetDataCallback(int game_type, int data_code, void *a3, int a4,
 			v7 = LoadCursorA(ghUiInst, "DIABLO_ARROWCURSOR");
 			break;
 		case 4:
-			v6 = (unsigned int *)a3;
+			v6 = (DWORD *)a3;
 			v5 = 4;
 			if (!a3)
 				goto LABEL_24;
@@ -330,7 +330,7 @@ BOOL __stdcall UiGetDataCallback(int game_type, int data_code, void *a3, int a4,
 		default:
 			goto LABEL_24;
 		}
-		*v6 = (unsigned int)v7;
+		*v6 = (DWORD)v7;
 		if (v7)
 			goto LABEL_24;
 		return 0;
@@ -338,14 +338,14 @@ BOOL __stdcall UiGetDataCallback(int game_type, int data_code, void *a3, int a4,
 	v5 = 4;
 	if (a3) {
 		if ((unsigned int)a4 >= 4) {
-			*(_DWORD *)a3 = 54;
+			*(DWORD *)a3 = 54;
 			goto LABEL_24;
 		}
 		return 0;
 	}
 LABEL_24:
 	if (a5)
-		*(_DWORD *)a5 = v5;
+		*(DWORD *)a5 = v5;
 	return v5 != 0;
 }
 
@@ -378,7 +378,7 @@ BOOL __stdcall UiAuthCallback(int a1, char *a2, char *a3, char a4, char *a5, LPS
 	_uiheroinfo heroinfo; // [esp+400h] [ebp-34h]
 	_gamedata GameData;   // [esp+42Ch] [ebp-8h]
 
-	*(_DWORD *)&GameData.bDiff = 0;
+	*(DWORD *)&GameData.bDiff = 0;
 	if (cchBufferMax)
 		*lpBuffer = 0;
 	v7            = strlen(a3) + 1;
@@ -403,7 +403,7 @@ BOOL __stdcall UiAuthCallback(int a1, char *a2, char *a3, char a4, char *a5, LPS
 				}
 				if (heroinfo.heroclass != v9)
 					goto LABEL_20;
-				*(_DWORD *)&GameData.bDiff = 1;
+				*(DWORD *)&GameData.bDiff = 1;
 			LABEL_16:
 				LoadStringA(ghUiInst, 0x408u, Buffer, 256);
 				v10 = strstr(v17, Buffer);
@@ -413,7 +413,7 @@ BOOL __stdcall UiAuthCallback(int a1, char *a2, char *a3, char a4, char *a5, LPS
 					if (heroinfo.level >= v12)
 						return 1;
 				}
-				if (*(_DWORD *)&GameData.bDiff)
+				if (*(DWORD *)&GameData.bDiff)
 					return 1;
 			LABEL_20:
 				if (lpBuffer) {
@@ -488,7 +488,7 @@ BOOL __stdcall UiDrawDescCallback(int arg0, COLORREF color, LPCSTR lpString, cha
 	v8        = a8;
 	memset(&Buffer[1], 0, 0x7Cu);
 	v9                     = a8[4];
-	*(_WORD *)&Buffer[125] = 0;
+	*(WORD *)&Buffer[125] = 0;
 	Buffer[127]            = 0;
 	v10                    = (unsigned char)v9 & 1;
 	v11                    = strlen(a4) + 1;
@@ -517,7 +517,7 @@ BOOL __stdcall UiDrawDescCallback(int arg0, COLORREF color, LPCSTR lpString, cha
 				v15   = strlen(Buffer);
 				TextOutA(v8[6], 0, 0, Buffer, v15);
 				LoadStringA(ghUiInst, 0x409u, String, 128);
-				MoveToEx(v8[6], (int)v8[7], (int)v8[8] + (_DWORD)lpStringa, 0);
+				MoveToEx(v8[6], (int)v8[7], (int)v8[8] + (DWORD)lpStringa, 0);
 				v16 = strlen(String);
 				TextOutA(v8[6], 0, 0, String, v16);
 				v17 = v8[6];
@@ -541,7 +541,7 @@ BOOL __stdcall UiDrawDescCallback(int arg0, COLORREF color, LPCSTR lpString, cha
 						if (!v19->tm_hour)
 							v19->tm_hour = 12;
 						sprintf(String, &heroinfo.name[8], v31, v19->tm_hour, v19->tm_min, &rc.top);
-						MoveToEx(v8[6], (int)v8[7], (int)v8[8] + 2 * (_DWORD)lpStringa, 0);
+						MoveToEx(v8[6], (int)v8[7], (int)v8[8] + 2 * (DWORD)lpStringa, 0);
 						v21 = strlen(String);
 						TextOutA(v8[6], 0, 0, String, v21);
 					}
@@ -581,7 +581,7 @@ BOOL __stdcall UiDrawDescCallback(int arg0, COLORREF color, LPCSTR lpString, cha
 			    (HWND)v8[5],
 			    0,
 			    (char *)v8[7],
-			    (int)v8[8] + (_DWORD)a4,
+			    (int)v8[8] + (DWORD)a4,
 			    connect_data3,
 			    &rc,
 			    (SIZE *)special_data,
@@ -600,16 +600,16 @@ BOOL __stdcall UiDrawDescCallback(int arg0, COLORREF color, LPCSTR lpString, cha
 		}
 		if (a5 & 8) {
 			v25          = (arg0 != 'BNET') - 1;
-			_LOBYTE(v25) = v25 & 0xFD;
+			v25 = v25 & 0xFD;
 			v24          = v25 + 4;
 			goto LABEL_46;
 		}
 	}
-	if (*(_DWORD *)a1 == 'CHAT') {
+	if (*(DWORD *)a1 == 'CHAT') {
 		v27 = 6;
 		goto LABEL_45;
 	}
-	if (*(_DWORD *)a1 == 'SEXP' || *(_DWORD *)a1 == 'SSHR' || *(_DWORD *)a1 == 'STAR') {
+	if (*(DWORD *)a1 == 'SEXP' || *(DWORD *)a1 == 'SSHR' || *(DWORD *)a1 == 'STAR') {
 		v27 = 7;
 		goto LABEL_45;
 	}
@@ -655,7 +655,7 @@ BOOL __stdcall UiDrawDescCallback(int arg0, COLORREF color, LPCSTR lpString, cha
 		    (HWND)v8[5],
 		    0,
 		    (char *)v8[7],
-		    (int)v8[8] + (_DWORD)a4,
+		    (int)v8[8] + (DWORD)a4,
 		    connect_data4,
 		    &rc,
 		    (SIZE *)heroport_data,
@@ -676,7 +676,7 @@ LABEL_55:
 // 10029614: using guessed type int connect_color_text;
 
 // ref: 0x10003CE4
-BOOL __stdcall UiCategoryCallback(int a1, int a2, int a3, int a4, int a5, _DWORD *a6, _DWORD *a7)
+BOOL __stdcall UiCategoryCallback(int a1, int a2, int a3, int a4, int a5, DWORD *a6, DWORD *a7)
 {
 	*a7 = 0xFFFF;
 	*a6 = Connect_GetRankFromLevel(connect_categorystr);
@@ -736,12 +736,12 @@ BOOL __fastcall Connect_DiffFromString(char *str, _gamedata *gamedata, int a3, i
 		*v8 = 0;
 		v9  = v8 + 1;
 		if (a3)
-			*(_DWORD *)a3 = (unsigned int)v9;
+			*(DWORD *)a3 = (DWORD)v9;
 		v10               = (char *)strchr(v9, 13);
 		if (v10) {
 			*v10 = 0;
 			if (a4)
-				*(_DWORD *)a4 = (unsigned int)v10 + 1;
+				*(DWORD *)a4 = (DWORD)v10 + 1;
 		}
 	}
 	return 1;
@@ -788,12 +788,12 @@ BOOL __fastcall Connect_GetHeroInfoConc(const char *a1, _uiheroinfo *pInfo)
 	memset(pInfo, 0, 0x2Cu);
 	if (!*a1)
 		return 0;
-	v4 = *(_DWORD *)a1;
-	if (*(_DWORD *)a1 != 'DRTL' && v4 != 'DSHR' && v4 != 'DTST')
+	v4 = *(DWORD *)a1;
+	if (*(DWORD *)a1 != 'DRTL' && v4 != 'DSHR' && v4 != 'DTST')
 		return 0;
 	if (sscanf(a1 + 4, "%d %d %d %d %d %d %d %d %d", &v13, &v12, &v11, &v18, &v17, &v16, &v15, &v10, &v14) != 9)
 		return 0;
-	v5 = *(_DWORD *)a1;
+	v5 = *(DWORD *)a1;
 	v6 = v14;
 	if (v5 == 'DRTL') {
 		if (v14)
@@ -824,7 +824,7 @@ BOOL __fastcall Connect_GetHeroInfoConc(const char *a1, _uiheroinfo *pInfo)
 // ref: 0x10003F6F
 void __fastcall Connect_MakeDescString(_uiheroinfo *a1, char *name, size_t size)
 {
-	*(_DWORD *)name = (unsigned int)connect_charname;
+	*(DWORD *)name = (DWORD)connect_charname;
 	_snprintf(
 	    name + 4,
 	    size,

--- a/DiabloUI/copyprot.cpp
+++ b/DiabloUI/copyprot.cpp
@@ -15,7 +15,7 @@ BOOL __stdcall UiCopyProtError(int *pdwResult)
 		*pdwResult = v2;
 	return 1;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x100040AF
 LRESULT __stdcall CopyProt_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
@@ -68,7 +68,7 @@ LRESULT __stdcall CopyProt_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 	}
 	return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x10004173
 void __cdecl CopyProt_FreeCopyResrcs()

--- a/DiabloUI/cr8game.cpp
+++ b/DiabloUI/cr8game.cpp
@@ -28,11 +28,11 @@ BOOL __fastcall cr8game_GetSnetCreaGame(HWND hWnd)
 	if (UiAuthCallback(2, a2, str, 0, a4, Text, 256)) {
 		v2 = cr8_somegamestruct;
 		if (cr8_somegamestruct[8] >= 8) {
-			*(_BYTE *)(cr8_somegamestruct[7] + 4) = cr8_gamedata.bDiff;
+			*(BYTE *)(cr8_somegamestruct[7] + 4) = cr8_gamedata.bDiff;
 			v2                                    = cr8_somegamestruct;
 		}
 		v3  = cr8game_playerID;
-		v4  = *(_DWORD *)(cr8_playercount + 8);
+		v4  = *(DWORD *)(cr8_playercount + 8);
 		v5  = v2[8];
 		v6  = (char *)v2[7];
 		v7  = Connect_GetRankFromLevel(str);
@@ -53,7 +53,7 @@ BOOL __fastcall cr8game_GetSnetCreaGame(HWND hWnd)
 	}
 	return result;
 }
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
 // 10029630: using guessed type int cr8_playercount;
 
 // ref: 0x100044AA
@@ -67,7 +67,7 @@ BOOL __stdcall UiCreateGameCallback(int a1, int a2, int a3, int a4, int a5, int 
 	cr8_dword_10029640 = a5;
 	cr8_dword_1002963C = a4;
 	cr8game_playerID   = (int *)a6;
-	v6                 = SDlgDialogBoxParam(ghUiInst, "DIALOG_CREATE_GAME", *(_DWORD *)(a4 + 8), cr8game_WndProc, 0);
+	v6                 = SDlgDialogBoxParam(ghUiInst, "DIALOG_CREATE_GAME", *(DWORD *)(a4 + 8), cr8game_WndProc, 0);
 	return v6 != -1 ? v6 : 0;
 }
 // 10029630: using guessed type int cr8_playercount;
@@ -169,7 +169,7 @@ LRESULT __stdcall cr8game_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 	}
 	return (LRESULT)SDlgDefDialogProc(hWnd, v4, (HDC)wParam, (HWND)lParam);
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x10004828
 void __cdecl cr8game_FreeCreaStuff()

--- a/DiabloUI/creadung.cpp
+++ b/DiabloUI/creadung.cpp
@@ -34,9 +34,9 @@ LRESULT __stdcall CreaDung_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 						Focus_CheckPlayMove(lParam);
 						Focus_DoBlitSpinIncFrame(hWnd, (HWND)lParam);
 						CreaDung_ParseDungProcs(hWnd, (unsigned short)wParam);
-					} else if (HIWORD(wParam) == 5 || (_WORD)wParam == 1) {
+					} else if (HIWORD(wParam) == 5 || (WORD)wParam == 1) {
 						CreaDung_DoAllPlaySnd(hWnd);
-					} else if ((_WORD)wParam == 2) {
+					} else if ((WORD)wParam == 2) {
 						CreaDung_PlaySndAndKill(hWnd, 2);
 					}
 					return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
@@ -58,7 +58,7 @@ LRESULT __stdcall CreaDung_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 	}
 	return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 // 100296D8: using guessed type int creadung_dword_100296D8;
 
 // ref: 0x10004D75
@@ -196,7 +196,7 @@ void __fastcall CreaDung_DoSnetCreaGame(HWND hWnd)
 		v2 = crea_somegamestruct;
 		if (crea_somegamestruct[8] >= 8) {
 			v3                 = crea_somegamestruct[7];
-			*(_BYTE *)(v3 + 4) = GetWindowLongA(v1, -12) - 70;
+			*(BYTE *)(v3 + 4) = GetWindowLongA(v1, -12) - 70;
 			v2                 = crea_somegamestruct;
 		}
 		if (SNetCreateGame(
@@ -206,7 +206,7 @@ void __fastcall CreaDung_DoSnetCreaGame(HWND hWnd)
 		        0,
 		        (char *)v2[7],
 		        v2[8],
-		        *(_DWORD *)(creadung_playername + 8),
+		        *(DWORD *)(creadung_playername + 8),
 		        a2,
 		        0,
 		        creadung_playerID)) {
@@ -223,7 +223,7 @@ void __fastcall CreaDung_DoSnetCreaGame(HWND hWnd)
 		}
 	}
 }
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
 // 100296BC: using guessed type int creadung_playername;
 // 100296D4: using guessed type int creadung_lasterror;
 
@@ -256,14 +256,14 @@ BOOL __fastcall CreaDung_SelDungDiff(int a1, int a2, int a3, int a4, int a5, int
 	crea_somegamestruct     = (DWORD *)a2;
 	creadung_gamename       = (char *)a8;
 	v8                      = SelHero_GetHeroIsGood();
-	result                  = SDlgDialogBoxParam(ghUiInst, "SELDIFF_DIALOG", *(_DWORD *)(a4 + 8), CreaDung_WndProc, v8);
+	result                  = SDlgDialogBoxParam(ghUiInst, "SELDIFF_DIALOG", *(DWORD *)(a4 + 8), CreaDung_WndProc, v8);
 	if (result != 1) {
 		SErrSetLastError(creadung_lasterror);
 		result = 0;
 	}
 	return result;
 }
-// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 1001041E: using guessed type int __stdcall SErrSetLastError(DWORD);
 // 100296BC: using guessed type int creadung_playername;
 // 100296C8: using guessed type int creadung_dword_100296C8;
 // 100296CC: using guessed type int creadung_delspinners;

--- a/DiabloUI/credits.cpp
+++ b/DiabloUI/credits.cpp
@@ -15,7 +15,7 @@ BOOL __stdcall UiCreditsDialog(int a1)
 	SDlgDialogBoxParam(ghUiInst, "CREDITS_DIALOG", v1, credits_WndProc, 25);
 	return 1;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x100052C7
 LRESULT __stdcall credits_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
@@ -37,7 +37,7 @@ LRESULT __stdcall credits_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 			}
 			return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 		}
-		if ((_WORD)wParam != 513 && (_WORD)wParam != 516)
+		if ((WORD)wParam != 513 && (WORD)wParam != 516)
 			return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 	LABEL_25:
 		Title_KillAndFadeDlg(hWnd);
@@ -70,7 +70,7 @@ LRESULT __stdcall credits_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 	credits_FreeCreditResrc(hWnd);
 	return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x100053D9
 void __fastcall credits_FreeCreditResrc(HWND hWnd)
@@ -145,12 +145,12 @@ void __fastcall credits_LoadImgCreditTxt(HWND hWnd, LPARAM lParam)
 // ref: 0x100055C0
 void __fastcall credits_CalcPosROP3(HWND hWnd)
 {
-	_DWORD *v2;          // edi
+	DWORD *v2;          // edi
 	struct tagRECT Rect; // [esp+Ch] [ebp-14h]
 	HWND hWnda;          // [esp+1Ch] [ebp-4h]
 
 	hWnda = GetDlgItem(hWnd, 1000);
-	v2    = (_DWORD *)GetWindowLongA(hWnd, -21);
+	v2    = (DWORD *)GetWindowLongA(hWnd, -21);
 	GetWindowRect(hWnda, &Rect);
 	ScreenToClient(hWnd, (LPPOINT)&Rect);
 	ScreenToClient(hWnd, (LPPOINT)&Rect.right);
@@ -204,8 +204,8 @@ void __fastcall credits_PrintCredLines(HWND hWnd)
 	if (i < 0)
 		Title_KillAndFadeDlg(hWnd);
 }
-// 100103A6: using guessed type int __stdcall SGdiSetPitch(_DWORD);
-// 100103AC: using guessed type int __stdcall SGdiSelectObject(_DWORD);
+// 100103A6: using guessed type int __stdcall SGdiSetPitch(DWORD);
+// 100103AC: using guessed type int __stdcall SGdiSelectObject(DWORD);
 // 100296E8: using guessed type int credittext_size;
 // 100296FC: using guessed type int credit_vertical_pos1;
 // 10029700: using guessed type int credit_line_count;

--- a/DiabloUI/diabedit.cpp
+++ b/DiabloUI/diabedit.cpp
@@ -105,7 +105,7 @@ void __fastcall DiabEdit_GetCursorProp(HWND hWnd)
 
 	String[0] = nullcharacter;
 	memset(&String[1], 0, 0xFCu);
-	*(_WORD *)&String[253] = 0;
+	*(WORD *)&String[253] = 0;
 	String[255]            = 0;
 	if (GetPropA(hWnd, "CURSOR")) {
 		SetPropA(hWnd, "CURSOR", 0);
@@ -139,9 +139,9 @@ void __fastcall DiabEdit_RestrictAndLimit(HWND hWnd, WPARAM wParam, LPARAM lPara
 	String[0] = nullcharacter;
 	v3        = wParam;
 	memset(&String[1], 0, 0xFCu);
-	*(_WORD *)&String[253] = 0;
+	*(WORD *)&String[253] = 0;
 	String[255]            = 0;
-	if ((_BYTE)wParam == 8)
+	if ((BYTE)wParam == 8)
 		goto LABEL_9;
 	if ((unsigned char)wParam < 0x20u || (unsigned char)wParam > 0x7Eu && (unsigned char)wParam < 0xC0u)
 		return;
@@ -185,7 +185,7 @@ void __fastcall DiabEdit_SetTextAndProp(HWND hWnd, WPARAM wParam, LPARAM lParam)
 
 	String[0] = nullcharacter;
 	memset(&String[1], 0, 0xFCu);
-	*(_WORD *)&String[253] = 0;
+	*(WORD *)&String[253] = 0;
 	String[255]            = 0;
 	v4                     = wParam;
 	GetWindowTextA(hWnd, String, 255);

--- a/DiabloUI/diabloui.h
+++ b/DiabloUI/diabloui.h
@@ -39,7 +39,7 @@ BOOL __stdcall UiProgressDialog(HWND window, char *msg, int enable, int(*fnfunc)
 int __stdcall UiProfileGetString();
 void __cdecl UiProfileCallback();
 void __cdecl UiProfileDraw();
-BOOL __stdcall UiCategoryCallback(int a1, int a2, int a3, int a4, int a5, _DWORD *a6, _DWORD *a7);
+BOOL __stdcall UiCategoryCallback(int a1, int a2, int a3, int a4, int a5, DWORD *a6, DWORD *a7);
 BOOL __stdcall UiGetDataCallback(int game_type, int data_code, void *a3, int a4, int a5);
 BOOL __stdcall UiAuthCallback(int a1, char *a2, char *a3, char a4, char *a5, LPSTR lpBuffer, int cchBufferMax);
 BOOL __stdcall UiSoundCallback(int a1, int type, int a3);

--- a/DiabloUI/dirlink.cpp
+++ b/DiabloUI/dirlink.cpp
@@ -10,7 +10,7 @@ signed int DirLink_10005CFA() { return 0; }
 // 10029730: using guessed type int dword_10029730;
 
 // ref: 0x10005D05
-BOOL __fastcall DirLink_10005D05(int a1, int a2, int a3, _DWORD *a4, int a5, int playerid) { return 0; }
+BOOL __fastcall DirLink_10005D05(int a1, int a2, int a3, DWORD *a4, int a5, int playerid) { return 0; }
 /* {
 	int v6; // esi
 
@@ -24,7 +24,7 @@ BOOL __fastcall DirLink_10005D05(int a1, int a2, int a3, _DWORD *a4, int a5, int
 	artfont_100010C8();
 	return v6 == 1;
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002983C: using guessed type int dword_1002983C;
 // 10029840: using guessed type int dword_10029840;
 // 10029844: using guessed type int gnDlinkPlayerid;
@@ -75,7 +75,7 @@ int __stdcall DirLink_10005D63(HWND hWnd, UINT Msg, WPARAM wParam, unsigned int 
 		{
 			DirLink_100060D1(hWnd);
 		}
-		else if ( (_WORD)wParam == 2 )
+		else if ( (WORD)wParam == 2 )
 		{
 			DirLink_10006047((int)hWnd, 2);
 		}
@@ -100,8 +100,8 @@ int __stdcall DirLink_10005D63(HWND hWnd, UINT Msg, WPARAM wParam, unsigned int 
 	DirLink_10005F7B(hWnd);
 	return 0;
 } */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x10005EB2
 int __fastcall DirLink_10005EB2(HWND hDlg, int a2) { return 0; }
@@ -128,7 +128,7 @@ int __fastcall DirLink_10005EB2(HWND hDlg, int a2) { return 0; }
 int UNKCALL DirLink_10005F1F(HWND hDlg) { return 0; }
 /* {
 	HWND v1; // esi
-	_DWORD *v2; // eax
+	DWORD *v2; // eax
 
 	v1 = hDlg;
 	Doom_10006C53(hDlg, (int *)&unk_10022A54);
@@ -136,7 +136,7 @@ int UNKCALL DirLink_10005F1F(HWND hDlg) { return 0; }
 	Doom_10006C53(v1, (int *)&unk_10022A40);
 	Doom_10006C53(v1, (int *)&unk_10022A38);
 	Doom_10006C53(v1, (int *)&unk_10022A2C);
-	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	v2 = (DWORD *)GetWindowLongA(v1, -21);
 	local_10007F72(v2);
 	Title_100100E7(v1);
 	return Focus_10007818(v1);
@@ -175,7 +175,7 @@ int UNKCALL DirLink_10005F7B(HWND hWnd) { return 0; }
 	DirLink_10006073(v1);
 	return SDlgSetTimer(v1, 3, 2000, 0);
 } */
-// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010412: using guessed type int __stdcall SDlgSetTimer(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10006047
 int __fastcall DirLink_10006047(int a1, int a2) { return 0; }
@@ -191,8 +191,8 @@ int __fastcall DirLink_10006047(int a1, int a2) { return 0; }
 	Fade_100072BE(10);
 	return SDlgEndDialog(v3, v2);
 } */
-// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
-// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 10010376: using guessed type int __stdcall SDlgEndDialog(DWORD, DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(DWORD, DWORD);
 
 // ref: 0x10006073
 void UNKCALL DirLink_10006073(void *arg) { return; }
@@ -209,7 +209,7 @@ void UNKCALL DirLink_10006073(void *arg) { return; }
 			DirLink_10006047(v1, 1);
 	}
 } */
-// 10010430: using guessed type int __stdcall SNetJoinGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010430: using guessed type int __stdcall SNetJoinGame(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
 // 10029738: using guessed type int dword_10029738;
 // 10029844: using guessed type int gnDlinkPlayerid;
 
@@ -267,7 +267,7 @@ int UNKCALL DirLink_10006141(void *arg) { return 0; }
 	memset(&v6, 0, 0x10u);
 	v6 = 16;
 	v7 = 1396916812;
-	v8 = *(_DWORD *)(dword_1002984C + 24);
+	v8 = *(DWORD *)(dword_1002984C + 24);
 	v9 = 0;
 	result = CreaDung_100051D8(
 				 (int)&v6,
@@ -317,8 +317,8 @@ int UNKCALL DirLink_100061E1(void *arg) { return 0; }
 	}
 	return SelYesNo_1000FD39(v1, v2, 0, 0);
 } */
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
-// 10010430: using guessed type int __stdcall SNetJoinGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
+// 10010430: using guessed type int __stdcall SNetJoinGame(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
 // 10029738: using guessed type int dword_10029738;
 // 10029844: using guessed type int gnDlinkPlayerid;
 
@@ -346,8 +346,8 @@ int UNKCALL DirLink_100062BF(void *arg, int a2, char *a3, char *a4) { return 0; 
 	}
 	return result;
 } */
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
-// 10010436: using guessed type int __stdcall SNetEnumGames(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
+// 10010436: using guessed type int __stdcall SNetEnumGames(DWORD, DWORD, DWORD, DWORD);
 // 10029738: using guessed type int dword_10029738;
 
 // ref: 0x1000632B

--- a/DiabloUI/disclaim.cpp
+++ b/DiabloUI/disclaim.cpp
@@ -7,7 +7,7 @@ BOOL __stdcall UiBetaDisclaimer(int a1)
 	SDlgDialogBoxParam(ghUiInst, "DISCLAIMER_DIALOG", v1, disclaim_WndProc, a1);
 	return 1;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x100063DA
 LRESULT __stdcall disclaim_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
@@ -17,7 +17,7 @@ LRESULT __stdcall disclaim_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 	if (Msg > 0x111) {
 		if (Msg != 513 && Msg != 516) {
 			if (Msg == 528) {
-				if ((_WORD)wParam == 513 || (_WORD)wParam == 516)
+				if ((WORD)wParam == 513 || (WORD)wParam == 516)
 					disclaim_FadeFromDisclaim(hWnd);
 			} else if (Msg == 2024) {
 				if (!Fade_CheckRange5())
@@ -50,7 +50,7 @@ LABEL_21:
 	disclaim_FadeFromDisclaim(hWnd);
 	return 0;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x100064C9
 void __fastcall disclaim_DelDisclaimProcs(HWND hWnd)

--- a/DiabloUI/doom.cpp
+++ b/DiabloUI/doom.cpp
@@ -45,8 +45,8 @@ void __fastcall Doom_GetSetWndText(HWND hWnd, int msg, int nFont, int a4)
 // ref: 0x1000663F
 void __fastcall Doom_PrintStrWithSpin(HWND hWnd, BOOL a2)
 {
-	_DWORD *v3;       // eax
-	_DWORD *v4;       // esi
+	DWORD *v3;       // eax
+	DWORD *v4;       // esi
 	char *v5;         // ebx
 	int v6;           // edi
 	size_t v7;        // eax
@@ -57,7 +57,7 @@ void __fastcall Doom_PrintStrWithSpin(HWND hWnd, BOOL a2)
 	char *v12;        // [esp+108h] [ebp-Ch]
 	int v14;          // [esp+110h] [ebp-4h]
 
-	v3 = (_DWORD *)GetWindowLongA(hWnd, -21);
+	v3 = (DWORD *)GetWindowLongA(hWnd, -21);
 	v4 = v3;
 	if (v3 && *v3) {
 		GetWindowTextA(hWnd, String, 255);
@@ -103,23 +103,23 @@ void __fastcall Doom_AllocAndSetBMP(HWND hWnd, int a2, int bmp_flags)
 // ref: 0x1000678A
 void __fastcall Doom_GetWindowROP3(HWND hWnd1, HWND hWnd2)
 {
-	_DWORD *v3;          // ebx
+	DWORD *v3;          // ebx
 	LONG v4;             // eax MAPDST
 	struct tagRECT Rect; // [esp+Ch] [ebp-14h]
 
-	v3 = (_DWORD *)GetWindowLongA(hWnd1, -21);
+	v3 = (DWORD *)GetWindowLongA(hWnd1, -21);
 	v4 = GetWindowLongA(hWnd2, -21);
 	if (v3 && *v3 && v4) {
-		if (*(_DWORD *)v4) {
+		if (*(DWORD *)v4) {
 			GetWindowRect(hWnd2, &Rect);
 			ScreenToClient(hWnd1, (LPPOINT)&Rect);
 			ScreenToClient(hWnd1, (LPPOINT)&Rect.right);
 			SBltROP3(
 			    *(void **)v4,
 			    (void *)(Rect.left + *v3 + Rect.top * v3[1]),
-			    *(_DWORD *)(v4 + 4),
-			    *(_DWORD *)(v4 + 8),
-			    *(_DWORD *)(v4 + 4),
+			    *(DWORD *)(v4 + 4),
+			    *(DWORD *)(v4 + 8),
+			    *(DWORD *)(v4 + 4),
 			    v3[1],
 			    0,
 			    0xCC0020u);
@@ -201,13 +201,13 @@ void __fastcall Doom_GetSetWndTxt3(HWND hWnd, int msg, int nFont)
 // ref: 0x1000695D
 void __fastcall Doom_PrintStrWithSpn2(HWND hWnd, int justify_type)
 {
-	_DWORD *v2;       // eax
-	_DWORD *v3;       // esi
+	DWORD *v2;       // eax
+	DWORD *v3;       // esi
 	char *v4;         // edi
 	int v5;           // eax
 	char String[256]; // [esp+4h] [ebp-108h]
 
-	v2 = (_DWORD *)GetWindowLongA(hWnd, -21);
+	v2 = (DWORD *)GetWindowLongA(hWnd, -21);
 	v3 = v2;
 	if (v2 && *v2) {
 		GetWindowTextA(hWnd, String, 255);
@@ -306,7 +306,7 @@ void __fastcall Doom_PrintTextMsg403(HWND hWnd)
 
 	v2        = (BYTE *)GetWindowLongA(hWnd, -21);
 	pWidthBin = v2;
-	if (v2 && *(_DWORD *)v2) {
+	if (v2 && *(DWORD *)v2) {
 		GetWindowTextA(hWnd, String, 255);
 		v14 = strlen(String);
 		v3  = Focus_GetSpinWidthOrZero();
@@ -324,7 +324,7 @@ void __fastcall Doom_PrintTextMsg403(HWND hWnd)
 		if (v12)
 			String[v14 - 1] = 124; // *(&v9 + v14) = 124;
 		v8                  = artfont_GetFontMaxHeight();
-		artfont_PrintFontStr(i, (DWORD **)pWidthBin, v4, (*((_DWORD *)pWidthBin + 2) - v8) / 2);
+		artfont_PrintFontStr(i, (DWORD **)pWidthBin, v4, (*((DWORD *)pWidthBin + 2) - v8) / 2);
 	}
 }
 

--- a/DiabloUI/entdial.cpp
+++ b/DiabloUI/entdial.cpp
@@ -53,8 +53,8 @@ int __stdcall EntDial_10006C96(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam
 	}
 	return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
 } */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x10006D78
 HWND UNKCALL EntDial_10006D78(HWND hDlg) { return 0; }
@@ -102,7 +102,7 @@ HWND USERCALL EntDial_10006DB8(HWND hWnd, int a2) { return 0; }
 	return Modem_10008563(v6, (const char *)&v9, (int)&v8);
 } */
 // 10006DB8: could not find valid save-restore pair for ebp
-// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010412: using guessed type int __stdcall SDlgSetTimer(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10006EA7
 int __fastcall EntDial_10006EA7(HWND hDlg, int a2) { return 0; }
@@ -122,8 +122,8 @@ int __fastcall EntDial_10006EA7(HWND hDlg, int a2) { return 0; }
 	lpString[31] = 0;
 	return SDlgEndDialog(v3, v2);
 } */
-// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
-// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 10010376: using guessed type int __stdcall SDlgEndDialog(DWORD, DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(DWORD, DWORD);
 
 // ref: 0x10006EE8
 void __fastcall EntDial_10006EE8(HWND hWnd, unsigned int a2, int a3) { return; }

--- a/DiabloUI/entname.cpp
+++ b/DiabloUI/entname.cpp
@@ -55,7 +55,7 @@ LRESULT __stdcall EntName_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 	}
 	return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x1000709E
 void __fastcall EntName_DelEntNameMsgs(HWND hWnd)

--- a/DiabloUI/fade.cpp
+++ b/DiabloUI/fade.cpp
@@ -63,7 +63,7 @@ void __fastcall Fade_UpdatePaletteRange(int range)
 	GetPaletteEntries(v6, 0xAu, 0xAu, &fadepal[246]);
 	SDrawUpdatePalette(0, 0x100u, fadepal, 1);
 }
-// 1001043C: using guessed type int __stdcall SDrawClearSurface(_DWORD);
+// 1001043C: using guessed type int __stdcall SDrawClearSurface(DWORD);
 
 // ref: 0x1000739F
 BOOL __cdecl Fade_CheckRange5()

--- a/DiabloUI/focus.cpp
+++ b/DiabloUI/focus.cpp
@@ -21,7 +21,7 @@ int __cdecl Focus_GetSpinWidthOrZero()
 // ref: 0x10007492
 void __fastcall Focus_BlitSpinner(HWND hWnd1, HWND hWnd2)
 {
-	_DWORD *v2;          // edi
+	DWORD *v2;          // edi
 	LONG v3;             // eax MAPDST
 	int v5;              // eax MAPDST
 	int v7;              // eax
@@ -29,10 +29,10 @@ void __fastcall Focus_BlitSpinner(HWND hWnd1, HWND hWnd2)
 	char *v9;            // [esp+18h] [ebp-8h]
 
 	v9 = (char *)hWnd1;
-	v2 = (_DWORD *)GetWindowLongA(hWnd1, -21);
+	v2 = (DWORD *)GetWindowLongA(hWnd1, -21);
 	v3 = GetWindowLongA(hWnd2, -21);
 	if (v2 && v3 && *v2) {
-		if (*(_DWORD *)v3) {
+		if (*(DWORD *)v3) {
 			GetWindowRect(hWnd2, &Rect);
 			ScreenToClient((HWND)v9, (LPPOINT)&Rect);
 			ScreenToClient((HWND)v9, (LPPOINT)&Rect.right);
@@ -40,8 +40,8 @@ void __fastcall Focus_BlitSpinner(HWND hWnd1, HWND hWnd2)
 			    *(void **)v3,
 			    (void *)(Rect.left + *v2 + Rect.top * v2[1]),
 			    focus_spin_width,
-			    *(_DWORD *)(v3 + 8),
-			    *(_DWORD *)(v3 + 4),
+			    *(DWORD *)(v3 + 8),
+			    *(DWORD *)(v3 + 4),
 			    v2[1],
 			    0,
 			    0xCC0020u);
@@ -49,10 +49,10 @@ void __fastcall Focus_BlitSpinner(HWND hWnd1, HWND hWnd2)
 			v7 = *v2 + Rect.top * v5;
 			v9 = *(char **)(v3 + 4);
 			SBltROP3(
-			    &v9[*(_DWORD *)v3 - focus_spin_width],
+			    &v9[*(DWORD *)v3 - focus_spin_width],
 			    &v9[v7 - focus_spin_width + Rect.left],
 			    focus_spin_width,
-			    *(_DWORD *)(v3 + 8),
+			    *(DWORD *)(v3 + 8),
 			    (int)v9,
 			    v5,
 			    0,

--- a/DiabloUI/local.cpp
+++ b/DiabloUI/local.cpp
@@ -57,7 +57,7 @@ void __cdecl local_ClearSurface()
 {
 	SDrawClearSurface(0);
 }
-// 1001043C: using guessed type int __stdcall SDrawClearSurface(_DWORD);
+// 1001043C: using guessed type int __stdcall SDrawClearSurface(DWORD);
 
 // ref: 0x100078BE
 BOOL __fastcall local_LoadArtImage(const char *pszFileName, BYTE **pBuffer, DWORD *pdwSize)
@@ -122,7 +122,7 @@ BOOL __fastcall local_LoadArtWithPal(HWND hWnd, int a2, char *src, int mask, int
 	}
 	return 1;
 }
-// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(_DWORD, _DWORD, _DWORD, _DWORD);
+// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10007A68
 void __fastcall local_AdjustRectSize(tagRECT *pRect, int a2, int a3)
@@ -247,8 +247,8 @@ void __fastcall local_DlgDoPaint(HWND hWnd)
 	SDlgBeginPaint(hWnd, v2);
 	SDlgEndPaint(hWnd, v2);
 }
-// 10010442: using guessed type int __stdcall SDlgEndPaint(_DWORD, _DWORD);
-// 10010448: using guessed type int __stdcall SDlgBeginPaint(_DWORD, _DWORD);
+// 10010442: using guessed type int __stdcall SDlgEndPaint(DWORD, DWORD);
+// 10010448: using guessed type int __stdcall SDlgBeginPaint(DWORD, DWORD);
 
 // ref: 0x10007CB5
 void __fastcall local_DoUiWndProc(HWND hWnd, DWORD *pdwMsgTbl)
@@ -414,7 +414,7 @@ DWORD *__cdecl local_AllocWndLongData()
 		result[1]               = 0;
 		result[2]               = 0;
 		result[3]               = 0;
-		*((_BYTE *)result + 16) = 0;
+		*((BYTE *)result + 16) = 0;
 	}
 	return result;
 }
@@ -435,9 +435,9 @@ void __fastcall local_SetWndLongStr(int WndLongData, const char *pszStr)
 	if (WndLongData) {
 		if (pszStr) {
 			strncpy((char *)(WndLongData + 16), pszStr, 0xFFu);
-			*(_BYTE *)(WndLongData + 271) = 0;
+			*(BYTE *)(WndLongData + 271) = 0;
 		} else {
-			*(_BYTE *)(WndLongData + 16) = 0;
+			*(BYTE *)(WndLongData + 16) = 0;
 		}
 	}
 }
@@ -503,14 +503,14 @@ void __cdecl local_SetCursorArt()
 		local_LoadArtCursor();
 	SDlgSetSystemCursor(gpCursorArt2, gpCursorArt, (int *)gdwCursData, 32512);
 }
-// 1001044E: using guessed type int __stdcall SDlgSetSystemCursor(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1001044E: using guessed type int __stdcall SDlgSetSystemCursor(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000811B
 void __cdecl local_SetCursorDefault()
 {
 	SDlgSetSystemCursor(0, 0, 0, 32512);
 }
-// 1001044E: using guessed type int __stdcall SDlgSetSystemCursor(_DWORD, _DWORD, _DWORD, _DWORD);
+// 1001044E: using guessed type int __stdcall SDlgSetSystemCursor(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000812B
 void __fastcall local_SetDiabloCursor(HWND hWnd)
@@ -523,4 +523,4 @@ void __fastcall local_SetDiabloCursor(HWND hWnd)
 	v2 = LoadCursorA(ghUiInst, "DIABLOCURSOR");
 	SDlgSetCursor(hWnd, v2, 32512, &v3);
 }
-// 10010454: using guessed type int __stdcall SDlgSetCursor(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010454: using guessed type int __stdcall SDlgSetCursor(DWORD, DWORD, DWORD, DWORD);

--- a/DiabloUI/mainmenu.cpp
+++ b/DiabloUI/mainmenu.cpp
@@ -26,7 +26,7 @@ BOOL __stdcall UiMainMenuDialog(char *name, int *pdwResult, void(__stdcall *fnSo
 		*pdwResult = v5;
 	return 1;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 // 1002A118: using guessed type int menu_item_timer;
 
 // ref: 0x100081E3
@@ -93,7 +93,7 @@ LRESULT __stdcall MainMenu_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 	}
 	return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 // 10029728: using guessed type int app_is_active;
 
 // ref: 0x10008354

--- a/DiabloUI/modem.cpp
+++ b/DiabloUI/modem.cpp
@@ -61,7 +61,7 @@ BOOL Modem_10008606() { return 0; }
 		result = 0;
 	return result;
 } */
-// 10010436: using guessed type int __stdcall SNetEnumGames(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010436: using guessed type int __stdcall SNetEnumGames(DWORD, DWORD, DWORD, DWORD);
 // 1002A150: using guessed type int dword_1002A150;
 
 // ref: 0x1000863D
@@ -116,7 +116,7 @@ int UNKCALL Modem_1000865F(char *arg) { return 0; }
 } */
 
 // ref: 0x10008680
-BOOL __fastcall Modem_10008680(int a1, int a2, int a3, _DWORD *a4, int a5, int playerid) { return 0; }
+BOOL __fastcall Modem_10008680(int a1, int a2, int a3, DWORD *a4, int a5, int playerid) { return 0; }
 /* {
 	int v6; // esi
 
@@ -130,7 +130,7 @@ BOOL __fastcall Modem_10008680(int a1, int a2, int a3, _DWORD *a4, int a5, int p
 	artfont_100010C8();
 	return v6 == 1;
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002A138: using guessed type int dword_1002A138;
 // 1002A13C: using guessed type int dword_1002A13C;
 // 1002A140: using guessed type int gnModemPlayerid;
@@ -183,20 +183,20 @@ int __stdcall Modem_100086DE(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) 
 	PostMessageA(hWnd, 0x7E8u, 0, 0);
 	return 0;
 } */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x1000879E
 void **UNKCALL Modem_1000879E(HWND hDlg) { return 0; }
 /* {
 	HWND v1; // esi
-	_DWORD *v2; // eax
+	DWORD *v2; // eax
 
 	v1 = hDlg;
 	Doom_10006C53(hDlg, (int *)&unk_10022C5C);
 	Doom_10006C53(v1, (int *)&unk_10022C54);
 	Doom_10006C53(v1, (int *)&unk_10022C4C);
-	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	v2 = (DWORD *)GetWindowLongA(v1, -21);
 	local_10007F72(v2);
 	return Title_100100E7(v1);
 } */
@@ -259,8 +259,8 @@ int Modem_10008888() { return 0; }
 	}
 	return result;
 } */
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
-// 10010436: using guessed type int __stdcall SNetEnumGames(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
+// 10010436: using guessed type int __stdcall SNetEnumGames(DWORD, DWORD, DWORD, DWORD);
 // 1002A124: using guessed type int dword_1002A124;
 // 1002A130: using guessed type int dword_1002A130;
 // 1002A134: using guessed type int dword_1002A134;
@@ -285,7 +285,7 @@ int UNKCALL Modem_100088DB(HWND hWnd) { return 0; }
 		return PostMessageA(v1, 0xBD1u, 0, 0);
 	return SelHero_1000C3E2((int)v1, 2);
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000893D
 int UNKCALL Modem_1000893D(HWND hWnd) { return 0; }
@@ -309,7 +309,7 @@ int UNKCALL Modem_1000893D(HWND hWnd) { return 0; }
 	memset(&v8, 0, 0x10u);
 	v8 = 16;
 	v9 = 1297040461;
-	v2 = *(_DWORD *)(dword_1002A138 + 24);
+	v2 = *(DWORD *)(dword_1002A138 + 24);
 	v11 = 0;
 	v10 = v2;
 	LoadStringA(hInstance, 0x47u, &Buffer, 31);
@@ -339,7 +339,7 @@ int UNKCALL Modem_1000893D(HWND hWnd) { return 0; }
 	}
 	return result;
 } */
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
 // 1002A124: using guessed type int dword_1002A124;
 // 1002A130: using guessed type int dword_1002A130;
 // 1002A138: using guessed type int dword_1002A138;
@@ -429,8 +429,8 @@ void __cdecl Modem_10008B42(char *a1) { return; }
 	dword_1002A148 = 1;
 	_endthread();
 } */
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
-// 10010430: using guessed type int __stdcall SNetJoinGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
+// 10010430: using guessed type int __stdcall SNetJoinGame(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
 // 10011E20: using guessed type int _endthread(void);
 // 1002A120: using guessed type int dword_1002A120;
 // 1002A124: using guessed type int dword_1002A124;
@@ -452,7 +452,7 @@ int UNKCALL Modem_10008BB7(HWND hWnd) { return 0; }
 		result = PostMessageA(v1, 0xBD0u, 0, 0);
 	return result;
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10008BFE
 int UNKCALL Modem_10008BFE(HWND hWnd) { return 0; }
@@ -473,5 +473,5 @@ int UNKCALL Modem_10008BFE(HWND hWnd) { return 0; }
 	dword_1002A124 = 0;
 	return PostMessageA(v1, 0xBD0u, 0, 0);
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002A124: using guessed type int dword_1002A124;

--- a/DiabloUI/modmstat.cpp
+++ b/DiabloUI/modmstat.cpp
@@ -17,7 +17,7 @@ int UNKCALL ModmStat_10008C87(void *arg) { return 0; }
 /* {
 	return SDlgDialogBoxParam(hInstance, "MODMSTAT_DIALOG", arg, ModmStat_10008CA0, 0);
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x10008CA0
 int __stdcall ModmStat_10008CA0(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) { return 0; }
@@ -53,7 +53,7 @@ int __stdcall ModmStat_10008CA0(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 						Focus_10007458((void *)lParam);
 						Focus_100075DC(hWnd, (HWND)lParam);
 					}
-					else if ( (_WORD)wParam == 1 || (_WORD)wParam == 2 )
+					else if ( (WORD)wParam == 1 || (WORD)wParam == 2 )
 					{
 						ModmStat_10008E89((int)hWnd, 1);
 					}
@@ -74,8 +74,8 @@ int __stdcall ModmStat_10008CA0(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 	}
 	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
 } */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 // 1002A258: using guessed type int dword_1002A258;
 // 1002A25C: using guessed type int dword_1002A25C;
 
@@ -83,10 +83,10 @@ int __stdcall ModmStat_10008CA0(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 int UNKCALL ModmStat_10008DB3(HWND hDlg) { return 0; }
 /* {
 	HWND v1; // esi
-	_DWORD *v2; // eax
+	DWORD *v2; // eax
 
 	v1 = hDlg;
-	v2 = (_DWORD *)GetWindowLongA(hDlg, -21);
+	v2 = (DWORD *)GetWindowLongA(hDlg, -21);
 	local_10007F72(v2);
 	Focus_100076C3();
 	Doom_10006C53(v1, (int *)&unk_10022CB4);
@@ -123,7 +123,7 @@ BOOL UNKCALL ModmStat_10008DE4(HWND hWnd) { return 0; }
 	dword_1002A25C = 0;
 	return result;
 } */
-// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010412: using guessed type int __stdcall SDlgSetTimer(DWORD, DWORD, DWORD, DWORD);
 // 1002A258: using guessed type int dword_1002A258;
 // 1002A25C: using guessed type int dword_1002A25C;
 // 1002A260: using guessed type int (*dword_1002A260)(void);
@@ -151,8 +151,8 @@ int __fastcall ModmStat_10008E89(int a1, int a2) { return 0; }
 	return result;
 } */
 // 1002A260: invalid function type has been ignored
-// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
-// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 10010376: using guessed type int __stdcall SDlgEndDialog(DWORD, DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(DWORD, DWORD);
 // 1002A25C: using guessed type int dword_1002A25C;
 // 1002A260: using guessed type int (*dword_1002A260)(void);
 

--- a/DiabloUI/okcancel.cpp
+++ b/DiabloUI/okcancel.cpp
@@ -103,7 +103,7 @@ LRESULT __stdcall OkCancel_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 		SDlgEndDialog(hWnd, (HANDLE)0xFF000000);
 	return 1;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x10009117
 void __fastcall OkCancel_FreeDlgBmp(HWND hWnd)
@@ -191,7 +191,7 @@ BOOL __fastcall OkCancel_LoadOkCancGFX(HWND hWnd, DWORD *lParam)
 	}
 	return 1;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x100092F5
 void __fastcall OkCancel_PlaySndEndDlg(HWND hWnd, int a2)

--- a/DiabloUI/progress.cpp
+++ b/DiabloUI/progress.cpp
@@ -30,7 +30,7 @@ BOOL __stdcall UiProgressDialog(HWND window, char *msg, int enable, int(*fnfunc)
 	}
 	return result;
 } */
-// 1001045A: using guessed type int __stdcall SDlgCreateDialogParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1001045A: using guessed type int __stdcall SDlgCreateDialogParam(DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002A2E8: using guessed type int dword_1002A2E8;
 // 1002A2F0: using guessed type int dword_1002A2F0;
 // 1002A2F4: using guessed type int (*dword_1002A2F4)(void);
@@ -67,7 +67,7 @@ int __stdcall Progress_100094F4(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 					ShowCursor(TRUE);
 					return 1;
 				case 0x111u:
-					if ( (_WORD)wParam == 2 )
+					if ( (WORD)wParam == 2 )
 					{
 						SDlgKillTimer(hWnd, 1);
 						v4 = GetParent(hWnd);
@@ -84,9 +84,9 @@ int __stdcall Progress_100094F4(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 	}
 	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
 } */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
-// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
+// 10010418: using guessed type int __stdcall SDlgKillTimer(DWORD, DWORD);
 
 // ref: 0x100095EC
 void *Progress_100095EC() { return 0; }
@@ -121,7 +121,7 @@ void *Progress_100095EC() { return 0; }
 	}
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
 // 1002A318: using guessed type int dword_1002A318;
 // 1002A31C: using guessed type int dword_1002A31C;
 // 1002A320: using guessed type int dword_1002A320;
@@ -175,11 +175,11 @@ BOOL __fastcall Progress_10009675(HWND hWnd, const CHAR *a2) { return 0; }
 	ShowWindow(v6, bEnable != 0);
 	return EnableWindow(v6, bEnable);
 } */
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
-// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010400: using guessed type int __stdcall SDlgSetBitmapI(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
-// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
+// 100103FA: using guessed type int __stdcall SDrawUpdatePalette(DWORD, DWORD, DWORD, DWORD);
+// 10010400: using guessed type int __stdcall SDlgSetBitmapI(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
+// 10010412: using guessed type int __stdcall SDlgSetTimer(DWORD, DWORD, DWORD, DWORD);
 // 1002A2F0: using guessed type int dword_1002A2F0;
 // 1002A300: using guessed type int dword_1002A300;
 // 1002A304: using guessed type int dword_1002A304;
@@ -225,7 +225,7 @@ BOOL __fastcall Progress_10009805(HWND hWnd, int a2) { return 0; }
 	ScreenToClient(v2, (LPPOINT)&Rect.right);
 	return InvalidateRect(v2, &Rect, 0);
 } */
-// 100103F4: using guessed type int __stdcall SBltROP3(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 100103F4: using guessed type int __stdcall SBltROP3(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002A300: using guessed type int dword_1002A300;
 // 1002A304: using guessed type int dword_1002A304;
 // 1002A308: using guessed type int dword_1002A308;
@@ -267,8 +267,8 @@ void UNKCALL Progress_100098C5(HWND hWnd) { return; }
 		Progress_10009805(v1, v2);
 	}
 } */
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
-// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
+// 10010418: using guessed type int __stdcall SDlgKillTimer(DWORD, DWORD);
 // 1002A2E8: using guessed type int dword_1002A2E8;
 // 1002A2F4: using guessed type int (*dword_1002A2F4)(void);
 
@@ -309,6 +309,6 @@ LABEL_12:
 	dword_1002A2F8 = 0;
 	return result;
 } */
-// 10010460: using guessed type _DWORD __stdcall SDlgUpdateCursor();
-// 10010466: using guessed type _DWORD __stdcall SDlgCheckTimers();
+// 10010460: using guessed type DWORD __stdcall SDlgUpdateCursor();
+// 10010466: using guessed type DWORD __stdcall SDlgCheckTimers();
 // 1002A2F8: using guessed type int dword_1002A2F8;

--- a/DiabloUI/sbar.cpp
+++ b/DiabloUI/sbar.cpp
@@ -21,8 +21,8 @@ BOOL __fastcall Sbar_CheckIfNextHero(HWND hWnd)
 // ref: 0x100099DC
 int __fastcall Sbar_NumScrollLines(HWND hWnd, int width, int height)
 {
-	_DWORD *v4;            // eax
-	_DWORD *v5;            // esi
+	DWORD *v4;            // eax
+	DWORD *v5;            // esi
 	int result;            // eax
 	signed int v7;         // ecx
 	LONG v8;               // ebx
@@ -36,7 +36,7 @@ int __fastcall Sbar_NumScrollLines(HWND hWnd, int width, int height)
 		return 0;
 	if (!IsWindowVisible(hWnd))
 		return 0;
-	v4 = (_DWORD *)GetWindowLongA(hWnd, -21);
+	v4 = (DWORD *)GetWindowLongA(hWnd, -21);
 	v5 = v4;
 	if (!v4)
 		return 0;
@@ -89,60 +89,60 @@ void __fastcall Sbar_DrawScrollBar(HWND hWnd, int nIDDlgItem, int width, int hei
 	if (v4) {
 		v5 = GetWindowLongA(v4, -21);
 		if (v5) {
-			if (*(_DWORD *)(v5 + 4)) {
-				v7                   = *(_DWORD *)(v5 + 16) == 0;
-				*(_DWORD *)(v5 + 52) = width;
-				*(_DWORD *)(v5 + 56) = height;
+			if (*(DWORD *)(v5 + 4)) {
+				v7                   = *(DWORD *)(v5 + 16) == 0;
+				*(DWORD *)(v5 + 52) = width;
+				*(DWORD *)(v5 + 56) = height;
 				if (!v7) {
 					SrcBuffer.left   = 0;
 					DstRect.left     = 0;
 					SrcBuffer.top    = 0;
 					DstRect.top      = 0;
-					DstRect.right    = *(_DWORD *)(v5 + 8) - 1;
-					DstRect.bottom   = *(_DWORD *)(v5 + 12) - 1;
-					SrcBuffer.right  = *(_DWORD *)(v5 + 8) - 1;
-					SrcBuffer.bottom = *(_DWORD *)(v5 + 24) - 1;
+					DstRect.right    = *(DWORD *)(v5 + 8) - 1;
+					DstRect.bottom   = *(DWORD *)(v5 + 12) - 1;
+					SrcBuffer.right  = *(DWORD *)(v5 + 8) - 1;
+					SrcBuffer.bottom = *(DWORD *)(v5 + 24) - 1;
 					SBltROP3Tiled(
 					    *(void **)(v5 + 4),
 					    &DstRect,
 					    *(POINT **)(v5 + 8),
-					    *(_DWORD *)(v5 + 16),
+					    *(DWORD *)(v5 + 16),
 					    &SrcBuffer,
 					    *(RECT **)(v5 + 20),
 					    0,
 					    0,
 					    0,
 					    0xCC0020u);
-					if (*(_DWORD *)(v5 + 28)) {
+					if (*(DWORD *)(v5 + 28)) {
 						if (width <= 1)
 							v8 = 22;
 						else
-							v8 = height * (*(_DWORD *)(v5 + 12) - *(_DWORD *)(v5 + 36) - 44) / (width - 1) + 22;
+							v8 = height * (*(DWORD *)(v5 + 12) - *(DWORD *)(v5 + 36) - 44) / (width - 1) + 22;
 						SBltROP3(
-						    (void *)(v8 * *(_DWORD *)(v5 + 8) + *(_DWORD *)(v5 + 4) + 3),
+						    (void *)(v8 * *(DWORD *)(v5 + 8) + *(DWORD *)(v5 + 4) + 3),
 						    *(void **)(v5 + 28),
 						    18,
-						    *(_DWORD *)(v5 + 36),
-						    *(_DWORD *)(v5 + 8),
-						    *(_DWORD *)(v5 + 32),
+						    *(DWORD *)(v5 + 36),
+						    *(DWORD *)(v5 + 8),
+						    *(DWORD *)(v5 + 32),
 						    0,
 						    0xCC0020u);
 						SBltROP3(
 						    *(void **)(v5 + 4),
-						    (void *)(*(_DWORD *)(v5 + 40) + 22 * (~*(_BYTE *)v5 & 1) * *(_DWORD *)(v5 + 44)),
-						    *(_DWORD *)(v5 + 8),
+						    (void *)(*(DWORD *)(v5 + 40) + 22 * (~*(BYTE *)v5 & 1) * *(DWORD *)(v5 + 44)),
+						    *(DWORD *)(v5 + 8),
 						    22,
-						    *(_DWORD *)(v5 + 8),
-						    *(_DWORD *)(v5 + 44),
+						    *(DWORD *)(v5 + 8),
+						    *(DWORD *)(v5 + 44),
 						    0,
 						    0xCC0020u);
 						SBltROP3(
-						    (void *)(*(_DWORD *)(v5 + 4) + *(_DWORD *)(v5 + 8) * (*(_DWORD *)(v5 + 12) - 22)),
-						    (void *)(*(_DWORD *)(v5 + 40) + 22 * ((~*(_BYTE *)v5 & 4 | 8u) >> 2) * *(_DWORD *)(v5 + 44)),
-						    *(_DWORD *)(v5 + 8),
+						    (void *)(*(DWORD *)(v5 + 4) + *(DWORD *)(v5 + 8) * (*(DWORD *)(v5 + 12) - 22)),
+						    (void *)(*(DWORD *)(v5 + 40) + 22 * ((~*(BYTE *)v5 & 4 | 8u) >> 2) * *(DWORD *)(v5 + 44)),
+						    *(DWORD *)(v5 + 8),
 						    22,
-						    *(_DWORD *)(v5 + 8),
-						    *(_DWORD *)(v5 + 44),
+						    *(DWORD *)(v5 + 8),
+						    *(DWORD *)(v5 + 44),
 						    0,
 						    0xCC0020u);
 						InvalidateRect(hWnda, 0, 0);
@@ -194,7 +194,7 @@ void __cdecl Sbar_cpp_init2()
 void __fastcall Sbar_FreeScrollBar(HWND hWnd, int nIDDlgItem)
 {
 	HWND v2;    // eax MAPDST
-	_DWORD *v4; // eax MAPDST
+	DWORD *v4; // eax MAPDST
 	void *v6;   // eax
 	void *v7;   // eax
 	void *v8;   // eax
@@ -202,7 +202,7 @@ void __fastcall Sbar_FreeScrollBar(HWND hWnd, int nIDDlgItem)
 
 	v2 = GetDlgItem(hWnd, nIDDlgItem);
 	if (v2) {
-		v4 = (_DWORD *)GetWindowLongA(v2, -21);
+		v4 = (DWORD *)GetWindowLongA(v2, -21);
 		if (v4) {
 			v6 = (void *)v4[1];
 			if (v6)

--- a/DiabloUI/selclass.cpp
+++ b/DiabloUI/selclass.cpp
@@ -50,9 +50,9 @@ LRESULT __stdcall SelClass_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 	} else {
 		if (HIWORD(wParam) != 6) {
 			v5 = 1;
-			if (HIWORD(wParam) == 5 || (_WORD)wParam == 1)
+			if (HIWORD(wParam) == 5 || (WORD)wParam == 1)
 				goto LABEL_19;
-			if ((_WORD)wParam != 2)
+			if ((WORD)wParam != 2)
 				return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 			goto LABEL_21;
 		}
@@ -62,7 +62,7 @@ LRESULT __stdcall SelClass_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 	}
 	return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x10009EC0
 void __fastcall SelClass_FreeClassMsgTbl(HWND hWnd)

--- a/DiabloUI/selconn.cpp
+++ b/DiabloUI/selconn.cpp
@@ -3,7 +3,7 @@ void *SelConn_1000A082() { return 0; }
 /* {
 	return SMemAlloc(272, "C:\\Src\\Diablo\\DiabloUI\\SelConn.cpp", 124, 0);
 } */
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000A09B
 signed int SelConn_1000A09B() { return 0; }
@@ -81,7 +81,7 @@ LABEL_25:
 			{
 				SelConn_1000AC30(hWnd);
 			}
-			else if ( (_WORD)wParam == 2 )
+			else if ( (WORD)wParam == 2 )
 			{
 				SelConn_1000AC07((int)hWnd, 2);
 			}
@@ -95,8 +95,8 @@ LABEL_27:
 	}
 	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
 } */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x1000A226
 HWND __fastcall SelConn_1000A226(HWND hDlg, int nIDDlgItem) { return 0; }
@@ -129,7 +129,7 @@ HWND __fastcall SelConn_1000A226(HWND hDlg, int nIDDlgItem) { return 0; }
 		result = (HWND)GetWindowLongA(result, -21);
 		if ( result )
 		{
-			v4 = *((_DWORD *)result + 3);
+			v4 = *((DWORD *)result + 3);
 			if ( v4 )
 			{
 				result = GetDlgItem(v2, 1081);
@@ -144,18 +144,18 @@ HWND __fastcall SelConn_1000A226(HWND hDlg, int nIDDlgItem) { return 0; }
 						LoadStringA(hInstance, 0x21u, &Buffer, 63);
 						if ( dword_1002A370 )
 						{
-							v7 = *(_DWORD *)(dword_1002A370 + 24);
-							if ( v7 >= *(_DWORD *)(v4 + 12) )
-								v7 = *(_DWORD *)(v4 + 12);
+							v7 = *(DWORD *)(dword_1002A370 + 24);
+							if ( v7 >= *(DWORD *)(v4 + 12) )
+								v7 = *(DWORD *)(v4 + 12);
 							wsprintfA(&v21, &Buffer, v7);
 						}
 						else
 						{
-							wsprintfA(&v21, &Buffer, *(_DWORD *)(v4 + 12));
+							wsprintfA(&v21, &Buffer, *(DWORD *)(v4 + 12));
 						}
 						v8 = GetWindowLongA(v6, -21);
 						local_10007FA4(v8, &v21);
-						if ( *(_DWORD *)(v4 + 8) == 1112425812 )
+						if ( *(DWORD *)(v4 + 8) == 1112425812 )
 						{
 							hWnd = GetDlgItem(v2, 1144);
 							v9 = BNetGW_10002B21(&unk_10029480, dword_1002948C);
@@ -216,8 +216,8 @@ int SelConn_1000A3FF() { return 0; }
 /* {
 	HWND v0; // eax
 	LONG v1; // eax
-	_DWORD *v2; // ecx
-	_DWORD *v3; // eax
+	DWORD *v2; // ecx
+	DWORD *v3; // eax
 	int v5; // edx
 
 	v0 = GetFocus();
@@ -226,10 +226,10 @@ int SelConn_1000A3FF() { return 0; }
 	v1 = GetWindowLongA(v0, -21);
 	if ( !v1 )
 		return 0;
-	v2 = (_DWORD *)dword_1002A35C;
+	v2 = (DWORD *)dword_1002A35C;
 	if ( !dword_1002A35C )
 		return 0;
-	v3 = *(_DWORD **)(v1 + 12);
+	v3 = *(DWORD **)(v1 + 12);
 	if ( !v3 )
 		return 0;
 	v5 = 0;
@@ -237,7 +237,7 @@ int SelConn_1000A3FF() { return 0; }
 	{
 		if ( v2 == v3 )
 			break;
-		v2 = (_DWORD *)*v2;
+		v2 = (DWORD *)*v2;
 		++v5;
 	}
 	while ( v2 );
@@ -249,36 +249,36 @@ int SelConn_1000A3FF() { return 0; }
 void UNKCALL SelConn_1000A43A(HWND hDlg) { return; }
 /* {
 	HWND v1; // esi
-	_DWORD *v2; // eax
+	DWORD *v2; // eax
 
 	v1 = hDlg;
 	Title_100100E7(hDlg);
 	Focus_10007818(v1);
 	Sbar_10009CD2(v1, 1105);
-	SelConn_1000A4B9((_DWORD *)dword_1002A35C);
+	SelConn_1000A4B9((DWORD *)dword_1002A35C);
 	Doom_10006C53(v1, &dword_10022F18);
 	Doom_10006C53(v1, (int *)&unk_10022F08);
 	Doom_10006C53(v1, (int *)&unk_10022ED8);
 	Doom_10006C53(v1, (int *)&unk_10022EE4);
 	Doom_10006C53(v1, (int *)&unk_10022F00);
 	Doom_10006C53(v1, (int *)&unk_10022EF0);
-	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	v2 = (DWORD *)GetWindowLongA(v1, -21);
 	local_10007F72(v2);
 } */
 // 10022F18: using guessed type int dword_10022F18;
 // 1002A35C: using guessed type int dword_1002A35C;
 
 // ref: 0x1000A4B9
-int __fastcall SelConn_1000A4B9(_DWORD *a1) { return 0; }
+int __fastcall SelConn_1000A4B9(DWORD *a1) { return 0; }
 /* {
-	_DWORD *v1; // esi
+	DWORD *v1; // esi
 	int result; // eax
 
 	if ( a1 )
 	{
 		do
 		{
-			v1 = (_DWORD *)*a1;
+			v1 = (DWORD *)*a1;
 			result = SelConn_1000A4CD(a1);
 			a1 = v1;
 		}
@@ -296,7 +296,7 @@ int UNKCALL SelConn_1000A4CD(void *arg) { return 0; }
 		result = SMemFree(arg, "C:\\Src\\Diablo\\DiabloUI\\SelConn.cpp", 130, 0);
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000A4E4
 HWND UNKCALL SelConn_1000A4E4(HWND hWnd, char *a2, int a3) { return 0; }
@@ -340,7 +340,7 @@ HWND UNKCALL SelConn_1000A4E4(HWND hWnd, char *a2, int a3) { return 0; }
 	}
 	return result;
 } */
-// 10010472: using guessed type int __stdcall SNetEnumProviders(_DWORD, _DWORD);
+// 10010472: using guessed type int __stdcall SNetEnumProviders(DWORD, DWORD);
 // 10022F18: using guessed type int dword_10022F18;
 // 10029488: using guessed type int dword_10029488;
 // 1002A35C: using guessed type int dword_1002A35C;
@@ -351,19 +351,19 @@ signed int __stdcall SelConn_1000A5F3(int a1, char *a2, char *a3, int a4) { retu
 /* {
 	int v4; // esi
 	int v6; // edx
-	_DWORD *v7; // eax
+	DWORD *v7; // eax
 
 	v4 = SelConn_1000A082();
 	if ( !v4 || a1 == 1112425812 && !dword_1002A368 )
 		return 0;
-	*(_DWORD *)v4 = 0;
-	v6 = *(_DWORD *)(a4 + 4);
-	*(_DWORD *)(v4 + 8) = a1;
-	*(_DWORD *)(v4 + 4) = v6 & 2;
-	*(_DWORD *)(v4 + 12) = *(_DWORD *)(a4 + 16);
+	*(DWORD *)v4 = 0;
+	v6 = *(DWORD *)(a4 + 4);
+	*(DWORD *)(v4 + 8) = a1;
+	*(DWORD *)(v4 + 4) = v6 & 2;
+	*(DWORD *)(v4 + 12) = *(DWORD *)(a4 + 16);
 	strcpy((char *)(v4 + 16), a2);
 	strcpy((char *)(v4 + 144), a3);
-	v7 = SelRegn_1000EF56(dword_1002A35C, (_DWORD *)v4);
+	v7 = SelRegn_1000EF56(dword_1002A35C, (DWORD *)v4);
 	++dword_1002A360;
 	dword_1002A35C = (int)v7;
 	return 1;
@@ -398,7 +398,7 @@ int __fastcall SelConn_1000A670(HWND a1, const char *a2) { return 0; }
 					v6 = GetWindowLongA(v5, -21);
 					if ( v6 )
 					{
-						*(_DWORD *)(v6 + 12) = v2;
+						*(DWORD *)(v6 + 12) = v2;
 						local_10007FA4(v6, v2 + 16);
 						v2 = *(const char **)v2;
 					}
@@ -593,7 +593,7 @@ HWND UNKCALL SelConn_1000A948(HWND hWnd) { return 0; }
 	HWND v3; // esi
 	HWND v4; // ebx
 	HWND v5; // eax
-	_DWORD *v6; // eax
+	DWORD *v6; // eax
 	int v7; // eax
 	const char *v8; // ebx
 	int v9; // eax
@@ -611,7 +611,7 @@ HWND UNKCALL SelConn_1000A948(HWND hWnd) { return 0; }
 			result = (HWND)GetWindowLongA(v5, -21);
 			if ( result )
 			{
-				v6 = (_DWORD *)*((_DWORD *)result + 3);
+				v6 = (DWORD *)*((DWORD *)result + 3);
 				if ( v6 && *v6 )
 				{
 					v7 = SelConn_1000A9F3(v4) + 6;
@@ -642,8 +642,8 @@ HWND UNKCALL SelConn_1000A948(HWND hWnd) { return 0; }
 int UNKCALL SelConn_1000A9F3(HWND hWnd) { return 0; }
 /* {
 	LONG v1; // eax
-	_DWORD *v2; // ecx
-	_DWORD *v3; // eax
+	DWORD *v2; // ecx
+	DWORD *v3; // eax
 	int v5; // edx
 
 	if ( !hWnd )
@@ -651,10 +651,10 @@ int UNKCALL SelConn_1000A9F3(HWND hWnd) { return 0; }
 	v1 = GetWindowLongA(hWnd, -21);
 	if ( !v1 )
 		return 0;
-	v2 = (_DWORD *)dword_1002A35C;
+	v2 = (DWORD *)dword_1002A35C;
 	if ( !dword_1002A35C )
 		return 0;
-	v3 = *(_DWORD **)(v1 + 12);
+	v3 = *(DWORD **)(v1 + 12);
 	if ( !v3 )
 		return 0;
 	v5 = 0;
@@ -662,7 +662,7 @@ int UNKCALL SelConn_1000A9F3(HWND hWnd) { return 0; }
 	{
 		if ( v2 == v3 )
 			break;
-		v2 = (_DWORD *)*v2;
+		v2 = (DWORD *)*v2;
 		++v5;
 	}
 	while ( v2 );
@@ -671,14 +671,14 @@ int UNKCALL SelConn_1000A9F3(HWND hWnd) { return 0; }
 // 1002A35C: using guessed type int dword_1002A35C;
 
 // ref: 0x1000AA28
-_DWORD *__fastcall SelConn_1000AA28(int a1) { return 0; }
+DWORD *__fastcall SelConn_1000AA28(int a1) { return 0; }
 /* {
-	_DWORD *result; // eax
+	DWORD *result; // eax
 
-	result = (_DWORD *)dword_1002A35C;
+	result = (DWORD *)dword_1002A35C;
 	while ( result && a1 )
 	{
-		result = (_DWORD *)*result;
+		result = (DWORD *)*result;
 		--a1;
 	}
 	return result;
@@ -709,7 +709,7 @@ HWND UNKCALL SelConn_1000AA3B(HWND hWnd) { return 0; }
 			result = (HWND)GetWindowLongA(result, -21);
 			if ( result )
 			{
-				result = (HWND)*((_DWORD *)result + 3);
+				result = (HWND)*((DWORD *)result + 3);
 				if ( result )
 				{
 					if ( result == (HWND)dword_1002A35C )
@@ -757,10 +757,10 @@ HWND UNKCALL SelConn_1000AAEB(HWND hWnd) { return 0; }
 	result = (HWND)GetWindowLongA(hWnd, -21);
 	if ( result )
 	{
-		result = (HWND)*((_DWORD *)result + 3);
+		result = (HWND)*((DWORD *)result + 3);
 		if ( result )
 		{
-			if ( *(_DWORD *)result )
+			if ( *(DWORD *)result )
 			{
 				if ( GetWindowLongA(v1, -12) >= 1074 )
 				{
@@ -771,7 +771,7 @@ HWND UNKCALL SelConn_1000AAEB(HWND hWnd) { return 0; }
 						result = (HWND)GetWindowLongA(result, -21);
 						if ( result )
 						{
-							v4 = (const char *)*((_DWORD *)result + 3);
+							v4 = (const char *)*((DWORD *)result + 3);
 							if ( v4 )
 							{
 								TitleSnd_10010315();
@@ -813,7 +813,7 @@ HWND UNKCALL SelConn_1000AB83(HWND hWnd) { return 0; }
 	result = (HWND)GetWindowLongA(v1, -21);
 	if ( result )
 	{
-		result = (HWND)*((_DWORD *)result + 3);
+		result = (HWND)*((DWORD *)result + 3);
 		if ( result )
 		{
 			v3 = (const char *)dword_1002A35C;
@@ -850,7 +850,7 @@ int __fastcall SelConn_1000AC07(int a1, int a2) { return 0; }
 	Fade_100072BE(10);
 	return SDlgEndDialog(v3, v2);
 } */
-// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010376: using guessed type int __stdcall SDlgEndDialog(DWORD, DWORD);
 
 // ref: 0x1000AC30
 int UNKCALL SelConn_1000AC30(HWND arg) { return 0; }
@@ -897,7 +897,7 @@ LABEL_14:
 	}
 	return result;
 } */
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
 // 1002A374: using guessed type int dword_1002A374;
 
 // ref: 0x1000AC9E
@@ -926,7 +926,7 @@ int UNKCALL SelConn_1000AC9E(HWND hWnd) { return 0; }
 	v3 = GetWindowLongA(v2, -21);
 	if ( !v3 )
 		return 0;
-	v4 = *(_DWORD *)(v3 + 12);
+	v4 = *(DWORD *)(v3 + 12);
 	if ( !v4 )
 		return 0;
 	SelGame_1000B677(*(void **)(v4 + 8));
@@ -961,8 +961,8 @@ int UNKCALL SelConn_1000AC9E(HWND hWnd) { return 0; }
 		SelConn_1000ADD0(v1);
 	return v9;
 } */
-// 10010478: using guessed type _DWORD __stdcall SNetDestroy();
-// 1001047E: using guessed type int __stdcall SNetInitializeProvider(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010478: using guessed type DWORD __stdcall SNetDestroy();
+// 1001047E: using guessed type int __stdcall SNetInitializeProvider(DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002A364: using guessed type int dword_1002A364;
 // 1002A370: using guessed type int dword_1002A370;
 
@@ -1014,7 +1014,7 @@ int __fastcall SelConn_1000AE19(int a1, UINT a2) { return 0; }
 	}
 	return result;
 } */
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
 
 // ref: 0x1000AE59
 HWND __fastcall SelConn_1000AE59(HWND hWnd, int a2, int a3) { return 0; }
@@ -1137,9 +1137,9 @@ int __stdcall UiSelectProvider(int a1, _SNETPROGRAMDATA *client_info, _SNETPLAYE
 	}
 	return 0;
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
-// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
+// 1001041E: using guessed type int __stdcall SErrSetLastError(DWORD);
 // 1002A364: using guessed type int dword_1002A364;
 // 1002A36C: using guessed type int dword_1002A36C;
 // 1002A370: using guessed type int dword_1002A370;

--- a/DiabloUI/seldial.cpp
+++ b/DiabloUI/seldial.cpp
@@ -111,7 +111,7 @@ int __stdcall SelDial_1000B0CF(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 			v6 = 1;
 			if ( wParam != 327681 )
 			{
-				if ( (_WORD)wParam != 2 )
+				if ( (WORD)wParam != 2 )
 					return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
 				v6 = 2;
 			}
@@ -120,8 +120,8 @@ int __stdcall SelDial_1000B0CF(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 	}
 	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
 } */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x1000B1FB
 HWND __fastcall SelDial_1000B1FB(HWND hWnd, int a2) { return 0; }
@@ -198,8 +198,8 @@ int __fastcall SelDial_1000B2D8(int a1, int a2) { return 0; }
 		strcpy(dword_1002A378, &byte_1002A380[32 * (v5 - 1119)]);
 	return SDlgEndDialog(v3, 4);
 } */
-// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
-// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 10010376: using guessed type int __stdcall SDlgEndDialog(DWORD, DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(DWORD, DWORD);
 
 // ref: 0x1000B354
 HWND UNKCALL SelDial_1000B354(HWND hDlg) { return 0; }
@@ -238,7 +238,7 @@ HWND UNKCALL SelDial_1000B354(HWND hDlg) { return 0; }
 	}
 	return result;
 } */
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
 
 // ref: 0x1000B3D8
 HWND UNKCALL SelDial_1000B3D8(HWND hDlg) { return 0; }
@@ -367,7 +367,7 @@ HWND USERCALL SelDial_1000B483(HWND hWnd, int a2) { return 0; }
 	return result;
 } */
 // 1000B483: could not find valid save-restore pair for ebp
-// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010412: using guessed type int __stdcall SDlgSetTimer(DWORD, DWORD, DWORD, DWORD);
 // 1002A400: using guessed type int dword_1002A400;
 
 // ref: 0x1000B5D9

--- a/DiabloUI/selgame.cpp
+++ b/DiabloUI/selgame.cpp
@@ -58,20 +58,20 @@ int __stdcall UiSelectGame(int a1, _SNETPROGRAMDATA *client_info, _SNETPLAYERDAT
 	v17 = &v12;
 	v18 = &v8;
 	if ( SelGame_1000B671() )
-		return SelIPX_1000C634(a1, a2, (int)&v16, (_DWORD *)a4, a5, playerid);
+		return SelIPX_1000C634(a1, a2, (int)&v16, (DWORD *)a4, a5, playerid);
 	v6 = SelGame_1000B67E();
 	switch ( v6 )
 	{
 		case 1230002254:
-			return SelIPX_1000C634(a1, a2, (int)&v16, (_DWORD *)a4, a5, playerid);
+			return SelIPX_1000C634(a1, a2, (int)&v16, (DWORD *)a4, a5, playerid);
 		case 1297040461:
-			return Modem_10008680(a1, a2, (int)&v16, (_DWORD *)a4, a5, playerid);
+			return Modem_10008680(a1, a2, (int)&v16, (DWORD *)a4, a5, playerid);
 		case 1396916812:
-			return DirLink_10005D05(a1, a2, (int)&v16, (_DWORD *)a4, a5, playerid);
+			return DirLink_10005D05(a1, a2, (int)&v16, (DWORD *)a4, a5, playerid);
 	}
 	return SNetSelectGame(a1, a2, &v16, a4, a5, playerid);
 } */
-// 10010490: using guessed type int __stdcall SNetSelectGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010490: using guessed type int __stdcall SNetSelectGame(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000B795
 signed int SelGame_1000B795() { return 0; }

--- a/DiabloUI/selhero.cpp
+++ b/DiabloUI/selhero.cpp
@@ -243,7 +243,7 @@ BOOL __stdcall UiSelHeroMultDialog(
 		*hero_is_created = selhero_is_created;
 	return 1;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 // 1002A45C: using guessed type int selhero_is_created;
 
 // ref: 0x1000BC46
@@ -324,7 +324,7 @@ LRESULT __stdcall SelHero_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 	SelHero_DoHeroSelClass(hWnd);
 	return 0;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 // 1002A420: using guessed type int selhero_difficulty;
 
 // ref: 0x1000BDAD
@@ -742,5 +742,5 @@ BOOL __stdcall UiSelHeroSingDialog(
 		artfont_FreeAllFonts();
 	return 1;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 // 1002A420: using guessed type int selhero_difficulty;

--- a/DiabloUI/selipx.cpp
+++ b/DiabloUI/selipx.cpp
@@ -3,7 +3,7 @@ void *SelIPX_1000C610() { return 0; }
 /* {
 	return SMemAlloc(268, "C:\\Src\\Diablo\\DiabloUI\\SelIPX.cpp", 105, 0);
 } */
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000C629
 signed int SelIPX_1000C629() { return 0; }
@@ -17,7 +17,7 @@ signed int SelIPX_1000C629() { return 0; }
 // 1002A4A4: using guessed type int dword_1002A4A4;
 
 // ref: 0x1000C634
-BOOL __fastcall SelIPX_1000C634(int a1, int a2, int a3, _DWORD *a4, int a5, int playerid) { return 0; }
+BOOL __fastcall SelIPX_1000C634(int a1, int a2, int a3, DWORD *a4, int a5, int playerid) { return 0; }
 /* {
 	int v6; // esi
 
@@ -31,7 +31,7 @@ BOOL __fastcall SelIPX_1000C634(int a1, int a2, int a3, _DWORD *a4, int a5, int 
 	artfont_100010C8();
 	return v6 == 1;
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002A49C: using guessed type int dword_1002A49C;
 // 1002A4A8: using guessed type int gnIpxPlayerid;
 // 1002A4AC: using guessed type int dword_1002A4AC;
@@ -105,7 +105,7 @@ LABEL_35:
 			{
 				SelIPX_1000D3C5(hWnd, (int)&savedregs);
 			}
-			else if ( (_WORD)wParam == 2 )
+			else if ( (WORD)wParam == 2 )
 			{
 				SelIPX_1000D3A0((int)hWnd, 2);
 			}
@@ -119,8 +119,8 @@ LABEL_12:
 	}
 	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
 } */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x1000C818
 LONG __fastcall SelIPX_1000C818(HWND hDlg, int nIDDlgItem) { return 0; }
@@ -151,11 +151,11 @@ LONG __fastcall SelIPX_1000C818(HWND hDlg, int nIDDlgItem) { return 0; }
 	result = GetWindowLongA(v3, -21);
 	if ( result )
 	{
-		result = *(_DWORD *)(result + 12);
+		result = *(DWORD *)(result + 12);
 		if ( result )
 		{
 			v5 = (const char *)(result + 140);
-			if ( *(_DWORD *)(result + 4) )
+			if ( *(DWORD *)(result + 4) )
 			{
 				if ( result == -140 || strlen((const char *)(result + 140)) < 0x10 )
 				{
@@ -212,8 +212,8 @@ int SelIPX_1000C99F() { return 0; }
 /* {
 	HWND v0; // eax
 	LONG v1; // eax
-	_DWORD *v2; // ecx
-	_DWORD *v3; // eax
+	DWORD *v2; // ecx
+	DWORD *v3; // eax
 	int v5; // edx
 
 	v0 = GetFocus();
@@ -222,10 +222,10 @@ int SelIPX_1000C99F() { return 0; }
 	v1 = GetWindowLongA(v0, -21);
 	if ( !v1 )
 		return 0;
-	v2 = (_DWORD *)dword_1002A4B4;
+	v2 = (DWORD *)dword_1002A4B4;
 	if ( !dword_1002A4B4 )
 		return 0;
-	v3 = *(_DWORD **)(v1 + 12);
+	v3 = *(DWORD **)(v1 + 12);
 	if ( !v3 )
 		return 0;
 	v5 = 0;
@@ -233,7 +233,7 @@ int SelIPX_1000C99F() { return 0; }
 	{
 		if ( v2 == v3 )
 			break;
-		v2 = (_DWORD *)*v2;
+		v2 = (DWORD *)*v2;
 		++v5;
 	}
 	while ( v2 );
@@ -253,9 +253,9 @@ const char *UNKCALL SelIPX_1000C9DA(HWND hDlg) { return 0; }
 
 	v1 = hDlg;
 	dword_1002A4B0 = 0;
-	SelIPX_1000CA64((_DWORD *)dword_1002A4B4);
+	SelIPX_1000CA64((DWORD *)dword_1002A4B4);
 	SNetEnumGames(0, 0, SelIPX_1000CAD5, 0);
-	result = (const char *)SelIPX_1000CA71((_DWORD *)dword_1002A4B4);
+	result = (const char *)SelIPX_1000CA71((DWORD *)dword_1002A4B4);
 	dword_1002A4B4 = (int)result;
 	if ( dword_1002A4B0 )
 	{
@@ -270,46 +270,46 @@ const char *UNKCALL SelIPX_1000C9DA(HWND hDlg) { return 0; }
 	}
 	return result;
 } */
-// 10010436: using guessed type int __stdcall SNetEnumGames(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010436: using guessed type int __stdcall SNetEnumGames(DWORD, DWORD, DWORD, DWORD);
 // 1002A4B0: using guessed type int dword_1002A4B0;
 // 1002A4B4: using guessed type int dword_1002A4B4;
 
 // ref: 0x1000CA64
-void __fastcall SelIPX_1000CA64(_DWORD *a1) { return; }
+void __fastcall SelIPX_1000CA64(DWORD *a1) { return; }
 /* {
 	while ( a1 )
 	{
 		a1[2] = 0;
-		a1 = (_DWORD *)*a1;
+		a1 = (DWORD *)*a1;
 	}
 } */
 
 // ref: 0x1000CA71
-_DWORD **__fastcall SelIPX_1000CA71(_DWORD *a1) { return 0; }
+DWORD **__fastcall SelIPX_1000CA71(DWORD *a1) { return 0; }
 /* {
-	_DWORD **v1; // edi
-	_DWORD *v2; // esi
+	DWORD **v1; // edi
+	DWORD *v2; // esi
 
-	v1 = (_DWORD **)a1;
+	v1 = (DWORD **)a1;
 	v2 = 0;
 	while ( a1 )
 	{
 		if ( a1[2] || !a1[1] )
 		{
 			v2 = a1;
-			a1 = (_DWORD *)*a1;
+			a1 = (DWORD *)*a1;
 		}
 		else
 		{
 			if ( v2 )
 				*v2 = *a1;
 			else
-				v1 = (_DWORD **)*a1;
+				v1 = (DWORD **)*a1;
 			SelIPX_1000CAC1(a1);
 			--dword_1002A4B8;
 			dword_1002A4B0 = 1;
 			if ( v2 )
-				a1 = (_DWORD *)*v2;
+				a1 = (DWORD *)*v2;
 			else
 				a1 = *v1;
 		}
@@ -327,17 +327,17 @@ int UNKCALL SelIPX_1000CAC1(void *arg) { return 0; }
 		result = SMemFree(arg, "C:\\Src\\Diablo\\DiabloUI\\SelIPX.cpp", 110, 0);
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000CAD5
 void *__stdcall SelIPX_1000CAD5(int a1, char *a2, char *a3) { return 0; }
 /* {
-	_DWORD *v3; // eax
+	DWORD *v3; // eax
 	int result; // eax
 	int v5; // esi
-	_DWORD *v6; // eax
+	DWORD *v6; // eax
 
-	v3 = SelIPX_1000CB73((_DWORD *)dword_1002A4B4, a1);
+	v3 = SelIPX_1000CB73((DWORD *)dword_1002A4B4, a1);
 	if ( v3 )
 	{
 		v3[2] = 1;
@@ -348,12 +348,12 @@ void *__stdcall SelIPX_1000CAD5(int a1, char *a2, char *a3) { return 0; }
 		v5 = result;
 		if ( !result )
 			return result;
-		*(_DWORD *)result = 0;
-		*(_DWORD *)(result + 4) = a1;
-		*(_DWORD *)(result + 8) = 1;
+		*(DWORD *)result = 0;
+		*(DWORD *)(result + 4) = a1;
+		*(DWORD *)(result + 8) = 1;
 		strcpy((char *)(result + 12), a2);
 		strcpy((char *)(v5 + 140), a3);
-		v6 = SelIPX_1000CB50((_DWORD *)dword_1002A4B4, (_DWORD *)v5);
+		v6 = SelIPX_1000CB50((DWORD *)dword_1002A4B4, (DWORD *)v5);
 		++dword_1002A4B8;
 		dword_1002A4B4 = (int)v6;
 		dword_1002A4B0 = 1;
@@ -364,15 +364,15 @@ void *__stdcall SelIPX_1000CAD5(int a1, char *a2, char *a3) { return 0; }
 // 1002A4B4: using guessed type int dword_1002A4B4;
 
 // ref: 0x1000CB50
-_DWORD *__fastcall SelIPX_1000CB50(_DWORD *a1, _DWORD *a2) { return 0; }
+DWORD *__fastcall SelIPX_1000CB50(DWORD *a1, DWORD *a2) { return 0; }
 /* {
-	_DWORD *result; // eax
-	_DWORD *v3; // edi
-	_DWORD *i; // esi
+	DWORD *result; // eax
+	DWORD *v3; // edi
+	DWORD *i; // esi
 
 	result = a1;
 	v3 = 0;
-	for ( i = a1; i; i = (_DWORD *)*i )
+	for ( i = a1; i; i = (DWORD *)*i )
 		v3 = i;
 	*a2 = i;
 	if ( !v3 )
@@ -382,11 +382,11 @@ _DWORD *__fastcall SelIPX_1000CB50(_DWORD *a1, _DWORD *a2) { return 0; }
 } */
 
 // ref: 0x1000CB73
-_DWORD *__fastcall SelIPX_1000CB73(_DWORD *a1, int a2) { return 0; }
+DWORD *__fastcall SelIPX_1000CB73(DWORD *a1, int a2) { return 0; }
 /* {
-	_DWORD *result; // eax
+	DWORD *result; // eax
 
-	for ( result = a1; result && result[1] != a2; result = (_DWORD *)*result )
+	for ( result = a1; result && result[1] != a2; result = (DWORD *)*result )
 		;
 	return result;
 } */
@@ -419,7 +419,7 @@ int __fastcall SelIPX_1000CB83(HWND a1, const char *a2) { return 0; }
 					v6 = GetWindowLongA(v4, -21);
 					if ( v6 )
 					{
-						*(_DWORD *)(v6 + 12) = v8;
+						*(DWORD *)(v6 + 12) = v8;
 						local_10007FA4(v6, v8 + 12);
 					}
 					v8 = *(const char **)v8;
@@ -432,7 +432,7 @@ int __fastcall SelIPX_1000CB83(HWND a1, const char *a2) { return 0; }
 					v5 = GetWindowLongA(v4, -21);
 					if ( v5 )
 					{
-						*(_DWORD *)(v5 + 12) = 0;
+						*(DWORD *)(v5 + 12) = 0;
 						local_10007FA4(v5, &byte_10029448);
 					}
 				}
@@ -449,10 +449,10 @@ int __fastcall SelIPX_1000CB83(HWND a1, const char *a2) { return 0; }
 int UNKCALL SelIPX_1000CC41(HWND hDlg) { return 0; }
 /* {
 	HWND v1; // esi
-	_DWORD *v2; // eax
+	DWORD *v2; // eax
 
 	v1 = hDlg;
-	SelIPX_1000CCC5((_DWORD *)dword_1002A4B4);
+	SelIPX_1000CCC5((DWORD *)dword_1002A4B4);
 	dword_1002A4B4 = 0;
 	Sbar_10009CD2(v1, 1105);
 	Doom_10006C53(v1, &dword_10023118);
@@ -460,27 +460,27 @@ int UNKCALL SelIPX_1000CC41(HWND hDlg) { return 0; }
 	Doom_10006C53(v1, (int *)&unk_10023104);
 	Doom_10006C53(v1, (int *)&unk_100230FC);
 	Doom_10006C53(v1, (int *)&unk_100230F0);
-	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	v2 = (DWORD *)GetWindowLongA(v1, -21);
 	local_10007F72(v2);
 	Title_100100E7(v1);
 	Focus_10007818(v1);
 	return SDrawClearSurface();
 } */
-// 1001043C: using guessed type _DWORD __stdcall SDrawClearSurface();
+// 1001043C: using guessed type DWORD __stdcall SDrawClearSurface();
 // 10023118: using guessed type int dword_10023118;
 // 1002A4B4: using guessed type int dword_1002A4B4;
 
 // ref: 0x1000CCC5
-int __fastcall SelIPX_1000CCC5(_DWORD *a1) { return 0; }
+int __fastcall SelIPX_1000CCC5(DWORD *a1) { return 0; }
 /* {
-	_DWORD *v1; // esi
+	DWORD *v1; // esi
 	int result; // eax
 
 	if ( a1 )
 	{
 		do
 		{
-			v1 = (_DWORD *)*a1;
+			v1 = (DWORD *)*a1;
 			result = SelIPX_1000CAC1(a1);
 			a1 = v1;
 		}
@@ -564,9 +564,9 @@ HWND UNKCALL SelIPX_1000CD4A(HWND hWnd) { return 0; }
 	if ( v6 )
 	{
 		++dword_1002A4B8;
-		*(_DWORD *)(v6 + 4) = 0;
-		*(_BYTE *)(dword_1002A4B4 + 140) = 0;
-		*(_DWORD *)dword_1002A4B4 = 0;
+		*(DWORD *)(v6 + 4) = 0;
+		*(BYTE *)(dword_1002A4B4 + 140) = 0;
+		*(DWORD *)dword_1002A4B4 = 0;
 		LoadStringA(hInstance, 0x24u, (LPSTR)(dword_1002A4B4 + 12), 127);
 		LoadStringA(hInstance, 0x2Au, (LPSTR)(dword_1002A4B4 + 140), 127);
 	}
@@ -581,8 +581,8 @@ HWND UNKCALL SelIPX_1000CD4A(HWND hWnd) { return 0; }
 	}
 	return result;
 } */
-// 10010412: using guessed type int __stdcall SDlgSetTimer(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010436: using guessed type int __stdcall SNetEnumGames(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010412: using guessed type int __stdcall SDlgSetTimer(DWORD, DWORD, DWORD, DWORD);
+// 10010436: using guessed type int __stdcall SNetEnumGames(DWORD, DWORD, DWORD, DWORD);
 // 10023118: using guessed type int dword_10023118;
 // 1002A4B4: using guessed type int dword_1002A4B4;
 
@@ -746,7 +746,7 @@ HWND UNKCALL SelIPX_1000D0E1(HWND hWnd) { return 0; }
 	HWND v3; // esi
 	HWND v4; // ebx
 	HWND v5; // eax
-	_DWORD *v6; // eax
+	DWORD *v6; // eax
 	int v7; // eax
 	const char *v8; // ebx
 	int v9; // eax
@@ -764,7 +764,7 @@ HWND UNKCALL SelIPX_1000D0E1(HWND hWnd) { return 0; }
 			result = (HWND)GetWindowLongA(v5, -21);
 			if ( result )
 			{
-				v6 = (_DWORD *)*((_DWORD *)result + 3);
+				v6 = (DWORD *)*((DWORD *)result + 3);
 				if ( v6 && *v6 )
 				{
 					v7 = SelIPX_1000D18C(v4) + 6;
@@ -795,8 +795,8 @@ HWND UNKCALL SelIPX_1000D0E1(HWND hWnd) { return 0; }
 int UNKCALL SelIPX_1000D18C(HWND hWnd) { return 0; }
 /* {
 	LONG v1; // eax
-	_DWORD *v2; // ecx
-	_DWORD *v3; // eax
+	DWORD *v2; // ecx
+	DWORD *v3; // eax
 	int v5; // edx
 
 	if ( !hWnd )
@@ -804,10 +804,10 @@ int UNKCALL SelIPX_1000D18C(HWND hWnd) { return 0; }
 	v1 = GetWindowLongA(hWnd, -21);
 	if ( !v1 )
 		return 0;
-	v2 = (_DWORD *)dword_1002A4B4;
+	v2 = (DWORD *)dword_1002A4B4;
 	if ( !dword_1002A4B4 )
 		return 0;
-	v3 = *(_DWORD **)(v1 + 12);
+	v3 = *(DWORD **)(v1 + 12);
 	if ( !v3 )
 		return 0;
 	v5 = 0;
@@ -815,7 +815,7 @@ int UNKCALL SelIPX_1000D18C(HWND hWnd) { return 0; }
 	{
 		if ( v2 == v3 )
 			break;
-		v2 = (_DWORD *)*v2;
+		v2 = (DWORD *)*v2;
 		++v5;
 	}
 	while ( v2 );
@@ -824,14 +824,14 @@ int UNKCALL SelIPX_1000D18C(HWND hWnd) { return 0; }
 // 1002A4B4: using guessed type int dword_1002A4B4;
 
 // ref: 0x1000D1C1
-_DWORD *__fastcall SelIPX_1000D1C1(int a1) { return 0; }
+DWORD *__fastcall SelIPX_1000D1C1(int a1) { return 0; }
 /* {
-	_DWORD *result; // eax
+	DWORD *result; // eax
 
-	result = (_DWORD *)dword_1002A4B4;
+	result = (DWORD *)dword_1002A4B4;
 	while ( result && a1 )
 	{
-		result = (_DWORD *)*result;
+		result = (DWORD *)*result;
 		--a1;
 	}
 	return result;
@@ -862,7 +862,7 @@ HWND UNKCALL SelIPX_1000D1D4(HWND hWnd) { return 0; }
 			result = (HWND)GetWindowLongA(result, -21);
 			if ( result )
 			{
-				result = (HWND)*((_DWORD *)result + 3);
+				result = (HWND)*((DWORD *)result + 3);
 				if ( result )
 				{
 					if ( result == (HWND)dword_1002A4B4 )
@@ -910,10 +910,10 @@ HWND UNKCALL SelIPX_1000D284(HWND hWnd) { return 0; }
 	result = (HWND)GetWindowLongA(hWnd, -21);
 	if ( result )
 	{
-		result = (HWND)*((_DWORD *)result + 3);
+		result = (HWND)*((DWORD *)result + 3);
 		if ( result )
 		{
-			if ( *(_DWORD *)result )
+			if ( *(DWORD *)result )
 			{
 				if ( GetWindowLongA(v1, -12) >= 1093 )
 				{
@@ -924,7 +924,7 @@ HWND UNKCALL SelIPX_1000D284(HWND hWnd) { return 0; }
 						result = (HWND)GetWindowLongA(result, -21);
 						if ( result )
 						{
-							v4 = (const char *)*((_DWORD *)result + 3);
+							v4 = (const char *)*((DWORD *)result + 3);
 							if ( v4 )
 							{
 								TitleSnd_10010315();
@@ -966,7 +966,7 @@ HWND UNKCALL SelIPX_1000D31C(HWND hWnd) { return 0; }
 	result = (HWND)GetWindowLongA(v1, -21);
 	if ( result )
 	{
-		result = (HWND)*((_DWORD *)result + 3);
+		result = (HWND)*((DWORD *)result + 3);
 		if ( result )
 		{
 			v3 = (const char *)dword_1002A4B4;
@@ -1002,8 +1002,8 @@ int __fastcall SelIPX_1000D3A0(int a1, int a2) { return 0; }
 	Fade_100072BE(10);
 	return SDlgEndDialog(v3, v2);
 } */
-// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
-// 10010418: using guessed type int __stdcall SDlgKillTimer(_DWORD, _DWORD);
+// 10010376: using guessed type int __stdcall SDlgEndDialog(DWORD, DWORD);
+// 10010418: using guessed type int __stdcall SDlgKillTimer(DWORD, DWORD);
 
 // ref: 0x1000D3C5
 HWND USERCALL SelIPX_1000D3C5(HWND hDlg, int a2) { return 0; }
@@ -1034,9 +1034,9 @@ HWND USERCALL SelIPX_1000D3C5(HWND hDlg, int a2) { return 0; }
 		result = (HWND)GetWindowLongA(v4, -21);
 		if ( result )
 		{
-			v6 = *((_DWORD *)result + 3);
+			v6 = *((DWORD *)result + 3);
 			TitleSnd_1001031F();
-			if ( *(_DWORD *)(v6 + 4) )
+			if ( *(DWORD *)(v6 + 4) )
 			{
 				result = (HWND)SelIPX_1000D5B0((int)v2, v6);
 			}
@@ -1051,7 +1051,7 @@ HWND USERCALL SelIPX_1000D3C5(HWND hDlg, int a2) { return 0; }
 				memset(&v13, 0, 0x10u);
 				v13 = 16;
 				v14 = 1230002254;
-				v8 = *(_DWORD *)(dword_1002A4AC + 24);
+				v8 = *(DWORD *)(dword_1002A4AC + 24);
 				v16 = 0;
 				v15 = v8;
 				v9 = GetFocus();
@@ -1168,7 +1168,7 @@ int __fastcall SelIPX_1000D5B0(int a1, int a2) { return 0; }
 	Connect_10004028((int)&v9, 128, (int)&v7, 128);
 	if ( UiAuthCallback(2, (int)&v9, &v7, 0, (char *)(v2 + 140), &v6, 256) )
 	{
-		if ( SNetJoinGame(*(_DWORD *)(v2 + 4), v2 + 12, 0, &v9, &v7, gnIpxPlayerid) )
+		if ( SNetJoinGame(*(DWORD *)(v2 + 4), v2 + 12, 0, &v9, &v7, gnIpxPlayerid) )
 			return SelIPX_1000D3A0(v10, 1);
 		if ( SErrGetLastError() == -2062548871 )
 			LoadStringA(hInstance, 0x32u, &Buffer, 127);
@@ -1183,8 +1183,8 @@ int __fastcall SelIPX_1000D5B0(int a1, int a2) { return 0; }
 	}
 	return SelYesNo_1000FD39(v10, v3, 0, 0);
 } */
-// 10010406: using guessed type _DWORD __stdcall SErrGetLastError();
-// 10010430: using guessed type int __stdcall SNetJoinGame(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 10010406: using guessed type DWORD __stdcall SErrGetLastError();
+// 10010430: using guessed type int __stdcall SNetJoinGame(DWORD, DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002A4A8: using guessed type int gnIpxPlayerid;
 
 // ref: 0x1000D696

--- a/DiabloUI/sellist.cpp
+++ b/DiabloUI/sellist.cpp
@@ -42,9 +42,9 @@ LRESULT __stdcall SelList_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		}
 		if (HIWORD(wParam) != 6) {
 			v6 = 1;
-			if (HIWORD(wParam) != 5 && (_WORD)wParam != 1) {
+			if (HIWORD(wParam) != 5 && (WORD)wParam != 1) {
 				v6 = 2;
-				if ((_WORD)wParam != 2)
+				if ((WORD)wParam != 2)
 					return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 			}
 		LABEL_25:
@@ -61,7 +61,7 @@ LRESULT __stdcall SelList_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 		SelList_DeleteFreeProcs(hWnd);
 		return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 	case 6u:
-		if ((_WORD)wParam == 1 || (_WORD)wParam == 2)
+		if ((WORD)wParam == 1 || (WORD)wParam == 2)
 			SelList_LoadFocus16(hWnd);
 		else
 			SelList_KillFocus16(hWnd);
@@ -87,7 +87,7 @@ LRESULT __stdcall SelList_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 	SelList_ShowListWindow(hWnd);
 	return 0;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x1000D916
 void __fastcall SelList_DeleteFreeProcs(HWND hWnd)
@@ -265,7 +265,7 @@ void __fastcall SelList_SetHeroDlgLong(HWND hWnd, _uiheroinfo *pInfo)
 				v6 = GetWindowLongA(v4, -21);
 				local_SetWndLongStr(v6, pInfo->name);
 				if (v6)
-					*(_DWORD *)(v6 + 12) = (unsigned int)pInfo;
+					*(DWORD *)(v6 + 12) = (unsigned int)pInfo;
 				pInfo                    = pInfo->next;
 			} else {
 				EnableWindow(v4, 0);

--- a/DiabloUI/selload.cpp
+++ b/DiabloUI/selload.cpp
@@ -50,9 +50,9 @@ LRESULT __stdcall SelLoad_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 	} else {
 		if (HIWORD(wParam) != 6) {
 			v5 = 1;
-			if (HIWORD(wParam) == 5 || (_WORD)wParam == 1)
+			if (HIWORD(wParam) == 5 || (WORD)wParam == 1)
 				goto LABEL_19;
-			if ((_WORD)wParam != 2)
+			if ((WORD)wParam != 2)
 				return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 			goto LABEL_21;
 		}
@@ -61,7 +61,7 @@ LRESULT __stdcall SelLoad_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPa
 	}
 	return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x1000E30E
 void __fastcall SelLoad_DeleteProcsAndSpin(HWND hWnd)

--- a/DiabloUI/selmodem.cpp
+++ b/DiabloUI/selmodem.cpp
@@ -28,7 +28,7 @@ int __fastcall SelModem_1000E435(void *a1, int a2, int a3, char *a4, char *a5) {
 		return SelModem_1000E51E();
 	return SelModem_1000E5CC();
 } */
-// 10010496: using guessed type int __stdcall SNetEnumDevices(_DWORD);
+// 10010496: using guessed type int __stdcall SNetEnumDevices(DWORD);
 // 1002A4D0: using guessed type int dword_1002A4D0;
 // 1002A4DC: using guessed type int dword_1002A4DC;
 // 1002A4E0: using guessed type int dword_1002A4E0;
@@ -39,17 +39,17 @@ char *__stdcall SelModem_1000E497(int a1, char *a2, char *a3) { return 0; }
 /* {
 	int result; // eax
 	int v4; // esi
-	_DWORD *v5; // eax
+	DWORD *v5; // eax
 
 	result = SelModem_1000E4EC();
 	v4 = result;
 	if ( result )
 	{
-		*(_DWORD *)result = 0;
-		*(_DWORD *)(result + 4) = a1;
+		*(DWORD *)result = 0;
+		*(DWORD *)(result + 4) = a1;
 		strcpy((char *)(result + 8), a2);
 		strcpy((char *)(v4 + 136), a3);
-		v5 = SelModem_1000E500(dword_1002A4DC, (_DWORD *)v4);
+		v5 = SelModem_1000E500(dword_1002A4DC, (DWORD *)v4);
 		++dword_1002A4D8;
 		dword_1002A4DC = (int)v5;
 		result = 1;
@@ -63,12 +63,12 @@ void *SelModem_1000E4EC() { return 0; }
 /* {
 	return SMemAlloc(264, "C:\\Src\\Diablo\\DiabloUI\\SelModem.cpp", 72, 0);
 } */
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000E500
-_DWORD *__fastcall SelModem_1000E500(int a1, _DWORD *a2) { return 0; }
+DWORD *__fastcall SelModem_1000E500(int a1, DWORD *a2) { return 0; }
 /* {
-	_DWORD *result; // eax
+	DWORD *result; // eax
 
 	result = a2;
 	*a2 = a1;
@@ -83,16 +83,16 @@ signed int UNKCALL SelModem_1000E505(void *arg) { return 0; }
 	SErrSetLastError(1222);
 	return 0;
 } */
-// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 1001041E: using guessed type int __stdcall SErrSetLastError(DWORD);
 
 // ref: 0x1000E51E
 signed int SelModem_1000E51E() { return 0; }
 /* {
 	signed int result; // eax
 
-	if ( SelModem_1000E57B(*((_DWORD *)dword_1002A4D4 + 2), *(_DWORD *)(dword_1002A4DC + 4)) )
+	if ( SelModem_1000E57B(*((DWORD *)dword_1002A4D4 + 2), *(DWORD *)(dword_1002A4DC + 4)) )
 	{
-		SelModem_1000E553((_DWORD *)dword_1002A4DC);
+		SelModem_1000E553((DWORD *)dword_1002A4DC);
 		result = 1;
 	}
 	else
@@ -102,20 +102,20 @@ signed int SelModem_1000E51E() { return 0; }
 	}
 	return result;
 } */
-// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 1001041E: using guessed type int __stdcall SErrSetLastError(DWORD);
 // 1002A4DC: using guessed type int dword_1002A4DC;
 
 // ref: 0x1000E553
-int __fastcall SelModem_1000E553(_DWORD *a1) { return 0; }
+int __fastcall SelModem_1000E553(DWORD *a1) { return 0; }
 /* {
-	_DWORD *v1; // esi
+	DWORD *v1; // esi
 	int result; // eax
 
 	if ( a1 )
 	{
 		do
 		{
-			v1 = (_DWORD *)*a1;
+			v1 = (DWORD *)*a1;
 			result = SelModem_1000E567(a1);
 			a1 = v1;
 		}
@@ -133,7 +133,7 @@ int UNKCALL SelModem_1000E567(void *arg) { return 0; }
 		result = SMemFree(arg, "C:\\Src\\Diablo\\DiabloUI\\SelModem.cpp", 77, 0);
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000E57B
 int __fastcall SelModem_1000E57B(int a1, int a2) { return 0; }
@@ -152,7 +152,7 @@ int __fastcall SelModem_1000E57B(int a1, int a2) { return 0; }
 	v6 = v3;
 	return SNetInitializeDevice(v2, dword_1002A4E0, dword_1002A4E8, &v5, dword_1002A4D0);
 } */
-// 1001049C: using guessed type int __stdcall SNetInitializeDevice(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
+// 1001049C: using guessed type int __stdcall SNetInitializeDevice(DWORD, DWORD, DWORD, DWORD, DWORD);
 // 1002A4D0: using guessed type int dword_1002A4D0;
 // 1002A4E0: using guessed type int dword_1002A4E0;
 // 1002A4E8: using guessed type int dword_1002A4E8;
@@ -164,26 +164,26 @@ signed int SelModem_1000E5CC() { return 0; }
 	signed int result; // eax
 
 	v0 = 1;
-	if ( SDlgDialogBoxParam(hInstance, "SELMODEM_DIALOG", *((_DWORD *)dword_1002A4D4 + 2), SelModem_1000E63E, 0) == 1 )
+	if ( SDlgDialogBoxParam(hInstance, "SELMODEM_DIALOG", *((DWORD *)dword_1002A4D4 + 2), SelModem_1000E63E, 0) == 1 )
 	{
-		if ( !SelModem_1000E57B(*((_DWORD *)dword_1002A4D4 + 2), dword_1002A4E4) )
+		if ( !SelModem_1000E57B(*((DWORD *)dword_1002A4D4 + 2), dword_1002A4E4) )
 		{
 			SErrSetLastError(-2062548879);
 			v0 = 0;
 		}
-		SelModem_1000E553((_DWORD *)dword_1002A4DC);
+		SelModem_1000E553((DWORD *)dword_1002A4DC);
 		result = v0;
 	}
 	else
 	{
-		SelModem_1000E553((_DWORD *)dword_1002A4DC);
+		SelModem_1000E553((DWORD *)dword_1002A4DC);
 		SErrSetLastError(1223);
 		result = 0;
 	}
 	return result;
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
-// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
+// 1001041E: using guessed type int __stdcall SErrSetLastError(DWORD);
 // 1002A4DC: using guessed type int dword_1002A4DC;
 // 1002A4E4: using guessed type int dword_1002A4E4;
 
@@ -254,7 +254,7 @@ LABEL_25:
 		v4 = 1;
 		if ( wParam != 327681 )
 		{
-			if ( (_WORD)wParam != 2 )
+			if ( (WORD)wParam != 2 )
 				return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
 			v4 = 2;
 		}
@@ -262,14 +262,14 @@ LABEL_25:
 	}
 	return SDlgDefDialogProc(hDlg, Msg, wParam, lParam);
 } */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x1000E783
 void UNKCALL SelModem_1000E783(HWND hDlg) { return; }
 /* {
 	HWND v1; // esi
-	_DWORD *v2; // eax
+	DWORD *v2; // eax
 
 	v1 = hDlg;
 	Sbar_10009CD2(hDlg, 1105);
@@ -280,7 +280,7 @@ void UNKCALL SelModem_1000E783(HWND hDlg) { return; }
 	Doom_10006C53(v1, (int *)&unk_100231E0);
 	Focus_10007818(v1);
 	local_1000811B();
-	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	v2 = (DWORD *)GetWindowLongA(v1, -21);
 	local_10007F72(v2);
 } */
 // 100231F4: using guessed type int dword_100231F4;
@@ -302,8 +302,8 @@ HWND UNKCALL SelModem_1000E7E9(HWND hDlg) { return 0; }
 int UNKCALL SelModem_1000E80E(HWND hWnd) { return 0; }
 /* {
 	LONG v1; // eax
-	_DWORD *v2; // ecx
-	_DWORD *v3; // eax
+	DWORD *v2; // ecx
+	DWORD *v3; // eax
 	int v5; // edx
 
 	if ( !hWnd )
@@ -311,10 +311,10 @@ int UNKCALL SelModem_1000E80E(HWND hWnd) { return 0; }
 	v1 = GetWindowLongA(hWnd, -21);
 	if ( !v1 )
 		return 0;
-	v2 = (_DWORD *)dword_1002A4DC;
+	v2 = (DWORD *)dword_1002A4DC;
 	if ( !dword_1002A4DC )
 		return 0;
-	v3 = *(_DWORD **)(v1 + 12);
+	v3 = *(DWORD **)(v1 + 12);
 	if ( !v3 )
 		return 0;
 	v5 = 0;
@@ -322,7 +322,7 @@ int UNKCALL SelModem_1000E80E(HWND hWnd) { return 0; }
 	{
 		if ( v2 == v3 )
 			break;
-		v2 = (_DWORD *)*v2;
+		v2 = (DWORD *)*v2;
 		++v5;
 	}
 	while ( v2 );
@@ -398,7 +398,7 @@ int __fastcall SelModem_1000E932(HWND a1, const char *a2) { return 0; }
 					v6 = GetWindowLongA(v5, -21);
 					local_10007FA4(v6, v2 + 8);
 					if ( v6 )
-						*(_DWORD *)(v6 + 12) = v2;
+						*(DWORD *)(v6 + 12) = v2;
 					v2 = *(const char **)v2;
 				}
 				else
@@ -590,7 +590,7 @@ HWND UNKCALL SelModem_1000EC0E(HWND hWnd) { return 0; }
 	HWND v2; // edi
 	HWND v3; // ebx
 	HWND v4; // eax
-	_DWORD *v5; // eax
+	DWORD *v5; // eax
 	int v6; // eax
 	const char *v7; // esi
 
@@ -606,7 +606,7 @@ HWND UNKCALL SelModem_1000EC0E(HWND hWnd) { return 0; }
 			result = (HWND)GetWindowLongA(v4, -21);
 			if ( result )
 			{
-				v5 = (_DWORD *)*((_DWORD *)result + 3);
+				v5 = (DWORD *)*((DWORD *)result + 3);
 				if ( v5 && *v5 )
 				{
 					v6 = SelModem_1000E80E(v3) + 6;
@@ -632,14 +632,14 @@ HWND UNKCALL SelModem_1000EC0E(HWND hWnd) { return 0; }
 } */
 
 // ref: 0x1000EC9F
-_DWORD *__fastcall SelModem_1000EC9F(int a1) { return 0; }
+DWORD *__fastcall SelModem_1000EC9F(int a1) { return 0; }
 /* {
-	_DWORD *result; // eax
+	DWORD *result; // eax
 
-	result = (_DWORD *)dword_1002A4DC;
+	result = (DWORD *)dword_1002A4DC;
 	while ( result && a1 )
 	{
-		result = (_DWORD *)*result;
+		result = (DWORD *)*result;
 		--a1;
 	}
 	return result;
@@ -667,7 +667,7 @@ HWND UNKCALL SelModem_1000ECB2(HWND hWnd) { return 0; }
 			result = (HWND)GetWindowLongA(result, -21);
 			if ( result )
 			{
-				result = (HWND)*((_DWORD *)result + 3);
+				result = (HWND)*((DWORD *)result + 3);
 				if ( result )
 				{
 					if ( result == (HWND)dword_1002A4DC )
@@ -711,10 +711,10 @@ HWND UNKCALL SelModem_1000ED3B(HWND hWnd) { return 0; }
 	result = (HWND)GetWindowLongA(hWnd, -21);
 	if ( result )
 	{
-		result = (HWND)*((_DWORD *)result + 3);
+		result = (HWND)*((DWORD *)result + 3);
 		if ( result )
 		{
-			if ( *(_DWORD *)result )
+			if ( *(DWORD *)result )
 			{
 				if ( GetWindowLongA(v1, -12) >= 1115 )
 				{
@@ -725,7 +725,7 @@ HWND UNKCALL SelModem_1000ED3B(HWND hWnd) { return 0; }
 						result = (HWND)GetWindowLongA(result, -21);
 						if ( result )
 						{
-							v4 = (const char *)*((_DWORD *)result + 3);
+							v4 = (const char *)*((DWORD *)result + 3);
 							if ( v4 )
 							{
 								TitleSnd_10010315();
@@ -762,7 +762,7 @@ HWND UNKCALL SelModem_1000EDBC(HWND hWnd) { return 0; }
 	result = (HWND)GetWindowLongA(v1, -21);
 	if ( result )
 	{
-		result = (HWND)*((_DWORD *)result + 3);
+		result = (HWND)*((DWORD *)result + 3);
 		if ( result )
 		{
 			v3 = (const char *)dword_1002A4DC;
@@ -802,9 +802,9 @@ int __fastcall SelModem_1000EE29(int a1, int a2) { return 0; }
 			v5 = GetWindowLongA(v4, -21);
 			if ( v5 )
 			{
-				v6 = *(_DWORD *)(v5 + 12);
+				v6 = *(DWORD *)(v5 + 12);
 				if ( v6 )
-					dword_1002A4E4 = *(_DWORD *)(v6 + 4);
+					dword_1002A4E4 = *(DWORD *)(v6 + 4);
 			}
 		}
 	}
@@ -812,7 +812,7 @@ int __fastcall SelModem_1000EE29(int a1, int a2) { return 0; }
 	Fade_100072BE(10);
 	return SDlgEndDialog(v3, v2);
 } */
-// 10010376: using guessed type int __stdcall SDlgEndDialog(_DWORD, _DWORD);
+// 10010376: using guessed type int __stdcall SDlgEndDialog(DWORD, DWORD);
 // 1002A4E4: using guessed type int dword_1002A4E4;
 
 // ref: 0x1000EE78

--- a/DiabloUI/selregn.cpp
+++ b/DiabloUI/selregn.cpp
@@ -3,7 +3,7 @@ void *SelRegn_1000EF42() { return 0; }
 /* {
 	return SMemAlloc(136, "C:\\Src\\Diablo\\DiabloUI\\SelRegn.cpp", 76, 0);
 } */
-// 10010364: using guessed type int __stdcall SMemAlloc(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010364: using guessed type int __stdcall SMemAlloc(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000EF56
 _uiheroinfo *__fastcall SelRegn_SetNextHero(_uiheroinfo *pNext, _uiheroinfo *pCurrent)
@@ -88,7 +88,7 @@ LABEL_25:
 			{
 				SelRegn_1000F8DD(hWnd);
 			}
-			else if ( (_WORD)wParam == 2 )
+			else if ( (WORD)wParam == 2 )
 			{
 				SelConn_1000AC07((int)hWnd, 2);
 			}
@@ -102,8 +102,8 @@ LABEL_27:
 	}
 	return SDlgDefDialogProc(hWnd, Msg, wParam, lParam);
 } */
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x1000F0D7
 HWND __fastcall SelRegn_1000F0D7(HWND hDlg, int nIDDlgItem) { return 0; }
@@ -118,7 +118,7 @@ HWND __fastcall SelRegn_1000F0D7(HWND hDlg, int nIDDlgItem) { return 0; }
 		result = (HWND)GetWindowLongA(result, -21);
 		if ( result )
 		{
-			if ( *((_DWORD *)result + 3) )
+			if ( *((DWORD *)result + 3) )
 				result = (HWND)Doom_10006A13(v2, (int *)&unk_10023250, 1);
 		}
 	}
@@ -141,8 +141,8 @@ int SelRegn_1000F126() { return 0; }
 /* {
 	HWND v0; // eax
 	LONG v1; // eax
-	_DWORD *v2; // ecx
-	_DWORD *v3; // eax
+	DWORD *v2; // ecx
+	DWORD *v3; // eax
 	int v5; // edx
 
 	v0 = GetFocus();
@@ -151,10 +151,10 @@ int SelRegn_1000F126() { return 0; }
 	v1 = GetWindowLongA(v0, -21);
 	if ( !v1 )
 		return 0;
-	v2 = (_DWORD *)dword_1002A4EC;
+	v2 = (DWORD *)dword_1002A4EC;
 	if ( !dword_1002A4EC )
 		return 0;
-	v3 = *(_DWORD **)(v1 + 12);
+	v3 = *(DWORD **)(v1 + 12);
 	if ( !v3 )
 		return 0;
 	v5 = 0;
@@ -162,7 +162,7 @@ int SelRegn_1000F126() { return 0; }
 	{
 		if ( v2 == v3 )
 			break;
-		v2 = (_DWORD *)*v2;
+		v2 = (DWORD *)*v2;
 		++v5;
 	}
 	while ( v2 );
@@ -174,35 +174,35 @@ int SelRegn_1000F126() { return 0; }
 void UNKCALL SelRegn_1000F161(HWND hDlg) { return; }
 /* {
 	HWND v1; // esi
-	_DWORD *v2; // eax
+	DWORD *v2; // eax
 
 	v1 = hDlg;
 	Title_100100E7(hDlg);
 	Focus_10007818(v1);
 	Sbar_10009CD2(v1, 1105);
-	SelRegn_1000F1D4((_DWORD *)dword_1002A4EC);
+	SelRegn_1000F1D4((DWORD *)dword_1002A4EC);
 	Doom_10006C53(v1, &dword_1002326C);
 	Doom_10006C53(v1, (int *)&unk_10023260);
 	Doom_10006C53(v1, (int *)&unk_10023244);
 	Doom_10006C53(v1, (int *)&unk_10023258);
 	Doom_10006C53(v1, (int *)&unk_10023250);
-	v2 = (_DWORD *)GetWindowLongA(v1, -21);
+	v2 = (DWORD *)GetWindowLongA(v1, -21);
 	local_10007F72(v2);
 } */
 // 1002326C: using guessed type int dword_1002326C;
 // 1002A4EC: using guessed type int dword_1002A4EC;
 
 // ref: 0x1000F1D4
-int __fastcall SelRegn_1000F1D4(_DWORD *a1) { return 0; }
+int __fastcall SelRegn_1000F1D4(DWORD *a1) { return 0; }
 /* {
-	_DWORD *v1; // esi
+	DWORD *v1; // esi
 	int result; // eax
 
 	if ( a1 )
 	{
 		do
 		{
-			v1 = (_DWORD *)*a1;
+			v1 = (DWORD *)*a1;
 			result = SelRegn_1000F1E8(a1);
 			a1 = v1;
 		}
@@ -220,7 +220,7 @@ int UNKCALL SelRegn_1000F1E8(void *arg) { return 0; }
 		result = SMemFree(arg, "C:\\Src\\Diablo\\DiabloUI\\SelRegn.cpp", 82, 0);
 	return result;
 } */
-// 10010340: using guessed type int __stdcall SMemFree(_DWORD, _DWORD, _DWORD, _DWORD);
+// 10010340: using guessed type int __stdcall SMemFree(DWORD, DWORD, DWORD, DWORD);
 
 // ref: 0x1000F1FC
 HWND UNKCALL SelRegn_1000F1FC(HWND hWnd) { return 0; }
@@ -272,7 +272,7 @@ signed int SelRegn_1000F2ED() { return 0; }
 	char *v1; // eax
 	char *v2; // esi
 	const char *v3; // eax
-	_DWORD *v4; // eax
+	DWORD *v4; // eax
 
 	for ( i = dword_10029488; ; --i )
 	{
@@ -282,8 +282,8 @@ signed int SelRegn_1000F2ED() { return 0; }
 		v2 = v1;
 		if ( !v1 )
 			break;
-		*(_DWORD *)v1 = 0;
-		*((_DWORD *)v1 + 1) = i;
+		*(DWORD *)v1 = 0;
+		*((DWORD *)v1 + 1) = i;
 		v3 = BNetGW_10002B21(&unk_10029480, i);
 		strcpy(v2 + 8, v3);
 		v4 = SelRegn_1000EF56(dword_1002A4EC, v2);
@@ -322,7 +322,7 @@ int __fastcall SelRegn_1000F346(HWND a1, const char *a2) { return 0; }
 					v6 = GetWindowLongA(v5, -21);
 					if ( v6 )
 					{
-						*(_DWORD *)(v6 + 12) = v2;
+						*(DWORD *)(v6 + 12) = v2;
 						local_10007FA4(v6, v2 + 8);
 						v2 = *(const char **)v2;
 					}
@@ -517,7 +517,7 @@ HWND UNKCALL SelRegn_1000F61E(HWND hWnd) { return 0; }
 	HWND v3; // esi
 	HWND v4; // ebx
 	HWND v5; // eax
-	_DWORD *v6; // eax
+	DWORD *v6; // eax
 	int v7; // eax
 	const char *v8; // ebx
 	int v9; // eax
@@ -535,7 +535,7 @@ HWND UNKCALL SelRegn_1000F61E(HWND hWnd) { return 0; }
 			result = (HWND)GetWindowLongA(v5, -21);
 			if ( result )
 			{
-				v6 = (_DWORD *)*((_DWORD *)result + 3);
+				v6 = (DWORD *)*((DWORD *)result + 3);
 				if ( v6 && *v6 )
 				{
 					v7 = SelRegn_1000F6C9(v4) + 6;
@@ -566,8 +566,8 @@ HWND UNKCALL SelRegn_1000F61E(HWND hWnd) { return 0; }
 int UNKCALL SelRegn_1000F6C9(HWND hWnd) { return 0; }
 /* {
 	LONG v1; // eax
-	_DWORD *v2; // ecx
-	_DWORD *v3; // eax
+	DWORD *v2; // ecx
+	DWORD *v3; // eax
 	int v5; // edx
 
 	if ( !hWnd )
@@ -575,10 +575,10 @@ int UNKCALL SelRegn_1000F6C9(HWND hWnd) { return 0; }
 	v1 = GetWindowLongA(hWnd, -21);
 	if ( !v1 )
 		return 0;
-	v2 = (_DWORD *)dword_1002A4EC;
+	v2 = (DWORD *)dword_1002A4EC;
 	if ( !dword_1002A4EC )
 		return 0;
-	v3 = *(_DWORD **)(v1 + 12);
+	v3 = *(DWORD **)(v1 + 12);
 	if ( !v3 )
 		return 0;
 	v5 = 0;
@@ -586,7 +586,7 @@ int UNKCALL SelRegn_1000F6C9(HWND hWnd) { return 0; }
 	{
 		if ( v2 == v3 )
 			break;
-		v2 = (_DWORD *)*v2;
+		v2 = (DWORD *)*v2;
 		++v5;
 	}
 	while ( v2 );
@@ -595,14 +595,14 @@ int UNKCALL SelRegn_1000F6C9(HWND hWnd) { return 0; }
 // 1002A4EC: using guessed type int dword_1002A4EC;
 
 // ref: 0x1000F6FE
-_DWORD *__fastcall SelRegn_1000F6FE(int a1) { return 0; }
+DWORD *__fastcall SelRegn_1000F6FE(int a1) { return 0; }
 /* {
-	_DWORD *result; // eax
+	DWORD *result; // eax
 
-	result = (_DWORD *)dword_1002A4EC;
+	result = (DWORD *)dword_1002A4EC;
 	while ( result && a1 )
 	{
-		result = (_DWORD *)*result;
+		result = (DWORD *)*result;
 		--a1;
 	}
 	return result;
@@ -633,7 +633,7 @@ HWND UNKCALL SelRegn_1000F711(HWND hWnd) { return 0; }
 			result = (HWND)GetWindowLongA(result, -21);
 			if ( result )
 			{
-				result = (HWND)*((_DWORD *)result + 3);
+				result = (HWND)*((DWORD *)result + 3);
 				if ( result )
 				{
 					if ( result == (HWND)dword_1002A4EC )
@@ -681,10 +681,10 @@ HWND UNKCALL SelRegn_1000F7C1(HWND hWnd) { return 0; }
 	result = (HWND)GetWindowLongA(hWnd, -21);
 	if ( result )
 	{
-		result = (HWND)*((_DWORD *)result + 3);
+		result = (HWND)*((DWORD *)result + 3);
 		if ( result )
 		{
-			if ( *(_DWORD *)result )
+			if ( *(DWORD *)result )
 			{
 				if ( GetWindowLongA(v1, -12) >= 1140 )
 				{
@@ -695,7 +695,7 @@ HWND UNKCALL SelRegn_1000F7C1(HWND hWnd) { return 0; }
 						result = (HWND)GetWindowLongA(result, -21);
 						if ( result )
 						{
-							v4 = (const char *)*((_DWORD *)result + 3);
+							v4 = (const char *)*((DWORD *)result + 3);
 							if ( v4 )
 							{
 								TitleSnd_10010315();
@@ -737,7 +737,7 @@ HWND UNKCALL SelRegn_1000F859(HWND hWnd) { return 0; }
 	result = (HWND)GetWindowLongA(v1, -21);
 	if ( result )
 	{
-		result = (HWND)*((_DWORD *)result + 3);
+		result = (HWND)*((DWORD *)result + 3);
 		if ( result )
 		{
 			v3 = (const char *)dword_1002A4EC;
@@ -785,10 +785,10 @@ signed int SelRegn_1000F8F6() { return 0; }
 	v1 = GetWindowLongA(v0, -21);
 	if ( !v1 )
 		return 0;
-	v2 = *(_DWORD *)(v1 + 12);
+	v2 = *(DWORD *)(v1 + 12);
 	if ( !v2 )
 		return 0;
-	BNetGW_10002B51(&unk_10029480, *(_DWORD *)(v2 + 4));
+	BNetGW_10002B51(&unk_10029480, *(DWORD *)(v2 + 4));
 	return 1;
 } */
 
@@ -863,7 +863,7 @@ HWND __fastcall SelRegn_1000F929(HWND hWnd, int a2, int a3) { return 0; }
 } */
 
 // ref: 0x1000F9F7
-signed int __stdcall UiSelectRegion(_DWORD *a1) { return 0; }
+signed int __stdcall UiSelectRegion(DWORD *a1) { return 0; }
 /* {
 	int v1; // eax
 	int v2; // eax
@@ -886,7 +886,7 @@ signed int __stdcall UiSelectRegion(_DWORD *a1) { return 0; }
 	}
 	return result;
 } */
-// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(_DWORD, _DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
-// 1001041E: using guessed type int __stdcall SErrSetLastError(_DWORD);
+// 10010370: using guessed type int __stdcall SDlgDialogBoxParam(DWORD, DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
+// 1001041E: using guessed type int __stdcall SErrSetLastError(DWORD);
 // 1002948C: using guessed type int dword_1002948C;

--- a/DiabloUI/selyesno.cpp
+++ b/DiabloUI/selyesno.cpp
@@ -45,7 +45,7 @@ LRESULT __stdcall SelYesNo_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 				Focus_DoBlitSpinIncFrame(hWnd, (HWND)lParam);
 			} else {
 				v7 = 1;
-				if ((_WORD)wParam == 1) {
+				if ((WORD)wParam == 1) {
 					v8  = GetFocus();
 					v9  = GetWindowLongA(v8, -12);
 					v10 = hWnd;
@@ -54,9 +54,9 @@ LRESULT __stdcall SelYesNo_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 					else
 						v7 = 2;
 				} else {
-					if ((_WORD)wParam == 2) {
+					if ((WORD)wParam == 2) {
 						v7 = 2;
-					} else if ((_WORD)wParam != 1109) {
+					} else if ((WORD)wParam != 1109) {
 						return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 					}
 					v10 = hWnd;
@@ -77,7 +77,7 @@ LRESULT __stdcall SelYesNo_WndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 	}
 	return (LRESULT)SDlgDefDialogProc(hWnd, Msg, (HDC)wParam, (HWND)lParam);
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x1000FBC7
 void __fastcall SelYesNo_RemoveYNDialog(HWND hWnd)

--- a/DiabloUI/title.cpp
+++ b/DiabloUI/title.cpp
@@ -1,13 +1,13 @@
 // ref: 0x1000FDEE
 void __fastcall Title_BlitTitleBuffer(HWND hWnd)
 {
-	_DWORD *v2;          // edi
+	DWORD *v2;          // edi
 	int v3;              // eax
 	HANDLE v4;           // esi
 	struct tagRECT Rect; // [esp+Ch] [ebp-18h]
 	HWND hWnda;          // [esp+20h] [ebp-4h]
 
-	v2    = (_DWORD *)GetWindowLongA(hWnd, -21);
+	v2    = (DWORD *)GetWindowLongA(hWnd, -21);
 	hWnda = GetDlgItem(hWnd, 1043);
 	if (IsWindowVisible(hWnd) && hWnda && v2 && *v2 && titlePHTrans[0]) {
 		v3            = titleTransIdx + 1;
@@ -22,13 +22,13 @@ void __fastcall Title_BlitTitleBuffer(HWND hWnd)
 			SBltROP3(
 			    *(void **)v4,
 			    (void *)(Rect.left + *v2 + Rect.top * v2[1]),
-			    *((_DWORD *)v4 + 1),
-			    *((_DWORD *)v4 + 2),
-			    *((_DWORD *)v4 + 1),
+			    *((DWORD *)v4 + 1),
+			    *((DWORD *)v4 + 2),
+			    *((DWORD *)v4 + 1),
 			    v2[1],
 			    0,
 			    0xCC0020u);
-			STransBlt(*(void **)v4, 0, 0, *((_DWORD *)v4 + 1), (HANDLE)titlePHTrans[titleTransIdx]);
+			STransBlt(*(void **)v4, 0, 0, *((DWORD *)v4 + 1), (HANDLE)titlePHTrans[titleTransIdx]);
 			InvalidateRect(hWnda, 0, 0);
 		}
 	}
@@ -72,7 +72,7 @@ void __fastcall Title_FreeTransMem(HWND hWnd)
 void __fastcall Title_SetTitleBMP(HWND hWnd)
 {
 	HWND v1;             // eax MAPDST
-	_DWORD *v2;          // esi
+	DWORD *v2;          // esi
 	void *v3;            // eax
 	struct tagRECT Rect; // [esp+0h] [ebp-18h]
 
@@ -80,9 +80,9 @@ void __fastcall Title_SetTitleBMP(HWND hWnd)
 	v1 = GetDlgItem(hWnd, 1043);
 	if (v1) {
 		GetClientRect(v1, &Rect);
-		v2    = (unsigned int *)SMemAlloc(0xCu, "C:\\Src\\Diablo\\DiabloUI\\Title.cpp", 134, 0);
+		v2    = (DWORD *)SMemAlloc(0xCu, "C:\\Src\\Diablo\\DiabloUI\\Title.cpp", 134, 0);
 		v3    = SMemAlloc(Rect.right * Rect.bottom, "C:\\Src\\Diablo\\DiabloUI\\Title.cpp", 136, 8);
-		*v2   = (unsigned int)v3;
+		*v2   = (DWORD)v3;
 		v2[1] = Rect.right;
 		v2[2] = Rect.bottom;
 		SDlgSetBitmapI(v1, 0, 0, -1, 1, v3, 0, Rect.right, Rect.bottom, -1);
@@ -94,8 +94,8 @@ void __fastcall Title_SetTitleBMP(HWND hWnd)
 void __fastcall Title_LoadTitleImage(HWND hWnd, const char *pszFileName)
 {
 	int v3;             // edi
-	_DWORD *v4;         // eax
-	_DWORD *v5;         // esi
+	DWORD *v4;         // eax
+	DWORD *v5;         // esi
 	int v6;             // ebx
 	int a5[4];          // [esp+8h] [ebp-20h]
 	int data[2];        // [esp+18h] [ebp-10h]
@@ -105,7 +105,7 @@ void __fastcall Title_LoadTitleImage(HWND hWnd, const char *pszFileName)
 	v3      = 0;
 	pBuffer = 0;
 	local_LoadArtImage(pszFileName, &pBuffer, (DWORD *)data);
-	v4 = (unsigned int *)GetPropA(hWnd, "TITLE_BUFFER");
+	v4 = (DWORD *)GetPropA(hWnd, "TITLE_BUFFER");
 	v5 = v4;
 	if (pBuffer) {
 		if (v4) {
@@ -174,7 +174,7 @@ BOOL __stdcall UiTitleDialog(int a1)
 	SDlgDialogBoxParam(ghUiInst, "TITLESCREEN_DIALOG", v1, Title_MainProc, a1);
 	return 1;
 }
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x10010126
 LRESULT __stdcall Title_MainProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
@@ -209,7 +209,7 @@ LRESULT __stdcall Title_MainProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 	if (uMsg != 275) {
 		if (uMsg != 513 && uMsg != 516) {
 			if (uMsg == 528) {
-				if ((_WORD)wParam == 513 || (_WORD)wParam == 516)
+				if ((WORD)wParam == 513 || (WORD)wParam == 516)
 					Title_KillAndFadeDlg(hWnd);
 			} else if (uMsg == 2024) {
 				if (!Fade_CheckRange5())
@@ -226,8 +226,8 @@ LRESULT __stdcall Title_MainProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 		goto LABEL_25;
 	return 0;
 }
-// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(_DWORD, _DWORD, _DWORD, _DWORD);
-// 10010382: using guessed type _DWORD __stdcall SDrawGetFrameWindow();
+// 1001037C: using guessed type int __stdcall SDlgDefDialogProc(DWORD, DWORD, DWORD, DWORD);
+// 10010382: using guessed type DWORD __stdcall SDrawGetFrameWindow();
 
 // ref: 0x10010235
 void __fastcall Title_KillTimerAndFree(HWND hWnd)

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -195,7 +195,7 @@ void PrintDebugPlayer(BOOL bNextPlayer)
 	char dstr[128];
 
 	if (bNextPlayer)
-		dbgplr = ((_BYTE)dbgplr + 1) & 3;
+		dbgplr = ((BYTE)dbgplr + 1) & 3;
 
 	sprintf(dstr, "Plr %i : Active = %i", dbgplr, plr[dbgplr].plractive);
 	NetSendCmdString(1 << myplr, dstr);

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -41,7 +41,7 @@ void dthread_send_delta(int pnum, char cmd, void *pbSrc, int dwLen)
 	pkt->pNext = NULL;
 	pkt->dwSpaceLeft = pnum;
 	pkt->data[0] = cmd;
-	*(_DWORD *)&pkt->data[4] = dwLen;
+	*(DWORD *)&pkt->data[4] = dwLen;
 	memcpy(&pkt->data[8], pbSrc, dwLen);
 #ifdef __cplusplus
 	sgMemCrit.Enter();
@@ -107,9 +107,9 @@ unsigned int __stdcall dthread_handler(void *unused)
 
 		if (pkt) {
 			if (pkt->dwSpaceLeft != 4)
-				multi_send_zero_packet(pkt->dwSpaceLeft, pkt->data[0], &pkt->data[8], *(_DWORD *)&pkt->data[4]);
+				multi_send_zero_packet(pkt->dwSpaceLeft, pkt->data[0], &pkt->data[8], *(DWORD *)&pkt->data[4]);
 
-			dwMilliseconds = 1000 * *(_DWORD *)&pkt->data[4] / gdwDeltaBytesSec;
+			dwMilliseconds = 1000 * *(DWORD *)&pkt->data[4] / gdwDeltaBytesSec;
 			if (dwMilliseconds >= 1)
 				dwMilliseconds = 1;
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -579,7 +579,7 @@ BOOL MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, BOOLE
 	    || t == MIS_HBOLT && monster[m].MType->mtype != MT_DIABLO && monster[m].MData->mMonstClass) {
 		return FALSE;
 	}
-	if (monster[m].MType->mtype == MT_ILLWEAV && _LOBYTE(monster[m]._mgoal) == MGOAL_RETREAT)
+	if (monster[m].MType->mtype == MT_ILLWEAV && monster[m]._mgoal == MGOAL_RETREAT)
 		return FALSE;
 	if (monster[m]._mmode == MM_CHARGE)
 		return FALSE;

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -107,7 +107,7 @@ void mpqapi_store_default_time(DWORD dwChar)
 	/// ASSERT: assert(dwChar < MAX_CHARACTERS);
 	idx = 16 * dwChar;
 	mpqapi_reg_load_modification_time(dst, sizeof(dst));
-	*(_DWORD *)&dst[idx + 4] = 0x78341348; // dwHighDateTime
+	*(DWORD *)&dst[idx + 4] = 0x78341348; // dwHighDateTime
 	mpqapi_reg_store_modification_time(dst, sizeof(dst));
 */
 }

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -579,12 +579,12 @@ void multi_send_zero_packet(DWORD pnum, char a2, void *pbSrc, DWORD dwLen)
 		pkt.hdr.bmag = 0;
 		pkt.hdr.bdex = 0;
 		pkt.body[0] = a2;
-		*(_WORD *)&pkt.body[1] = v5;
+		*(WORD *)&pkt.body[1] = v5;
 		dwBody = gdwLargestMsgSize - 24;
 		if (dwLen < dwBody)
 			dwBody = dwLen;
-		*(_WORD *)&pkt.body[3] = dwBody;
-		memcpy(&pkt.body[5], pbSrc, *(_WORD *)&pkt.body[3]);
+		*(WORD *)&pkt.body[3] = dwBody;
+		memcpy(&pkt.body[5], pbSrc, *(WORD *)&pkt.body[3]);
 		t = *(WORD *)&pkt.body[3] + 24;
 		pkt.hdr.wLen = t;
 		if (!SNetSendMessage(pnum, &pkt.hdr, t)) {
@@ -593,7 +593,7 @@ void multi_send_zero_packet(DWORD pnum, char a2, void *pbSrc, DWORD dwLen)
 		}
 		pbSrc = (char *)pbSrc + *(WORD *)&pkt.body[3];
 		dwLen -= *(WORD *)&pkt.body[3];
-		v5 += *(_WORD *)&pkt.body[3];
+		v5 += *(WORD *)&pkt.body[3];
 	}
 }
 // 67975C: using guessed type int gdwLargestMsgSize;

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -132,17 +132,17 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 
 	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pBuff;
-	if (!(_BYTE)light_table_index) {
+	if (!(BYTE)light_table_index) {
 		if (level_cel_block & 0x8000)
-			level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+			level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 			    + (unsigned short)(level_cel_block & 0xF000);
-		src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+		src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 		cel_type_16 = ((level_cel_block >> 12) & 7) + 8;
 		goto LABEL_11;
 	}
-	if ((_BYTE)light_table_index != lightmax) {
+	if ((BYTE)light_table_index != lightmax) {
 		if (!(level_cel_block & 0x8000)) {
-			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+			src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 			tbl = &pLightTbl[256 * light_table_index];
 			cel_type_16 = (unsigned char)(level_cel_block >> 12);
 			switch (cel_type_16) {
@@ -186,7 +186,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						yy_32 -= width;
 					} while (yy_32);
 				LABEL_67:
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					dst -= 800;
 					--xx_32;
 				} while (xx_32);
@@ -196,8 +196,8 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				xx_32 = 30;
 				while (dst >= gpBufEnd) {
 					dst += xx_32;
-					src += (32 - (_BYTE)xx_32) & 2;
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					src += (32 - (BYTE)xx_32) & 2;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						asm_trans_light_cel_0_2(32 - xx_32, tbl, &dst, &src);
 					} else {
@@ -211,8 +211,8 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 							if (dst < gpBufEnd)
 								break;
 							dst += yy_32;
-							src += (32 - (_BYTE)yy_32) & 2;
-							WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+							src += (32 - (BYTE)yy_32) & 2;
+							WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 							if (WorldBoolFlag) {
 								asm_trans_light_cel_0_2(32 - yy_32, tbl, &dst, &src);
 							} else {
@@ -229,7 +229,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				WorldBoolFlag = 0;
 				xx_32 = 30;
 				while (dst >= gpBufEnd) {
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						asm_trans_light_cel_0_2(32 - xx_32, tbl, &dst, &src);
 					} else {
@@ -243,7 +243,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						do {
 							if (dst < gpBufEnd)
 								break;
-							WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+							WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 							if (WorldBoolFlag) {
 								asm_trans_light_cel_0_2(32 - yy_32, tbl, &dst, &src);
 							} else {
@@ -262,8 +262,8 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				xx_32 = 30;
 				while (dst >= gpBufEnd) {
 					dst += xx_32;
-					src += (32 - (_BYTE)xx_32) & 2;
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					src += (32 - (BYTE)xx_32) & 2;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						asm_trans_light_cel_0_2(32 - xx_32, tbl, &dst, &src);
 					} else {
@@ -292,7 +292,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				WorldBoolFlag = 0;
 				xx_32 = 30;
 				while (dst >= gpBufEnd) {
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						asm_trans_light_cel_0_2(32 - xx_32, tbl, &dst, &src);
 					} else {
@@ -322,7 +322,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 			return;
 		}
 		src = (unsigned char *)pSpeedCels
-		    + *(_DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
+		    + *(DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
 		cel_type_16 = (unsigned char)(level_cel_block >> 12);
 	LABEL_11:
 
@@ -370,7 +370,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					xx_32 -= width;
 					if (!xx_32) {
 					LABEL_271:
-						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+						WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 						dst -= 800;
 						if (!--yy_32)
 							return;
@@ -441,7 +441,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 			while (dst >= gpBufEnd) {
 				dst += xx_32;
 				x_minus = 32 - xx_32;
-				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 				if (WorldBoolFlag) {
 					n_draw_shift = x_minus >> 2;
 					if (x_minus & 2) {
@@ -484,7 +484,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 							break;
 						dst += yy_32;
 						y_minus = 32 - yy_32;
-						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+						WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 						if (WorldBoolFlag) {
 							n_draw_shift = y_minus >> 2;
 							if (y_minus & 2) {
@@ -530,7 +530,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 			xx_32 = 30;
 			while (dst >= gpBufEnd) {
 				x_minus = 32 - xx_32;
-				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 				if (WorldBoolFlag) {
 					for (n_draw_shift = x_minus >> 2; n_draw_shift; --n_draw_shift) {
 						dst[1] = src[1];
@@ -564,7 +564,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						if (dst < gpBufEnd)
 							break;
 						y_minus = 32 - yy_32;
-						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+						WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 						if (WorldBoolFlag) {
 							for (n_draw_shift = y_minus >> 2; n_draw_shift; --n_draw_shift) {
 								dst[1] = src[1];
@@ -605,7 +605,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 			while (dst >= gpBufEnd) {
 				dst += xx_32;
 				x_minus = 32 - xx_32;
-				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 				if (WorldBoolFlag) {
 					n_draw_shift = x_minus >> 2;
 					if (x_minus & 2) {
@@ -677,7 +677,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 			xx_32 = 30;
 			while (dst >= gpBufEnd) {
 				x_minus = 32 - xx_32;
-				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 				if (WorldBoolFlag) {
 					for (n_draw_shift = x_minus >> 2; n_draw_shift; --n_draw_shift) {
 						dst[1] = src[1];
@@ -685,7 +685,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						src += 4;
 						dst += 4;
 					}
-					if ((32 - (_BYTE)xx_32) & 2) {
+					if ((32 - (BYTE)xx_32) & 2) {
 						dst[1] = src[1];
 						src += 4;
 						dst += 2;
@@ -697,7 +697,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						src += 4;
 						dst += 4;
 					}
-					if ((32 - (_BYTE)xx_32) & 2) {
+					if ((32 - (BYTE)xx_32) & 2) {
 						dst[0] = src[0];
 						src += 4;
 						dst += 2;
@@ -740,9 +740,9 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 		return;
 	}
 	if (level_cel_block & 0x8000)
-		level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+		level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 		    + (unsigned short)(level_cel_block & 0xF000);
-	src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+	src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 	cel_type_16 = (level_cel_block >> 12) & 7;
 	switch (cel_type_16) {
 	case 0: // upper (top transparent), black
@@ -839,7 +839,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				yy_32 -= width;
 			} while (yy_32);
 		LABEL_391:
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			dst -= 800;
 			if (!--xx_32)
 				return;
@@ -851,7 +851,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				return;
 			dst += xx_32;
 			x_minus = 32 - xx_32;
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			if (WorldBoolFlag) {
 				n_draw_shift = x_minus >> 2;
 				if (x_minus & 2) {
@@ -891,7 +891,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				break;
 			dst += yy_32;
 			y_minus = 32 - yy_32;
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			if (WorldBoolFlag) {
 				n_draw_shift = y_minus >> 2;
 				if (y_minus & 2) {
@@ -931,7 +931,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 			if (dst < gpBufEnd)
 				return;
 			x_minus = 32 - xx_32;
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			if (WorldBoolFlag) {
 				n_draw_shift = x_minus >> 2;
 				if (x_minus & 2) {
@@ -971,7 +971,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 			if (dst < gpBufEnd)
 				break;
 			y_minus = 32 - yy_32;
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			if (WorldBoolFlag) {
 				n_draw_shift = y_minus >> 2;
 				if (y_minus & 2) {
@@ -1012,7 +1012,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				return;
 			dst += xx_32;
 			x_minus = 32 - xx_32;
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			if (WorldBoolFlag) {
 				n_draw_shift = x_minus >> 2;
 				if (x_minus & 2) {
@@ -1077,7 +1077,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 			if (dst < gpBufEnd)
 				return;
 			x_minus = 32 - xx_32;
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			if (WorldBoolFlag) {
 				n_draw_shift = x_minus >> 2;
 				if (x_minus & 2) {
@@ -1157,11 +1157,11 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pBuff;
 	gpDrawMask = pMask;
-	if (!(_BYTE)light_table_index) {
+	if (!(BYTE)light_table_index) {
 		if (level_cel_block & 0x8000)
-			level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+			level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 			    + (unsigned short)(level_cel_block & 0xF000);
-		src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+		src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 		cel_type_16 = ((level_cel_block >> 12) & 7) + 8;
 	LABEL_12:
 		switch (cel_type_16) {
@@ -1230,13 +1230,13 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 				dst += xx_32;
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 				if ((32 - xx_32) & 2) {
-					*(_WORD *)dst = *((_WORD *)src + 1);
+					*(WORD *)dst = *((WORD *)src + 1);
 					src += 4;
 					dst += 2;
 				}
 				if (n_draw_shift) {
 					do {
-						*(_DWORD *)dst = *(_DWORD *)src;
+						*(DWORD *)dst = *(DWORD *)src;
 						src += 4;
 						dst += 4;
 						--n_draw_shift;
@@ -1252,13 +1252,13 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 						dst += yy_32;
 						n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
 						if ((32 - yy_32) & 2) {
-							*(_WORD *)dst = *((_WORD *)src + 1);
+							*(WORD *)dst = *((WORD *)src + 1);
 							src += 4;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = *(_DWORD *)src;
+								*(DWORD *)dst = *(DWORD *)src;
 								src += 4;
 								dst += 4;
 								--n_draw_shift;
@@ -1275,12 +1275,12 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 			xx_32 = 30;
 			while (dst >= gpBufEnd) {
 				for (n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift) {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 				}
-				if ((32 - (_BYTE)xx_32) & 2) {
-					*(_WORD *)dst = *(_WORD *)src;
+				if ((32 - (BYTE)xx_32) & 2) {
+					*(WORD *)dst = *(WORD *)src;
 					src += 4;
 					dst += 2;
 				}
@@ -1292,12 +1292,12 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 						if (dst < gpBufEnd)
 							break;
 						for (n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift) {
-							*(_DWORD *)dst = *(_DWORD *)src;
+							*(DWORD *)dst = *(DWORD *)src;
 							src += 4;
 							dst += 4;
 						}
-						if ((32 - (_BYTE)yy_32) & 2) {
-							*(_WORD *)dst = *(_WORD *)src;
+						if ((32 - (BYTE)yy_32) & 2) {
+							*(WORD *)dst = *(WORD *)src;
 							src += 4;
 							dst += 2;
 						}
@@ -1314,13 +1314,13 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 				dst += xx_32;
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 				if ((32 - xx_32) & 2) {
-					*(_WORD *)dst = *((_WORD *)src + 1);
+					*(WORD *)dst = *((WORD *)src + 1);
 					src += 4;
 					dst += 2;
 				}
 				if (n_draw_shift) {
 					do {
-						*(_DWORD *)dst = *(_DWORD *)src;
+						*(DWORD *)dst = *(DWORD *)src;
 						src += 4;
 						dst += 4;
 						--n_draw_shift;
@@ -1356,12 +1356,12 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 			xx_32 = 30;
 			while (dst >= gpBufEnd) {
 				for (n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift) {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 				}
-				if ((32 - (_BYTE)xx_32) & 2) {
-					*(_WORD *)dst = *(_WORD *)src;
+				if ((32 - (BYTE)xx_32) & 2) {
+					*(WORD *)dst = *(WORD *)src;
 					src += 4;
 					dst += 2;
 				}
@@ -1395,9 +1395,9 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 		}
 		return;
 	}
-	if ((_BYTE)light_table_index != lightmax) {
+	if ((BYTE)light_table_index != lightmax) {
 		if (!(level_cel_block & 0x8000)) {
-			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+			src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 			tbl = &pLightTbl[256 * light_table_index];
 			cel_type_16 = (unsigned char)(level_cel_block >> 12);
 			switch (cel_type_16) {
@@ -1445,7 +1445,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 				xx_32 = 30;
 				while (dst >= gpBufEnd) {
 					dst += xx_32;
-					src += (32 - (_BYTE)xx_32) & 2;
+					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					dst -= 800;
 					xx_32 -= 2;
@@ -1455,7 +1455,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 							if (dst < gpBufEnd)
 								break;
 							dst += yy_32;
-							src += (32 - (_BYTE)yy_32) & 2;
+							src += (32 - (BYTE)yy_32) & 2;
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
 							dst -= 800;
 							yy_32 += 2;
@@ -1489,7 +1489,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 				xx_32 = 30;
 				while (dst >= gpBufEnd) {
 					dst += xx_32;
-					src += (32 - (_BYTE)xx_32) & 2;
+					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					dst -= 800;
 					xx_32 -= 2;
@@ -1536,14 +1536,14 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 			return;
 		}
 		src = (unsigned char *)pSpeedCels
-		    + *(_DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
+		    + *(DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
 		cel_type_16 = (unsigned char)(level_cel_block >> 12);
 		goto LABEL_12;
 	}
 	if (level_cel_block & 0x8000)
-		level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+		level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 		    + (unsigned short)(level_cel_block & 0xF000);
-	src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+	src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 	cel_type_16 = (level_cel_block >> 12) & 7;
 	switch (cel_type_16) {
 	case 0: // upper (bottom transparent), black
@@ -1610,12 +1610,12 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 			dst += xx_32;
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = 0;
+				*(WORD *)dst = 0;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = 0;
+					*(DWORD *)dst = 0;
 					dst += 4;
 					--n_draw_shift;
 				} while (n_draw_shift);
@@ -1629,12 +1629,12 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					dst += yy_32;
 					n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
 					if ((32 - yy_32) & 2) {
-						*(_WORD *)dst = 0;
+						*(WORD *)dst = 0;
 						dst += 2;
 					}
 					if (n_draw_shift) {
 						do {
-							*(_DWORD *)dst = 0;
+							*(DWORD *)dst = 0;
 							dst += 4;
 							--n_draw_shift;
 						} while (n_draw_shift);
@@ -1652,12 +1652,12 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 		while (dst >= gpBufEnd) {
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = 0;
+				*(WORD *)dst = 0;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = 0;
+					*(DWORD *)dst = 0;
 					dst += 4;
 					--n_draw_shift;
 				} while (n_draw_shift);
@@ -1670,12 +1670,12 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 						break;
 					n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
 					if ((32 - yy_32) & 2) {
-						*(_WORD *)dst = 0;
+						*(WORD *)dst = 0;
 						dst += 2;
 					}
 					if (n_draw_shift) {
 						do {
-							*(_DWORD *)dst = 0;
+							*(DWORD *)dst = 0;
 							dst += 4;
 							--n_draw_shift;
 						} while (n_draw_shift);
@@ -1695,12 +1695,12 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 			dst += xx_32;
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = 0;
+				*(WORD *)dst = 0;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = 0;
+					*(DWORD *)dst = 0;
 					dst += 4;
 					--n_draw_shift;
 				} while (n_draw_shift);
@@ -1735,12 +1735,12 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 		while (dst >= gpBufEnd) {
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = 0;
+				*(WORD *)dst = 0;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = 0;
+					*(DWORD *)dst = 0;
 					dst += 4;
 					--n_draw_shift;
 				} while (n_draw_shift);
@@ -1808,11 +1808,11 @@ void drawUpperScreen(BYTE *pBuff)
 	}
 	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pBuff;
-	if (!(_BYTE)light_table_index) {
+	if (!(BYTE)light_table_index) {
 		if (level_cel_block & 0x8000)
-			level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+			level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 			    + (unsigned short)(level_cel_block & 0xF000);
-		src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+		src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 		cel_type_16 = ((level_cel_block >> 12) & 7) + 8;
 	LABEL_22:
 		switch (cel_type_16) {
@@ -1823,7 +1823,7 @@ void drawUpperScreen(BYTE *pBuff)
 					break;
 				j = 8;
 				do {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 					--j;
@@ -1858,14 +1858,14 @@ void drawUpperScreen(BYTE *pBuff)
 					}
 					n_draw_shift = chk_sh_and >> 1;
 					if (chk_sh_and & 1) {
-						*(_WORD *)dst = *(_WORD *)src;
+						*(WORD *)dst = *(WORD *)src;
 						src += 2;
 						dst += 2;
 						if (!n_draw_shift)
 							continue;
 					}
 					do {
-						*(_DWORD *)dst = *(_DWORD *)src;
+						*(DWORD *)dst = *(DWORD *)src;
 						src += 4;
 						dst += 4;
 						--n_draw_shift;
@@ -1882,13 +1882,13 @@ void drawUpperScreen(BYTE *pBuff)
 				dst += xx_32;
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 				if ((32 - xx_32) & 2) {
-					*(_WORD *)dst = *((_WORD *)src + 1);
+					*(WORD *)dst = *((WORD *)src + 1);
 					src += 4;
 					dst += 2;
 				}
 				if (n_draw_shift) {
 					do {
-						*(_DWORD *)dst = *(_DWORD *)src;
+						*(DWORD *)dst = *(DWORD *)src;
 						src += 4;
 						dst += 4;
 						--n_draw_shift;
@@ -1904,13 +1904,13 @@ void drawUpperScreen(BYTE *pBuff)
 						dst += yy_32;
 						n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
 						if ((32 - yy_32) & 2) {
-							*(_WORD *)dst = *((_WORD *)src + 1);
+							*(WORD *)dst = *((WORD *)src + 1);
 							src += 4;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = *(_DWORD *)src;
+								*(DWORD *)dst = *(DWORD *)src;
 								src += 4;
 								dst += 4;
 								--n_draw_shift;
@@ -1927,12 +1927,12 @@ void drawUpperScreen(BYTE *pBuff)
 			xx_32 = 30;
 			while (dst >= gpBufEnd) {
 				for (n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift) {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 				}
-				if ((32 - (_BYTE)xx_32) & 2) {
-					*(_WORD *)dst = *(_WORD *)src;
+				if ((32 - (BYTE)xx_32) & 2) {
+					*(WORD *)dst = *(WORD *)src;
 					src += 4;
 					dst += 2;
 				}
@@ -1944,12 +1944,12 @@ void drawUpperScreen(BYTE *pBuff)
 						if (dst < gpBufEnd)
 							break;
 						for (n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift) {
-							*(_DWORD *)dst = *(_DWORD *)src;
+							*(DWORD *)dst = *(DWORD *)src;
 							src += 4;
 							dst += 4;
 						}
-						if ((32 - (_BYTE)yy_32) & 2) {
-							*(_WORD *)dst = *(_WORD *)src;
+						if ((32 - (BYTE)yy_32) & 2) {
+							*(WORD *)dst = *(WORD *)src;
 							src += 4;
 							dst += 2;
 						}
@@ -1966,13 +1966,13 @@ void drawUpperScreen(BYTE *pBuff)
 				dst += xx_32;
 				n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 				if ((32 - xx_32) & 2) {
-					*(_WORD *)dst = *((_WORD *)src + 1);
+					*(WORD *)dst = *((WORD *)src + 1);
 					src += 4;
 					dst += 2;
 				}
 				if (n_draw_shift) {
 					do {
-						*(_DWORD *)dst = *(_DWORD *)src;
+						*(DWORD *)dst = *(DWORD *)src;
 						src += 4;
 						dst += 4;
 						--n_draw_shift;
@@ -1987,7 +1987,7 @@ void drawUpperScreen(BYTE *pBuff)
 							break;
 						j = 8;
 						do {
-							*(_DWORD *)dst = *(_DWORD *)src;
+							*(DWORD *)dst = *(DWORD *)src;
 							src += 4;
 							dst += 4;
 							--j;
@@ -2003,12 +2003,12 @@ void drawUpperScreen(BYTE *pBuff)
 			xx_32 = 30;
 			while (dst >= gpBufEnd) {
 				for (n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift) {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 				}
-				if ((32 - (_BYTE)xx_32) & 2) {
-					*(_WORD *)dst = *(_WORD *)src;
+				if ((32 - (BYTE)xx_32) & 2) {
+					*(WORD *)dst = *(WORD *)src;
 					src += 4;
 					dst += 2;
 				}
@@ -2021,7 +2021,7 @@ void drawUpperScreen(BYTE *pBuff)
 							break;
 						j = 8;
 						do {
-							*(_DWORD *)dst = *(_DWORD *)src;
+							*(DWORD *)dst = *(DWORD *)src;
 							src += 4;
 							dst += 4;
 							--j;
@@ -2036,9 +2036,9 @@ void drawUpperScreen(BYTE *pBuff)
 		}
 		return;
 	}
-	if ((_BYTE)light_table_index != lightmax) {
+	if ((BYTE)light_table_index != lightmax) {
 		if (!(level_cel_block & 0x8000)) {
-			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+			src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 			tbl = &pLightTbl[256 * light_table_index];
 			cel_type_16 = (unsigned short)level_cel_block >> 12;
 			switch (cel_type_16) {
@@ -2081,7 +2081,7 @@ void drawUpperScreen(BYTE *pBuff)
 				xx_32 = 30;
 				while (dst >= gpBufEnd) {
 					dst += xx_32;
-					src += (32 - (_BYTE)xx_32) & 2;
+					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					dst -= 800;
 					xx_32 -= 2;
@@ -2091,7 +2091,7 @@ void drawUpperScreen(BYTE *pBuff)
 							if (dst < gpBufEnd)
 								break;
 							dst += yy_32;
-							src += (32 - (_BYTE)yy_32) & 2;
+							src += (32 - (BYTE)yy_32) & 2;
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
 							dst -= 800;
 							yy_32 += 2;
@@ -2125,7 +2125,7 @@ void drawUpperScreen(BYTE *pBuff)
 				xx_32 = 30;
 				while (dst >= gpBufEnd) {
 					dst += xx_32;
-					src += (32 - (_BYTE)xx_32) & 2;
+					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					dst -= 800;
 					xx_32 -= 2;
@@ -2166,14 +2166,14 @@ void drawUpperScreen(BYTE *pBuff)
 			return;
 		}
 		src = (unsigned char *)pSpeedCels
-		    + *(_DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
+		    + *(DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
 		cel_type_16 = (unsigned short)level_cel_block >> 12;
 		goto LABEL_22;
 	}
 	if (level_cel_block & 0x8000)
-		level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+		level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 		    + (unsigned short)(level_cel_block & 0xF000);
-	src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+	src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 	cel_type_16 = ((unsigned int)level_cel_block >> 12) & 7;
 	switch (cel_type_16) {
 	case 0: // upper (solid), black
@@ -2183,7 +2183,7 @@ void drawUpperScreen(BYTE *pBuff)
 				break;
 			j = 8;
 			do {
-				*(_DWORD *)dst = 0;
+				*(DWORD *)dst = 0;
 				dst += 4;
 				--j;
 			} while (j);
@@ -2218,13 +2218,13 @@ void drawUpperScreen(BYTE *pBuff)
 				}
 				n_draw_shift = width >> 2;
 				if (chk_sh_and & 1) {
-					*(_WORD *)dst = 0;
+					*(WORD *)dst = 0;
 					dst += 2;
 					if (!n_draw_shift)
 						continue;
 				}
 				do {
-					*(_DWORD *)dst = 0;
+					*(DWORD *)dst = 0;
 					dst += 4;
 					--n_draw_shift;
 				} while (n_draw_shift);
@@ -2240,12 +2240,12 @@ void drawUpperScreen(BYTE *pBuff)
 			dst += xx_32;
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = 0;
+				*(WORD *)dst = 0;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = 0;
+					*(DWORD *)dst = 0;
 					dst += 4;
 					--n_draw_shift;
 				} while (n_draw_shift);
@@ -2259,12 +2259,12 @@ void drawUpperScreen(BYTE *pBuff)
 					dst += yy_32;
 					n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
 					if ((32 - yy_32) & 2) {
-						*(_WORD *)dst = 0;
+						*(WORD *)dst = 0;
 						dst += 2;
 					}
 					if (n_draw_shift) {
 						do {
-							*(_DWORD *)dst = 0;
+							*(DWORD *)dst = 0;
 							dst += 4;
 							--n_draw_shift;
 						} while (n_draw_shift);
@@ -2282,12 +2282,12 @@ void drawUpperScreen(BYTE *pBuff)
 		while (dst >= gpBufEnd) {
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = 0;
+				*(WORD *)dst = 0;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = 0;
+					*(DWORD *)dst = 0;
 					dst += 4;
 					--n_draw_shift;
 				} while (n_draw_shift);
@@ -2300,12 +2300,12 @@ void drawUpperScreen(BYTE *pBuff)
 						break;
 					n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
 					if ((32 - yy_32) & 2) {
-						*(_WORD *)dst = 0;
+						*(WORD *)dst = 0;
 						dst += 2;
 					}
 					if (n_draw_shift) {
 						do {
-							*(_DWORD *)dst = 0;
+							*(DWORD *)dst = 0;
 							dst += 4;
 							--n_draw_shift;
 						} while (n_draw_shift);
@@ -2325,12 +2325,12 @@ void drawUpperScreen(BYTE *pBuff)
 			dst += xx_32;
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = 0;
+				*(WORD *)dst = 0;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = 0;
+					*(DWORD *)dst = 0;
 					dst += 4;
 					--n_draw_shift;
 				} while (n_draw_shift);
@@ -2343,7 +2343,7 @@ void drawUpperScreen(BYTE *pBuff)
 						break;
 					j = 8;
 					do {
-						*(_DWORD *)dst = 0;
+						*(DWORD *)dst = 0;
 						dst += 4;
 						--j;
 					} while (j);
@@ -2360,12 +2360,12 @@ void drawUpperScreen(BYTE *pBuff)
 		while (dst >= gpBufEnd) {
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = 0;
+				*(WORD *)dst = 0;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = 0;
+					*(DWORD *)dst = 0;
 					dst += 4;
 					--n_draw_shift;
 				} while (n_draw_shift);
@@ -2378,7 +2378,7 @@ void drawUpperScreen(BYTE *pBuff)
 						break;
 					j = 8;
 					do {
-						*(_DWORD *)dst = 0;
+						*(DWORD *)dst = 0;
 						dst += 4;
 						--j;
 					} while (j);
@@ -2414,19 +2414,19 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 
 	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pBuff;
-	if (!(_BYTE)light_table_index) {
+	if (!(BYTE)light_table_index) {
 		if (level_cel_block & 0x8000)
-			level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+			level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 			    + (unsigned short)(level_cel_block & 0xF000);
-		src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+		src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 		cel_type_16 = ((level_cel_block >> 12) & 7) + 8;
 		goto LABEL_11;
 	}
-	if ((_BYTE)light_table_index == lightmax) {
+	if ((BYTE)light_table_index == lightmax) {
 		if (level_cel_block & 0x8000)
-			level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+			level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 			    + (unsigned short)(level_cel_block & 0xF000);
-		src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+		src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 		cel_type_16 = (level_cel_block >> 12) & 7;
 		switch (cel_type_16) {
 		case 0: // lower (top transparent), black
@@ -2476,7 +2476,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					yy_32 -= width;
 					if (!yy_32) {
 					LABEL_433:
-						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+						WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 						dst -= 800;
 						if (!--xx_32)
 							return;
@@ -2546,7 +2546,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 				if (dst < gpBufEnd) {
 					dst += xx_32;
 					x_minus = 32 - xx_32;
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						n_draw_shift = x_minus >> 2;
 						if (x_minus & 2) {
@@ -2589,7 +2589,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 				if (dst < gpBufEnd) {
 					dst += yy_32;
 					y_minus = 32 - yy_32;
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						n_draw_shift = y_minus >> 2;
 						if (y_minus & 2) {
@@ -2632,7 +2632,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 			for (xx_32 = 30;; xx_32 -= 2) {
 				if (dst < gpBufEnd) {
 					x_minus = 32 - xx_32;
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						n_draw_shift = x_minus >> 2;
 						if (x_minus & 2) {
@@ -2675,7 +2675,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 			do {
 				if (dst < gpBufEnd) {
 					y_minus = 32 - yy_32;
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						n_draw_shift = y_minus >> 2;
 						if (y_minus & 2) {
@@ -2719,7 +2719,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 				if (dst < gpBufEnd) {
 					dst += xx_32;
 					x_minus = 32 - xx_32;
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						n_draw_shift = x_minus >> 2;
 						if (x_minus & 2) {
@@ -2793,7 +2793,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 			for (xx_32 = 30;; xx_32 -= 2) {
 				if (dst < gpBufEnd) {
 					x_minus = 32 - xx_32;
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						n_draw_shift = x_minus >> 2;
 						if (x_minus & 2) {
@@ -2867,7 +2867,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 		return;
 	}
 	if (!(level_cel_block & 0x8000)) {
-		src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+		src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 		tbl = &pLightTbl[256 * light_table_index];
 		cel_type_16 = (unsigned char)(level_cel_block >> 12);
 		switch (cel_type_16) {
@@ -2920,7 +2920,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					}
 				} while (yy_32);
 			LABEL_69:
-				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 				dst -= 800;
 				--xx_32;
 			} while (xx_32);
@@ -2948,8 +2948,8 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					}
 					do {
 						dst += yy_32;
-						src += (32 - (_BYTE)yy_32) & 2;
-						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+						src += (32 - (BYTE)yy_32) & 2;
+						WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 						if (WorldBoolFlag) {
 							asm_trans_light_cel_0_2(32 - yy_32, tbl, &dst, &src);
 						} else {
@@ -2969,8 +2969,8 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 			}
 			do {
 				dst += xx_32;
-				src += (32 - (_BYTE)xx_32) & 2;
-				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+				src += (32 - (BYTE)xx_32) & 2;
+				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 				if (WorldBoolFlag) {
 					asm_trans_light_cel_0_2(32 - xx_32, tbl, &dst, &src);
 				} else {
@@ -3002,7 +3002,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 						WorldBoolFlag += world_tbl >> 1;
 					}
 					do {
-						WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+						WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 						if (WorldBoolFlag) {
 							asm_trans_light_cel_0_2(32 - yy_32, tbl, &dst, &src);
 						} else {
@@ -3022,7 +3022,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 				WorldBoolFlag += world_tbl >> 1;
 			}
 			do {
-				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 				if (WorldBoolFlag) {
 					asm_trans_light_cel_0_2(32 - xx_32, tbl, &dst, &src);
 				} else {
@@ -3071,8 +3071,8 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 			}
 			do {
 				dst += xx_32;
-				src += (32 - (_BYTE)xx_32) & 2;
-				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+				src += (32 - (BYTE)xx_32) & 2;
+				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 				if (WorldBoolFlag) {
 					asm_trans_light_cel_0_2(32 - xx_32, tbl, &dst, &src);
 				} else {
@@ -3119,7 +3119,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 				WorldBoolFlag += world_tbl >> 1;
 			}
 			do {
-				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 				if (WorldBoolFlag) {
 					asm_trans_light_cel_0_2(32 - xx_32, tbl, &dst, &src);
 				} else {
@@ -3133,7 +3133,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 		}
 		return;
 	}
-	src = (unsigned char *)pSpeedCels + *(_DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
+	src = (unsigned char *)pSpeedCels + *(DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
 	cel_type_16 = (unsigned char)(level_cel_block >> 12);
 LABEL_11:
 	switch (cel_type_16) {
@@ -3246,7 +3246,7 @@ LABEL_11:
 				yy_32 -= width;
 			} while (yy_32);
 		LABEL_293:
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			dst -= 800;
 			if (!--xx_32)
 				return;
@@ -3275,7 +3275,7 @@ LABEL_11:
 				do {
 					dst += yy_32;
 					y_minus = 32 - yy_32;
-					WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 					if (WorldBoolFlag) {
 						n_draw_shift = y_minus >> 2;
 						if (y_minus & 2) {
@@ -3325,7 +3325,7 @@ LABEL_11:
 		do {
 			dst += xx_32;
 			x_minus = 32 - xx_32;
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			if (WorldBoolFlag) {
 				n_draw_shift = x_minus >> 2;
 				if (x_minus & 2) {
@@ -3379,7 +3379,7 @@ LABEL_11:
 			do {
 			LABEL_326:
 				x_minus = 32 - xx_32;
-				WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 				if (WorldBoolFlag) {
 					for (n_draw_shift = x_minus >> 2; n_draw_shift; --n_draw_shift) {
 						dst[1] = src[1];
@@ -3387,7 +3387,7 @@ LABEL_11:
 						src += 4;
 						dst += 4;
 					}
-					if ((32 - (_BYTE)xx_32) & 2) {
+					if ((32 - (BYTE)xx_32) & 2) {
 						dst[1] = src[1];
 						src += 4;
 						dst += 2;
@@ -3399,7 +3399,7 @@ LABEL_11:
 						src += 4;
 						dst += 4;
 					}
-					if ((32 - (_BYTE)xx_32) & 2) {
+					if ((32 - (BYTE)xx_32) & 2) {
 						dst[0] = src[0];
 						src += 4;
 						dst += 2;
@@ -3427,7 +3427,7 @@ LABEL_11:
 		}
 		do {
 			y_minus = 32 - yy_32;
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			if (WorldBoolFlag) {
 				for (n_draw_shift = y_minus >> 2; n_draw_shift; --n_draw_shift) {
 					dst[1] = src[1];
@@ -3435,7 +3435,7 @@ LABEL_11:
 					src += 4;
 					dst += 4;
 				}
-				if ((32 - (_BYTE)yy_32) & 2) {
+				if ((32 - (BYTE)yy_32) & 2) {
 					dst[1] = src[1];
 					src += 4;
 					dst += 2;
@@ -3447,7 +3447,7 @@ LABEL_11:
 					src += 4;
 					dst += 4;
 				}
-				if ((32 - (_BYTE)yy_32) & 2) {
+				if ((32 - (BYTE)yy_32) & 2) {
 					dst[0] = src[0];
 					src += 4;
 					dst += 2;
@@ -3510,7 +3510,7 @@ LABEL_11:
 		do {
 			dst += xx_32;
 			x_minus = 32 - xx_32;
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			if (WorldBoolFlag) {
 				n_draw_shift = x_minus >> 2;
 				if (x_minus & 2) {
@@ -3600,7 +3600,7 @@ LABEL_11:
 		}
 		do {
 			x_minus = 32 - xx_32;
-			WorldBoolFlag = ((_BYTE)WorldBoolFlag + 1) & 1;
+			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
 			if (WorldBoolFlag) {
 				for (n_draw_shift = x_minus >> 2; n_draw_shift; --n_draw_shift) {
 					dst[1] = src[1];
@@ -3608,7 +3608,7 @@ LABEL_11:
 					src += 4;
 					dst += 4;
 				}
-				if ((32 - (_BYTE)xx_32) & 2) {
+				if ((32 - (BYTE)xx_32) & 2) {
 					dst[1] = src[1];
 					src += 4;
 					dst += 2;
@@ -3620,7 +3620,7 @@ LABEL_11:
 					src += 4;
 					dst += 4;
 				}
-				if ((32 - (_BYTE)xx_32) & 2) {
+				if ((32 - (BYTE)xx_32) & 2) {
 					dst[0] = src[0];
 					src += 4;
 					dst += 2;
@@ -3652,12 +3652,12 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pBuff;
 	gpDrawMask = pMask;
-	if ((_BYTE)light_table_index) {
-		if ((_BYTE)light_table_index == lightmax) {
+	if ((BYTE)light_table_index) {
+		if ((BYTE)light_table_index == lightmax) {
 			if (level_cel_block & 0x8000)
-				level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+				level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 				    + (unsigned short)(level_cel_block & 0xF000);
-			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+			src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 			cel_type_16 = (level_cel_block >> 12) & 7;
 			switch (cel_type_16) {
 			case 0: // lower (bottom transparent), black
@@ -3730,12 +3730,12 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						dst += i;
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -3754,12 +3754,12 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						dst += i;
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -3777,12 +3777,12 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 					if (dst < gpBufEnd) {
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -3801,12 +3801,12 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 					if (dst < gpBufEnd) {
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -3825,12 +3825,12 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						dst += i;
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -3870,12 +3870,12 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 					if (dst < gpBufEnd) {
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -3915,7 +3915,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 			return;
 		}
 		if (!(level_cel_block & 0x8000)) {
-			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+			src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 			tbl = &pLightTbl[256 * light_table_index];
 			cel_type_16 = (unsigned char)(level_cel_block >> 12);
 			switch (cel_type_16) {
@@ -3985,7 +3985,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						}
 						do {
 							dst += yy_32;
-							src += (32 - (_BYTE)yy_32) & 2;
+							src += (32 - (BYTE)yy_32) & 2;
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
 							yy_32 += 2;
 							dst -= 800;
@@ -3999,7 +3999,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 				}
 				do {
 					dst += xx_32;
-					src += (32 - (_BYTE)xx_32) & 2;
+					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					dst -= 800;
 					xx_32 -= 2;
@@ -4074,7 +4074,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 				}
 				do {
 					dst += xx_32;
-					src += (32 - (_BYTE)xx_32) & 2;
+					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					dst -= 800;
 					xx_32 -= 2;
@@ -4120,13 +4120,13 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 			return;
 		}
 		src = (unsigned char *)pSpeedCels
-		    + *(_DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
+		    + *(DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
 		cel_type_16 = (unsigned char)(level_cel_block >> 12);
 	} else {
 		if (level_cel_block & 0x8000)
-			level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+			level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 			    + (unsigned short)(level_cel_block & 0xF000);
-		src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+		src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 		cel_type_16 = ((level_cel_block >> 12) & 7) + 8;
 	}
 	switch (cel_type_16) {
@@ -4217,13 +4217,13 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 					dst += yy_32;
 					n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
 					if ((32 - yy_32) & 2) {
-						*(_WORD *)dst = *((_WORD *)src + 1);
+						*(WORD *)dst = *((WORD *)src + 1);
 						src += 4;
 						dst += 2;
 					}
 					if (n_draw_shift) {
 						do {
-							*(_DWORD *)dst = *(_DWORD *)src;
+							*(DWORD *)dst = *(DWORD *)src;
 							src += 4;
 							dst += 4;
 							--n_draw_shift;
@@ -4243,13 +4243,13 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 			dst += xx_32;
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = *((_WORD *)src + 1);
+				*(WORD *)dst = *((WORD *)src + 1);
 				src += 4;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 					--n_draw_shift;
@@ -4272,12 +4272,12 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 			do {
 			LABEL_175:
 				for (n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift) {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 				}
-				if ((32 - (_BYTE)xx_32) & 2) {
-					*(_WORD *)dst = *(_WORD *)src;
+				if ((32 - (BYTE)xx_32) & 2) {
+					*(WORD *)dst = *(WORD *)src;
 					src += 4;
 					dst += 2;
 				}
@@ -4301,12 +4301,12 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 		}
 		do {
 			for (n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift) {
-				*(_DWORD *)dst = *(_DWORD *)src;
+				*(DWORD *)dst = *(DWORD *)src;
 				src += 4;
 				dst += 4;
 			}
-			if ((32 - (_BYTE)yy_32) & 2) {
-				*(_WORD *)dst = *(_WORD *)src;
+			if ((32 - (BYTE)yy_32) & 2) {
+				*(WORD *)dst = *(WORD *)src;
 				src += 4;
 				dst += 2;
 			}
@@ -4355,13 +4355,13 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 			dst += xx_32;
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = *((_WORD *)src + 1);
+				*(WORD *)dst = *((WORD *)src + 1);
 				src += 4;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 					--n_draw_shift;
@@ -4411,12 +4411,12 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 		}
 		do {
 			for (n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift) {
-				*(_DWORD *)dst = *(_DWORD *)src;
+				*(DWORD *)dst = *(DWORD *)src;
 				src += 4;
 				dst += 4;
 			}
-			if ((32 - (_BYTE)xx_32) & 2) {
-				*(_WORD *)dst = *(_WORD *)src;
+			if ((32 - (BYTE)xx_32) & 2) {
+				*(WORD *)dst = *(WORD *)src;
 				src += 4;
 				dst += 2;
 			}
@@ -4463,12 +4463,12 @@ void drawLowerScreen(BYTE *pBuff)
 	}
 	gpCelFrame = (unsigned char *)SpeedFrameTbl;
 	dst = pBuff;
-	if ((_BYTE)light_table_index) {
-		if ((_BYTE)light_table_index == lightmax) {
+	if ((BYTE)light_table_index) {
+		if ((BYTE)light_table_index == lightmax) {
 			if (level_cel_block & 0x8000)
-				level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+				level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 				    + (unsigned short)(level_cel_block & 0xF000);
-			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+			src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 			cel_type_16 = (level_cel_block >> 12) & 7;
 			switch (cel_type_16) {
 			case 0: // lower (solid), black
@@ -4477,7 +4477,7 @@ void drawLowerScreen(BYTE *pBuff)
 					if (dst < gpBufEnd) {
 						j = 8;
 						do {
-							*(_DWORD *)dst = 0;
+							*(DWORD *)dst = 0;
 							dst += 4;
 							--j;
 						} while (j);
@@ -4515,12 +4515,12 @@ void drawLowerScreen(BYTE *pBuff)
 							if (chk_sh_and) {
 								n_draw_shift = width >> 2;
 								if (chk_sh_and & 1) {
-									*(_WORD *)dst = 0;
+									*(WORD *)dst = 0;
 									dst += 2;
 								}
 								if (n_draw_shift) {
 									do {
-										*(_DWORD *)dst = 0;
+										*(DWORD *)dst = 0;
 										dst += 4;
 										--n_draw_shift;
 									} while (n_draw_shift);
@@ -4542,12 +4542,12 @@ void drawLowerScreen(BYTE *pBuff)
 						dst += i;
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -4566,12 +4566,12 @@ void drawLowerScreen(BYTE *pBuff)
 						dst += i;
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -4589,12 +4589,12 @@ void drawLowerScreen(BYTE *pBuff)
 					if (dst < gpBufEnd) {
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -4613,12 +4613,12 @@ void drawLowerScreen(BYTE *pBuff)
 					if (dst < gpBufEnd) {
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -4637,12 +4637,12 @@ void drawLowerScreen(BYTE *pBuff)
 						dst += i;
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -4660,7 +4660,7 @@ void drawLowerScreen(BYTE *pBuff)
 					if (dst < gpBufEnd) {
 						j = 8;
 						do {
-							*(_DWORD *)dst = 0;
+							*(DWORD *)dst = 0;
 							dst += 4;
 							--j;
 						} while (j);
@@ -4677,12 +4677,12 @@ void drawLowerScreen(BYTE *pBuff)
 					if (dst < gpBufEnd) {
 						n_draw_shift = (unsigned int)(32 - i) >> 2;
 						if ((32 - i) & 2) {
-							*(_WORD *)dst = 0;
+							*(WORD *)dst = 0;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = 0;
+								*(DWORD *)dst = 0;
 								dst += 4;
 								--n_draw_shift;
 							} while (n_draw_shift);
@@ -4701,7 +4701,7 @@ void drawLowerScreen(BYTE *pBuff)
 					if (dst < gpBufEnd) {
 						j = 8;
 						do {
-							*(_DWORD *)dst = 0;
+							*(DWORD *)dst = 0;
 							dst += 4;
 							--j;
 						} while (j);
@@ -4717,7 +4717,7 @@ void drawLowerScreen(BYTE *pBuff)
 			return;
 		}
 		if (!(level_cel_block & 0x8000)) {
-			src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+			src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 			tbl = &pLightTbl[256 * light_table_index];
 			cel_type_16 = (unsigned short)level_cel_block >> 12;
 			switch (cel_type_16) {
@@ -4778,7 +4778,7 @@ void drawLowerScreen(BYTE *pBuff)
 						}
 						do {
 							dst += yy_32;
-							src += (32 - (_BYTE)yy_32) & 2;
+							src += (32 - (BYTE)yy_32) & 2;
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
 							yy_32 += 2;
 							dst -= 800;
@@ -4792,7 +4792,7 @@ void drawLowerScreen(BYTE *pBuff)
 				}
 				do {
 					dst += xx_32;
-					src += (32 - (_BYTE)xx_32) & 2;
+					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					dst -= 800;
 					xx_32 -= 2;
@@ -4864,7 +4864,7 @@ void drawLowerScreen(BYTE *pBuff)
 				}
 				do {
 					dst += xx_32;
-					src += (32 - (_BYTE)xx_32) & 2;
+					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					dst -= 800;
 					xx_32 -= 2;
@@ -4907,13 +4907,13 @@ void drawLowerScreen(BYTE *pBuff)
 			return;
 		}
 		src = (unsigned char *)pSpeedCels
-		    + *(_DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
+		    + *(DWORD *)&gpCelFrame[4 * (light_table_index + 16 * (level_cel_block & 0xFFF))];
 		cel_type_16 = (unsigned short)level_cel_block >> 12;
 	} else {
 		if (level_cel_block & 0x8000)
-			level_cel_block = *(_DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
+			level_cel_block = *(DWORD *)&gpCelFrame[64 * (level_cel_block & 0xFFF)]
 			    + (unsigned short)(level_cel_block & 0xF000);
-		src = (unsigned char *)pDungeonCels + *((_DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
+		src = (unsigned char *)pDungeonCels + *((DWORD *)pDungeonCels + (level_cel_block & 0xFFF));
 		cel_type_16 = (((unsigned int)level_cel_block >> 12) & 7) + 8;
 	}
 	switch (cel_type_16) {
@@ -4923,7 +4923,7 @@ void drawLowerScreen(BYTE *pBuff)
 			if (dst < gpBufEnd) {
 				j = 8;
 				do {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 					--j;
@@ -4962,13 +4962,13 @@ void drawLowerScreen(BYTE *pBuff)
 					if (chk_sh_and) {
 						n_draw_shift = chk_sh_and >> 1;
 						if (chk_sh_and & 1) {
-							*(_WORD *)dst = *(_WORD *)src;
+							*(WORD *)dst = *(WORD *)src;
 							src += 2;
 							dst += 2;
 						}
 						if (n_draw_shift) {
 							do {
-								*(_DWORD *)dst = *(_DWORD *)src;
+								*(DWORD *)dst = *(DWORD *)src;
 								src += 4;
 								dst += 4;
 								--n_draw_shift;
@@ -5007,13 +5007,13 @@ void drawLowerScreen(BYTE *pBuff)
 					dst += yy_32;
 					n_draw_shift = (unsigned int)(32 - yy_32) >> 2;
 					if ((32 - yy_32) & 2) {
-						*(_WORD *)dst = *((_WORD *)src + 1);
+						*(WORD *)dst = *((WORD *)src + 1);
 						src += 4;
 						dst += 2;
 					}
 					if (n_draw_shift) {
 						do {
-							*(_DWORD *)dst = *(_DWORD *)src;
+							*(DWORD *)dst = *(DWORD *)src;
 							src += 4;
 							dst += 4;
 							--n_draw_shift;
@@ -5033,13 +5033,13 @@ void drawLowerScreen(BYTE *pBuff)
 			dst += xx_32;
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = *((_WORD *)src + 1);
+				*(WORD *)dst = *((WORD *)src + 1);
 				src += 4;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 					--n_draw_shift;
@@ -5062,12 +5062,12 @@ void drawLowerScreen(BYTE *pBuff)
 			do {
 			LABEL_166:
 				for (n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift) {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 				}
-				if ((32 - (_BYTE)xx_32) & 2) {
-					*(_WORD *)dst = *(_WORD *)src;
+				if ((32 - (BYTE)xx_32) & 2) {
+					*(WORD *)dst = *(WORD *)src;
 					src += 4;
 					dst += 2;
 				}
@@ -5091,12 +5091,12 @@ void drawLowerScreen(BYTE *pBuff)
 		}
 		do {
 			for (n_draw_shift = (unsigned int)(32 - yy_32) >> 2; n_draw_shift; --n_draw_shift) {
-				*(_DWORD *)dst = *(_DWORD *)src;
+				*(DWORD *)dst = *(DWORD *)src;
 				src += 4;
 				dst += 4;
 			}
-			if ((32 - (_BYTE)yy_32) & 2) {
-				*(_WORD *)dst = *(_WORD *)src;
+			if ((32 - (BYTE)yy_32) & 2) {
+				*(WORD *)dst = *(WORD *)src;
 				src += 4;
 				dst += 2;
 			}
@@ -5118,7 +5118,7 @@ void drawLowerScreen(BYTE *pBuff)
 					if (dst < gpBufEnd) {
 						j = 8;
 						do {
-							*(_DWORD *)dst = *(_DWORD *)src;
+							*(DWORD *)dst = *(DWORD *)src;
 							src += 4;
 							dst += 4;
 							--j;
@@ -5141,13 +5141,13 @@ void drawLowerScreen(BYTE *pBuff)
 			dst += xx_32;
 			n_draw_shift = (unsigned int)(32 - xx_32) >> 2;
 			if ((32 - xx_32) & 2) {
-				*(_WORD *)dst = *((_WORD *)src + 1);
+				*(WORD *)dst = *((WORD *)src + 1);
 				src += 4;
 				dst += 2;
 			}
 			if (n_draw_shift) {
 				do {
-					*(_DWORD *)dst = *(_DWORD *)src;
+					*(DWORD *)dst = *(DWORD *)src;
 					src += 4;
 					dst += 4;
 					--n_draw_shift;
@@ -5170,7 +5170,7 @@ void drawLowerScreen(BYTE *pBuff)
 					if (dst < gpBufEnd) {
 						j = 8;
 						do {
-							*(_DWORD *)dst = *(_DWORD *)src;
+							*(DWORD *)dst = *(DWORD *)src;
 							src += 4;
 							dst += 4;
 							--j;
@@ -5191,12 +5191,12 @@ void drawLowerScreen(BYTE *pBuff)
 		}
 		do {
 			for (n_draw_shift = (unsigned int)(32 - xx_32) >> 2; n_draw_shift; --n_draw_shift) {
-				*(_DWORD *)dst = *(_DWORD *)src;
+				*(DWORD *)dst = *(DWORD *)src;
 				src += 4;
 				dst += 4;
 			}
-			if ((32 - (_BYTE)xx_32) & 2) {
-				*(_WORD *)dst = *(_WORD *)src;
+			if ((32 - (BYTE)xx_32) & 2) {
+				*(WORD *)dst = *(WORD *)src;
 				src += 4;
 				dst += 2;
 			}
@@ -5221,7 +5221,7 @@ void world_draw_black_tile(BYTE *pBuff)
 		dst += xx_32;
 		j = i;
 		do {
-			*(_DWORD *)dst = 0;
+			*(DWORD *)dst = 0;
 			dst += 4;
 			--j;
 		} while (j);
@@ -5236,7 +5236,7 @@ void world_draw_black_tile(BYTE *pBuff)
 		dst += yy_32;
 		j = i;
 		do {
-			*(_DWORD *)dst = 0;
+			*(DWORD *)dst = 0;
 			dst += 4;
 			--j;
 		} while (j);

--- a/defs.h
+++ b/defs.h
@@ -140,22 +140,10 @@
 // Partially defined types. They are used when the decompiler does not know
 // anything about the type except its size.
 #define _BYTE  unsigned char
-#define _WORD  unsigned short
 #define _DWORD unsigned int
 
-// Some convenience macros to make partial accesses nicer
-#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
-#  define LOW_IND(x,part_type)   (sizeof(x)/sizeof(part_type) - 1)
-#else
-#  define LOW_IND(x,part_type)   0
-#endif
-
-// first unsigned macros:
-#define BYTEn(x, n)   (*((BYTE*)&(x)+n))
-#define WORDn(x, n)   (*((WORD*)&(x)+n))
-
-#define _LOBYTE(x)  BYTEn(x,LOW_IND(x,BYTE))
-#define _LOWORD(x)  WORDn(x,LOW_IND(x,WORD))
+#define _LOBYTE(x)  (*((BYTE*)&(x)))
+#define _LOWORD(x)  (*((WORD*)&(x)))
 
 #endif /* IDA_GARBAGE */
 


### PR DESCRIPTION
- Drop IDA helpers for DiabloUI and C render code
- Clean up code that used IDA helpers and where bin exact
- Drop IDA helpers that are no longer in use

This leaves just 4 lines used in 7 functions
- FindPath
- MI_Wave
- log_create
- mpqapi_store_modified_time
- mpqapi_store_creation_time
- multi_process_network_packets
- gmenu_draw_menu_item