### PR TITLE
Make some member functions of TList<EXTERNMESSAGE> bin exact.

### DIFF
--- a/Source/list.h
+++ b/Source/list.h
@@ -69,7 +69,6 @@ private:
 
 	static __forceinline void SDelete(T *node)
 	{
-		node->~T();
 		SMemFree(node, (char *)OBJECT_NAME(T), SLOG_OBJECT, 0);
 	}
 };
@@ -97,8 +96,10 @@ TList<T>::TList()
 template <class T>
 void TList<T>::DeleteAll()
 {
-	while (T *node = m_link.Next())
+	while (T *node = m_link.Next()) {
+		node->Delete(0x0);
 		SDelete(node);
+	}
 }
 
 //=============================================================================
@@ -122,6 +123,7 @@ T *TList<T>::Remove(T *node)
 {
 	TLink<T> *link = node ? &node->m_Link : &m_link;
 	T *next = link->Next();
+	node->Delete(0x0);
 	SDelete(node);
 	return next;
 }

--- a/Source/msgcmd.cpp
+++ b/Source/msgcmd.cpp
@@ -12,16 +12,20 @@
 struct EXTERNMESSAGE {
 	LIST_LINK(EXTERNMESSAGE) m_Link;
 	char command[COMMAND_LEN];
-	~EXTERNMESSAGE()
-	{
-		// BUGFIX: this is already called by m_Link's destructor
-		m_Link.Unlink();
-	}
-	static void operator delete(void *p) {
-		if (p)
-			SMemFree(p, "delete", SLOG_FUNCTION, 0);
-	}
+
+	void *Delete(DWORD flags);
 };
+
+void *EXTERNMESSAGE::Delete(DWORD flags)
+{
+	// BUGFIX: this is already called by m_Link's destructor
+	m_Link.Unlink();
+	this->~EXTERNMESSAGE();
+	if ((flags & 0x1) && this) {
+		SMemFree(this, "delete", SLOG_FUNCTION, 0);
+	}
+    return this;
+}
 
 static TList<EXTERNMESSAGE> sgChat_Cmd;
 


### PR DESCRIPTION
While I have no clear understanding why this was written this way but it's easy to see that what we call destructor of `EXTERNMESSAGE` now cannot actually be destructor because it has an argument and return value. So I renamed it to `remove` function, it's most likely member function and I believe definition should be outside class to prevent inlining.

Some other points:
* Redundant `m_Link.Unlink();` could be kept in `~EXTERNMESSAGE` but it does not get inlined in this case for some reason.
* Check on `this` may indicate actual call to `delete` operator but since destructor and freeing of memory are split here it does not seem to be the case. Also modern compilers may issue a warning for such check.

This should make 3 functions bin exact including `EXTERNMESSAGE::~EXTERNMESSAGE` if it's renamed to `EXTERNMESSAGE::remove` in config.