### PR TITLE
General clean up, mostly mpqapi.cpp

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -2404,7 +2404,7 @@ void control_set_gold_curs(int pnum)
 	else
 		plr[pnum].HoldItem._iCurs = ICURS_GOLD_MEDIUM;
 
-	SetCursor_(plr[pnum].HoldItem._iCurs + CURSOR_FIRSTITEM);
+	NewCursor(plr[pnum].HoldItem._iCurs + CURSOR_FIRSTITEM);
 }
 
 void DrawTalkPan()

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -4,7 +4,7 @@
 DWORD sgdwMpqOffset;
 char mpq_buf[4096];
 _HASHENTRY *sgpHashTbl;
-BOOL save_archive_modified; // weak
+BOOL save_archive_modified;
 _BLOCKENTRY *sgpBlockTbl;
 BOOLEAN save_archive_open; // weak
 
@@ -457,7 +457,7 @@ BOOL OpenMPQ(const char *pszArchive, BOOL hidden, DWORD dwChar)
 		if (sghArchive == INVALID_HANDLE_VALUE)
 			return 0;
 		save_archive_open = 1;
-		save_archive_modified = 1;
+		save_archive_modified = TRUE;
 	}
 	if (!sgpBlockTbl || !sgpHashTbl) {
 		memset(&fhdr, 0, sizeof(fhdr));
@@ -489,7 +489,6 @@ BOOL OpenMPQ(const char *pszArchive, BOOL hidden, DWORD dwChar)
 	}
 	return 1;
 }
-// 65AB0C: using guessed type int save_archive_modified;
 // 65AB14: using guessed type char save_archive_open;
 // 679660: using guessed type char gbMaxPlayers;
 
@@ -526,7 +525,7 @@ BOOL ParseMPQHeader(_FILEHEADER *pHdr, DWORD *pdwNextFileStart)
 		pHdr->sectorsizeid = 3;
 		pHdr->version = 0;
 		*pdwNextFileStart = 0x10068;
-		save_archive_modified = 1;
+		save_archive_modified = TRUE;
 		save_archive_open = 1;
 	}
 
@@ -564,7 +563,7 @@ void mpqapi_store_modified_time(const char *pszArchive, DWORD dwChar)
 		handle = FindFirstFile(pszArchive, &FindFileData);
 		if (handle != INVALID_HANDLE_VALUE) {
 			FindClose(handle);
-			*((FILETIME*) (dst) + dwChar * 2 + 1) = FindFileData.ftLastWriteTime;
+			*((FILETIME *)(dst) + dwChar * 2 + 1) = FindFileData.ftLastWriteTime;
 			mpqapi_reg_store_modification_time(dst, 160);
 		}
 	}
@@ -572,22 +571,22 @@ void mpqapi_store_modified_time(const char *pszArchive, DWORD dwChar)
 
 BOOL mpqapi_flush_and_close(const char *pszArchive, BOOL bFree, DWORD dwChar)
 {
-    BOOL ret = FALSE;
-    if (sghArchive == INVALID_HANDLE_VALUE)
+	BOOL ret = FALSE;
+	if (sghArchive == INVALID_HANDLE_VALUE)
 		ret = TRUE;
 	else {
-        ret = FALSE;
-        if (!save_archive_modified)
-          ret = TRUE;
-        else if (mpqapi_can_seek() && WriteMPQHeader() && mpqapi_write_block_table()) {
-	        if (mpqapi_write_hash_table())
+		ret = FALSE;
+		if (!save_archive_modified)
+			ret = TRUE;
+		else if (mpqapi_can_seek() && WriteMPQHeader() && mpqapi_write_block_table()) {
+			if (mpqapi_write_hash_table())
 				ret = TRUE;
 			else
 				ret = FALSE;
 		}
-    }
-    CloseMPQ(pszArchive, bFree, dwChar);
-    return ret;
+	}
+	CloseMPQ(pszArchive, bFree, dwChar);
+	return ret;
 }
 
 BOOL WriteMPQHeader()

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -29,7 +29,7 @@ BOOL mpqapi_set_hidden(const char *pszArchive, BOOL hidden)
 		return SetFileAttributes(pszArchive, dwFileAttributesToSet);
 }
 
-void mpqapi_store_creation_time(const char *pszArchive, int dwChar)
+void mpqapi_store_creation_time(const char *pszArchive, DWORD dwChar)
 {
 	HANDLE handle;
 	struct _WIN32_FIND_DATAA FindFileData;
@@ -283,7 +283,7 @@ _BLOCKENTRY *mpqapi_add_file(const char *pszName, _BLOCKENTRY *pBlk, int block_i
 	return pBlk;
 }
 
-BOOL mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, int dwLen, _BLOCKENTRY *pBlk)
+BOOL mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, DWORD dwLen, _BLOCKENTRY *pBlk)
 {
 	const char *v4;              // esi
 	const char *v5;              // eax
@@ -432,7 +432,7 @@ BOOL mpqapi_has_file(const char *pszName)
 	return FetchHandle(pszName) != -1;
 }
 
-BOOL OpenMPQ(const char *pszArchive, BOOL hidden, int dwChar)
+BOOL OpenMPQ(const char *pszArchive, BOOL hidden, DWORD dwChar)
 {
 	const char *v3;         // ebp
 	BOOL v4;                // esi
@@ -461,7 +461,7 @@ BOOL OpenMPQ(const char *pszArchive, BOOL hidden, int dwChar)
 	}
 	if (!sgpBlockTbl || !sgpHashTbl) {
 		memset(&fhdr, 0, sizeof(fhdr));
-		if (!ParseMPQHeader(&fhdr, (int *)&sgdwMpqOffset)) {
+		if (!ParseMPQHeader(&fhdr, &sgdwMpqOffset)) {
 		LABEL_15:
 			CloseMPQ(lpFileName, 1, dwChar);
 			return 0;
@@ -493,7 +493,7 @@ BOOL OpenMPQ(const char *pszArchive, BOOL hidden, int dwChar)
 // 65AB14: using guessed type char save_archive_open;
 // 679660: using guessed type char gbMaxPlayers;
 
-BOOL ParseMPQHeader(_FILEHEADER *pHdr, int *pdwNextFileStart)
+BOOL ParseMPQHeader(_FILEHEADER *pHdr, DWORD *pdwNextFileStart)
 {
 	DWORD size;
 	DWORD NumberOfBytesRead;
@@ -533,7 +533,7 @@ BOOL ParseMPQHeader(_FILEHEADER *pHdr, int *pdwNextFileStart)
 	return TRUE;
 }
 
-void CloseMPQ(const char *pszArchive, BOOL bFree, int dwChar)
+void CloseMPQ(const char *pszArchive, BOOL bFree, DWORD dwChar)
 {
 	if (bFree) {
 		MemFreeDbg(sgpBlockTbl);
@@ -553,7 +553,7 @@ void CloseMPQ(const char *pszArchive, BOOL bFree, int dwChar)
 	}
 }
 
-void mpqapi_store_modified_time(const char *pszArchive, int dwChar)
+void mpqapi_store_modified_time(const char *pszArchive, DWORD dwChar)
 {
 	HANDLE handle;
 	struct _WIN32_FIND_DATAA FindFileData;
@@ -570,7 +570,7 @@ void mpqapi_store_modified_time(const char *pszArchive, int dwChar)
 	}
 }
 
-BOOL mpqapi_flush_and_close(const char *pszArchive, BOOL bFree, int dwChar)
+BOOL mpqapi_flush_and_close(const char *pszArchive, BOOL bFree, DWORD dwChar)
 {
     BOOL ret = FALSE;
     if (sghArchive == INVALID_HANDLE_VALUE)

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -7,12 +7,11 @@ extern BOOL save_archive_modified; // weak
 extern BOOLEAN save_archive_open;     // weak
 
 BOOL mpqapi_set_hidden(const char *pszArchive, BOOL hidden);
-void mpqapi_store_creation_time(const char *pszArchive, int dwChar);
+void mpqapi_store_creation_time(const char *pszArchive, DWORD dwChar);
 BOOL mpqapi_reg_load_modification_time(char *dst, int size);
 void mpqapi_xor_buf(char *pbData);
 void mpqapi_store_default_time(DWORD dwChar);
 BOOLEAN mpqapi_reg_store_modification_time(char *pbData, DWORD dwLen);
-_BLOCKENTRY *j_mpqapi_remove_hash_entry(char *pszName);
 void mpqapi_remove_hash_entry(const char *pszName);
 void mpqapi_alloc_block(int block_offset, int block_size);
 _BLOCKENTRY *mpqapi_new_block(int *block_index);
@@ -21,15 +20,15 @@ int mpqapi_get_hash_index(short index, int hash_a, int hash_b, int locale);
 void mpqapi_remove_hash_entries(BOOL(__stdcall *fnGetName)(DWORD, char *));
 BOOL mpqapi_write_file(const char *pszName, const BYTE *pbData, DWORD dwLen);
 _BLOCKENTRY *mpqapi_add_file(const char *pszName, _BLOCKENTRY *pBlk, int block_index);
-BOOL mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, int dwLen, _BLOCKENTRY *pBlk);
+BOOL mpqapi_write_file_contents(const char *pszName, const BYTE *pbData, DWORD dwLen, _BLOCKENTRY *pBlk);
 int mpqapi_find_free_block(int size, int *block_size);
 void mpqapi_rename(char *pszOld, char *pszNew);
 BOOL mpqapi_has_file(const char *pszName);
-BOOL OpenMPQ(const char *pszArchive, BOOL hidden, int dwChar);
-BOOL ParseMPQHeader(_FILEHEADER *pHdr, int *pdwNextFileStart);
-void CloseMPQ(const char *pszArchive, BOOL bFree, int dwChar);
-void mpqapi_store_modified_time(const char *pszArchive, int dwChar);
-BOOL mpqapi_flush_and_close(const char *pszArchive, BOOL bFree, int dwChar);
+BOOL OpenMPQ(const char *pszArchive, BOOL hidden, DWORD dwChar);
+BOOL ParseMPQHeader(_FILEHEADER *pHdr, DWORD *pdwNextFileStart);
+void CloseMPQ(const char *pszArchive, BOOL bFree, DWORD dwChar);
+void mpqapi_store_modified_time(const char *pszArchive, DWORD dwChar);
+BOOL mpqapi_flush_and_close(const char *pszArchive, BOOL bFree, DWORD dwChar);
 BOOL WriteMPQHeader();
 BOOL mpqapi_write_block_table();
 BOOL mpqapi_write_hash_table();

--- a/defs.h
+++ b/defs.h
@@ -138,14 +138,7 @@
 /////////////////////////////////////////////////////////////////////////
 #ifndef IDA_GARBAGE
 #define IDA_GARBAGE
-
-// Partially defined types. They are used when the decompiler does not know
-// anything about the type except its size.
-#define _BYTE  unsigned char
-#define _DWORD unsigned int
-
 #define _LOBYTE(x)  (*((BYTE*)&(x)))
-
 #endif /* IDA_GARBAGE */
 
 // Typedef for the function pointer

--- a/structs.h
+++ b/structs.h
@@ -1472,7 +1472,7 @@ typedef struct _FILEHEADER {
 	int signature;
 	int headersize;
 	int filesize;
-	short version;
+	WORD version;
 	short sectorsizeid;
 	int hashoffset;
 	int blockoffset;


### PR DESCRIPTION
This fixes a min diff in ParseMPQHeader that had been overlooked previously.
Drops j_mpqapi_remove_hash_entry from the header since it was dropped from code.
Corrects the function called in control_set_gold_curs (NewCursor wraps SetCursor_).
Plus some other loose stuff.