### PR TITLE
Infinity

### DIFF
--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -7,6 +7,7 @@
 #include <winuser.h>
 #include <winsock.h>
 #include <ddraw.h>
+#include <limits>
 
 // Note to self: Linker error => forgot a return value in cpp
 
@@ -52,6 +53,8 @@ typedef struct _WSIZE
 } WSIZE, *PWSIZE;
 
 #ifdef __cplusplus
+static float infinity = std::numeric_limits<float>::infinity();
+
 struct CCritSect {
 	CRITICAL_SECTION m_critsect;
 


### PR DESCRIPTION
This introduces infinity via storm.h, this should add the missing init functions at the start of files that include it, ex:
```
  440dae:    e9 00 00 00 00           jmp    0x440db3
  440db3:    a1 64 f1 47 00           mov    0x47f164,%eax
  440db8:    a3 00 97 67 00           mov    %eax,0x679700
  440dbd:    c3                       ret    
```