### PR TITLE
Make TList<EXTERNMESSAGE>::Create not inlined and bin exact.

### DIFF
--- a/3rdParty/Storm/Source/storm.cpp
+++ b/3rdParty/Storm/Source/storm.cpp
@@ -134,7 +134,7 @@ BOOL STORMAPI SGdiSetPitch(int pitch) rBool;
 
 BOOL STORMAPI Ordinal393(char *string, int, int) rBool;
 
-void* STORMAPI SMemAlloc(size_t amount, char *logfilename, int logline, char defaultValue) rPVoid;
+void *STORMAPI SMemAlloc(size_t amount, char *logfilename, int logline, int defaultValue) rPVoid;
 
 BOOL STORMAPI SMemFree(void *location, char *logfilename, int logline, char defaultValue) rBool;
 

--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -814,13 +814,13 @@ BOOL STORMAPI Ordinal393(char *pszString, int, int);
  *  Returns a pointer to the allocated memory. This pointer does NOT include
  *  the additional storm header.
  */
-void*
-STORMAPI
-SMemAlloc(
-    unsigned int amount,
-    char  *logfilename,
-    int   logline,
-    char  defaultValue);
+void *
+    STORMAPI
+    SMemAlloc(
+        unsigned int amount,
+        char *logfilename,
+        int logline,
+        int defaultValue);
 
 #define SMAlloc(amount) SMemAlloc((amount), __FILE__, __LINE__)
 

--- a/Source/list.h
+++ b/Source/list.h
@@ -4,10 +4,6 @@
 
 #include "../3rdParty/Storm/Source/storm.h"
 
-#ifdef _MSC_VER
-#pragma warning (disable : 4291) // no matching operator delete found
-#endif
-
 #define OBJECT_NAME(obj) (((const char *)&typeid(obj)) + 8)
 
 /******************************************************************************
@@ -59,13 +55,6 @@ private:
 	// Hide copy-constructor and assignment operator
 	TList(const TList &);
 	TList &operator=(const TList &);
-
-	// replacement new/delete operators for Storm objects
-	static __forceinline T *SNew(size_t extralen, int flags)
-	{
-		void *obj = SMemAlloc(sizeof(T) + extralen, (char *)OBJECT_NAME(T), SLOG_OBJECT, flags | (1<<3));
-		return new (obj) T();
-	}
 
 	static __forceinline void SDelete(T *node)
 	{
@@ -131,7 +120,7 @@ T *TList<T>::Remove(T *node)
 template <class T>
 T *TList<T>::Create(InsertPos pos, size_t extra, int memflags)
 {
-	T *node = SNew(extra, memflags);
+	T *node = new (extra, memflags) T;
 	if (pos != NONE)
 		Insert(node, pos, NULL);
 	return node;

--- a/Source/msgcmd.cpp
+++ b/Source/msgcmd.cpp
@@ -12,7 +12,16 @@
 struct EXTERNMESSAGE {
 	LIST_LINK(EXTERNMESSAGE) m_Link;
 	char command[COMMAND_LEN];
-
+	void *operator new(size_t n, DWORD extralen, int flags)
+	{
+		return SMemAlloc(n + extralen, (char *)OBJECT_NAME(EXTERNMESSAGE), SLOG_OBJECT, flags | (1 << 3));
+	}
+	void operator delete(void *address, DWORD extralen, int flags)
+	{
+	}
+	void operator delete(void *address)
+	{
+	}
 	void *Delete(DWORD flags);
 };
 


### PR DESCRIPTION
I'm not entirely familair with overloading operator `new` so I was a bit confused at what is happening here. It seems like VS totally does not trust your parametrized `operator new` if you do not have `operator delete` with the same arguments and refuses to inline constructor call after it. It has warning about missing it though which we had unfortunately ignored.

Parameterized operator delete is complete obscure beast btw and it seems to get only used in case of exception thrown but still makes problems for us in this case.

_Edit: The effect from paragraph below seems to happen due to bug in old VC++._

Another annoyance is that after it to make explicit desturctor call from `EXTERNMESSAGE::Delete`  I had to add parameter-less `operator delete` which is never called so I didn't add any code there. Being completely technical then I have to also add parameter-less `operator new` which is never called and that way lies madness. Btw there's also workaround to just make double call to `m_Link.Unlink();` in `EXTERNMESSAGE::Delete` and be done with it no destructor calls needed.

TLDR: Custom `operator new` is alright and probably makes sense, `EXTERNMESSAGE::Delete` is abomination. But hopefully all that closes the deal with `msgcmd.cpp`