### PR TITLE
Fix Pkware.dsp for VC6 DevStudio GUI

### DIFF
--- a/3rdParty/PKWare/Pkware.dsp
+++ b/3rdParty/PKWare/Pkware.dsp
@@ -7,19 +7,19 @@
 CFG=Pkware - Win32 Debug
 !MESSAGE This is not a valid makefile. To build this project using NMAKE,
 !MESSAGE use the Export Makefile command and run
-!MESSAGE 
+!MESSAGE
 !MESSAGE NMAKE /f "Pkware.mak".
-!MESSAGE 
+!MESSAGE
 !MESSAGE You can specify a configuration when running NMAKE
 !MESSAGE by defining the macro CFG on the command line. For example:
-!MESSAGE 
+!MESSAGE
 !MESSAGE NMAKE /f "Pkware.mak" CFG="Pkware - Win32 Debug"
-!MESSAGE 
+!MESSAGE
 !MESSAGE Possible choices for configuration are:
-!MESSAGE 
+!MESSAGE
 !MESSAGE "Pkware - Win32 Release" (based on "Win32 (x86) Static Library")
 !MESSAGE "Pkware - Win32 Debug" (based on "Win32 (x86) Static Library")
-!MESSAGE 
+!MESSAGE
 
 # Begin Project
 # PROP AllowPerConfigDependencies 0
@@ -74,7 +74,7 @@ LIB32=link.exe -lib
 # ADD BASE LIB32 /nologo
 # ADD LIB32 /nologo
 
-!ENDIF 
+!ENDIF
 
 # Begin Target
 


### PR DESCRIPTION
Checking out the project and opening it with VC6 on windows currently results in this error, making it impossible to build via gui:

![image](https://user-images.githubusercontent.com/5844066/58831199-70d2a400-864c-11e9-99f8-8e06e7b90875.png)

For some reason Pkware.dsp had LF line endings instead of CRLF ones, so I've converted it back and it now loads/compiles fine again :)