### PR TITLE
Add macro for aligning by 1 and apply it to 3 functions to make them bin exact

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -272,11 +272,11 @@ int GetDirection8(int x1, int y1, int x2, int y2)
 		{ 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
 		{ 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }
 	};
-	unsigned char trans[4][3] = { { 3, 4, 5 },
-		{ 3, 2, 1 },
-		{ 7, 0, 1 },
-		{ 7, 6, 5 } };
 	int mx, my, md;
+	ALIGN_BY_1 BYTE urtoll[] = { 3, 4, 5 },
+	ultolr[] = { 3, 2, 1 },
+	lrtoul[] = { 7, 6, 5 },
+	lltour[] = { 7, 0, 1 };
 
 	mx = abs(x2 - x1);
 	if (mx > 15)
@@ -287,13 +287,13 @@ int GetDirection8(int x1, int y1, int x2, int y2)
 	md = Dirs[my][mx];
 	if (x1 > x2) {
 		if (y1 > y2)
-			md = trans[0][md];
+			md = urtoll[md];
 		else
-			md = trans[1][md];
+			md = ultolr[md];
 	} else if (y1 > y2)
-		md = trans[3][md];
+		md = lrtoul[md];
 	else
-		md = trans[2][md];
+		md = lltour[md];
 	return md;
 }
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -655,7 +655,7 @@ void NetSendCmdGolem(BYTE mx, BYTE my, BYTE dir, BYTE menemy, int hp, BYTE cl)
 
 void NetSendCmdLoc(BOOL bHiPri, BYTE bCmd, BYTE x, BYTE y)
 {
-	TCmdLoc cmd;
+	ALIGN_BY_1 TCmdLoc cmd;
 
 	cmd.bCmd = bCmd;
 	cmd.x = x;
@@ -713,7 +713,7 @@ void NetSendCmdLocParam3(BOOL bHiPri, BYTE bCmd, BYTE x, BYTE y, WORD wParam1, W
 
 void NetSendCmdParam1(BOOL bHiPri, BYTE bCmd, WORD wParam1)
 {
-	TCmdParam1 cmd;
+	ALIGN_BY_1 TCmdParam1 cmd;
 
 	cmd.bCmd = bCmd;
 	cmd.wParam1 = wParam1;

--- a/defs.h
+++ b/defs.h
@@ -160,3 +160,10 @@ typedef void (*_PVFV)(void);
 #else
 #define SEG_ALLOCATE(SEGMENT)
 #endif
+
+// To apply to certain functions which have local variables aligned by 1 for unknown yet reason
+#ifdef _MSC_VER
+#define ALIGN_BY_1 __declspec(align(1))
+#else
+#define ALIGN_BY_1
+#endif


### PR DESCRIPTION
I also propose to close #507 and #1168 and open low-priority issue with the description similar to "Figure out nature of the unusual alignment of 3-byte structures/arrays and remove ALIGN_BY_1 macro"

This should leave just 5 functions as not bin-exact, each of which does not look like an easy target to my understanding.

Edit: I also applied `ALIGN_BY_1` to local vars, not to structs themselves to avoid touching anything else accidentally.