### PR TITLE
Correct TSyncHeader and TSyncMonster types

### DIFF
--- a/structs.h
+++ b/structs.h
@@ -866,7 +866,7 @@ typedef struct TSyncHeader {
 	BYTE bItemY;
 	WORD wItemIndx;
 	WORD wItemCI;
-	int dwItemSeed;
+	DWORD dwItemSeed;
 	BYTE bItemId;
 	BYTE bItemDur;
 	BYTE bItemMDur;
@@ -877,15 +877,15 @@ typedef struct TSyncHeader {
 	BYTE bPInvLoc;
 	WORD wPInvIndx;
 	WORD wPInvCI;
-	int dwPInvSeed;
+	DWORD dwPInvSeed;
 	BYTE bPInvId;
 } TSyncHeader;
 
 typedef struct TSyncMonster {
 	BYTE _mndx;
-	char _mx;
-	char _my;
-	char _menemy;
+	BYTE _mx;
+	BYTE _my;
+	BYTE _menemy;
 	BYTE _mdelta;
 } TSyncMonster;
 


### PR DESCRIPTION
As @Predelnik pointed out correcting the types in TSyncMonster fixes the diff in sync_monster. I also corrected the types in TSyncHeader and checked all functions that interact with them, none were affected in a negative way.