### PR TITLE
Fix min diff in dx_init.

### DIFF
--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -32,9 +32,9 @@ void dx_init(HWND hWnd)
 	SetFocus(hWnd);
 	ShowWindow(hWnd, SW_SHOWNORMAL);
 
-	lpGUID = (GUID *)DDCREATE_EMULATIONONLY;
-	if(!gbEmulate) {
-		lpGUID = NULL;
+	lpGUID = NULL;
+	if (gbEmulate) {
+		lpGUID = (GUID *)DDCREATE_EMULATIONONLY;
 	}
 	hDDVal = dx_DirectDrawCreate(lpGUID, &lpDDInterface, NULL);
 	if(hDDVal != DD_OK) {
@@ -76,7 +76,9 @@ void dx_init(HWND hWnd)
 			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 170);
 		}
 #ifdef __cplusplus
-		hDDVal = lpDDInterface->SetDisplayMode(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_BPP);
+		hDDVal = DD_OK;
+		if (hDDVal == DD_OK)
+			hDDVal = lpDDInterface->SetDisplayMode(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_BPP);
 #else
 		hDDVal = lpDDInterface->lpVtbl->SetDisplayMode(lpDDInterface, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_BPP);
 #endif


### PR DESCRIPTION
This fix makes very little sense. Basically, wrapping
```
hDDVal = lpDDInterface->SetDisplayMode(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_BPP);
```
over optimized away condition on `hDDVal` makes register usage correct.
The other solution is to replace it with `if` on anything non-trivial with two identical branches containing the function call but I think it's a bit uglier due to code duplication etc.

However since difference in register usage is about storing `0` this is still a bit weird why this particular function call matters since it does not involve zeroes, I have no believable explanation for this unfortunately.