### PR TITLE
dx_init bin exact (proper fix)

### DIFF
--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -32,9 +32,9 @@ void dx_init(HWND hWnd)
 	SetFocus(hWnd);
 	ShowWindow(hWnd, SW_SHOWNORMAL);
 
-	lpGUID = (GUID *)DDCREATE_EMULATIONONLY;
-	if(!gbEmulate) {
-		lpGUID = NULL;
+	lpGUID = NULL;
+	if(gbEmulate) {
+		lpGUID = (GUID *)DDCREATE_EMULATIONONLY;
 	}
 	hDDVal = dx_DirectDrawCreate(lpGUID, &lpDDInterface, NULL);
 	if(hDDVal != DD_OK) {
@@ -88,9 +88,9 @@ void dx_init(HWND hWnd)
 #else
 			hDDVal = lpDDInterface->lpVtbl->SetDisplayMode(lpDDInterface, winw, winh, SCREEN_BPP);
 #endif
-			if(hDDVal != DD_OK) {
-				ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 183);
-			}
+		}
+		if(hDDVal != DD_OK) {
+			ErrDlg(IDD_DIALOG1, hDDVal, "C:\\Src\\Diablo\\Source\\dx.cpp", 183);
 		}
 	}
 


### PR DESCRIPTION
Thanks to @predelnik original commit. As soon as I saw that it clicked, given that I based this function off older patches. It makes sense because the code for getting the system metrics was added in newer patches.