### PR TITLE
Replace resolution-related hard-coded numbers with constants

### DIFF
--- a/Source/doom.cpp
+++ b/Source/doom.cpp
@@ -2,7 +2,7 @@
 
 int doom_quest_time;
 int doom_stars_drawn;
-void *pDoomCel;
+BYTE *pDoomCel;
 BOOL doomflag;
 int DoomQuestState;
 
@@ -91,5 +91,5 @@ void doom_draw()
 		}
 	}
 
-	CelDecodeOnly(SCREEN_X, PANEL_Y - 1, (BYTE *)pDoomCel, 1, 640);
+	CelDecodeOnly(SCREEN_X, PANEL_Y - 1, pDoomCel, 1, SCREEN_WIDTH);
 }

--- a/Source/doom.h
+++ b/Source/doom.h
@@ -2,11 +2,11 @@
 #ifndef __DOOM_H__
 #define __DOOM_H__
 
-extern int doom_quest_time;  // weak
-extern int doom_stars_drawn; // weak
-extern void *pDoomCel;
-extern int doomflag;       // weak
-extern int DoomQuestState; // idb
+extern int doom_quest_time;
+extern int doom_stars_drawn;
+extern BYTE *pDoomCel;
+extern int doomflag;
+extern int DoomQuestState;
 
 /*
 void doom_reset_state();

--- a/Source/render.cpp
+++ b/Source/render.cpp
@@ -152,11 +152,11 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					if (dst < gpBufEnd)
 						break;
 					asm_trans_light_square_1_3(8, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (dst < gpBufEnd)
 						break;
 					asm_trans_light_square_0_2(8, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--i;
 				} while (i);
 				break;
@@ -187,7 +187,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					} while (yy_32);
 				LABEL_67:
 					WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--xx_32;
 				} while (xx_32);
 				break;
@@ -203,7 +203,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					} else {
 						asm_trans_light_cel_1_3(32 - xx_32, tbl, &dst, &src);
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						yy_32 = 2;
@@ -218,7 +218,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 							} else {
 								asm_trans_light_cel_1_3(32 - yy_32, tbl, &dst, &src);
 							}
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							yy_32 += 2;
 						} while (yy_32 != 32);
 						return;
@@ -236,7 +236,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						asm_trans_light_cel_1_3(32 - xx_32, tbl, &dst, &src);
 					}
 					src += (unsigned char)src & 2;
-					dst = &dst[xx_32 - 800];
+					dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						yy_32 = 2;
@@ -250,7 +250,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 								asm_trans_light_cel_1_3(32 - yy_32, tbl, &dst, &src);
 							}
 							src += (unsigned char)src & 2;
-							dst = &dst[yy_32 - 800];
+							dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 							yy_32 += 2;
 						} while (yy_32 != 32);
 						return;
@@ -269,7 +269,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					} else {
 						asm_trans_light_cel_1_3(32 - xx_32, tbl, &dst, &src);
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						i = 8;
@@ -277,11 +277,11 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 							if (dst < gpBufEnd)
 								break;
 							asm_trans_light_square_1_3(8, tbl, &dst, &src);
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							if (dst < gpBufEnd)
 								break;
 							asm_trans_light_square_0_2(8, tbl, &dst, &src);
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							--i;
 						} while (i);
 						return;
@@ -299,7 +299,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						asm_trans_light_cel_1_3(32 - xx_32, tbl, &dst, &src);
 					}
 					src += (unsigned char)src & 2;
-					dst = &dst[xx_32 - 800];
+					dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						i = 8;
@@ -307,11 +307,11 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 							if (dst < gpBufEnd)
 								break;
 							asm_trans_light_square_1_3(8, tbl, &dst, &src);
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							if (dst < gpBufEnd)
 								break;
 							asm_trans_light_square_0_2(8, tbl, &dst, &src);
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							--i;
 						} while (i);
 						return;
@@ -340,7 +340,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					dst += 4;
 					--j;
 				} while (j);
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				if (dst < gpBufEnd)
 					break;
 				j = 8;
@@ -351,7 +351,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					dst += 4;
 					--j;
 				} while (j);
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				--i;
 			} while (i);
 			break;
@@ -371,7 +371,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					if (!xx_32) {
 					LABEL_271:
 						WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						if (!--yy_32)
 							return;
 						goto LABEL_251;
@@ -475,7 +475,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						} while (n_draw_shift);
 					}
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					yy_32 = 2;
@@ -518,7 +518,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 								} while (n_draw_shift);
 							}
 						}
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						yy_32 += 2;
 					} while (yy_32 != 32);
 					return;
@@ -556,7 +556,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						dst += 2;
 					}
 				}
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					yy_32 = 2;
@@ -592,7 +592,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 								dst += 2;
 							}
 						}
-						dst = &dst[yy_32 - 800];
+						dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 						yy_32 += 2;
 					} while (yy_32 != 32);
 					return;
@@ -639,7 +639,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						} while (n_draw_shift);
 					}
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					i = 8;
@@ -654,7 +654,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 							dst += 4;
 							--j;
 						} while (j);
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						if (dst < gpBufEnd)
 							break;
 						j = 8;
@@ -665,7 +665,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 							dst += 4;
 							--j;
 						} while (j);
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						--i;
 					} while (i);
 					return;
@@ -703,7 +703,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 						dst += 2;
 					}
 				}
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					i = 8;
@@ -718,7 +718,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 							dst += 4;
 							--j;
 						} while (j);
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						if (dst < gpBufEnd)
 							break;
 						j = 8;
@@ -729,7 +729,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 							dst += 4;
 							--j;
 						} while (j);
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						--i;
 					} while (i);
 					return;
@@ -757,7 +757,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				dst += 4;
 				--j;
 			} while (j);
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (dst < gpBufEnd)
 				break;
 			j = 8;
@@ -767,7 +767,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				dst += 4;
 				--j;
 			} while (j);
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--i;
 		} while (i);
 		break;
@@ -840,7 +840,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 			} while (yy_32);
 		LABEL_391:
 			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!--xx_32)
 				return;
 		}
@@ -881,7 +881,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					} while (n_draw_shift);
 				}
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32)
 				break;
 		}
@@ -921,7 +921,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					} while (n_draw_shift);
 				}
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			yy_32 += 2;
 		} while (yy_32 != 32);
 		break;
@@ -961,7 +961,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					} while (n_draw_shift);
 				}
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32)
 				break;
 			dst += xx_32;
@@ -1001,7 +1001,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					} while (n_draw_shift);
 				}
 			}
-			dst = &dst[yy_32 - 800];
+			dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 			yy_32 += 2;
 		} while (yy_32 != 32);
 		break;
@@ -1042,7 +1042,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					} while (n_draw_shift);
 				}
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32)
 				break;
 		}
@@ -1057,7 +1057,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				dst += 4;
 				--j;
 			} while (j);
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (dst < gpBufEnd)
 				break;
 			j = 8;
@@ -1067,7 +1067,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				dst += 4;
 				--j;
 			} while (j);
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--i;
 		} while (i);
 		break;
@@ -1107,7 +1107,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 					} while (n_draw_shift);
 				}
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32)
 				break;
 			dst += xx_32;
@@ -1123,7 +1123,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				dst += 4;
 				--j;
 			} while (j);
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (dst < gpBufEnd)
 				break;
 			j = 8;
@@ -1133,7 +1133,7 @@ void drawTopArchesUpperScreen(BYTE *pBuff)
 				dst += 4;
 				--j;
 			} while (j);
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--i;
 		} while (i);
 		break;
@@ -1180,7 +1180,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					++dst;
 					--i;
 				} while (i);
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				--gpDrawMask;
 				--xx_32;
 			} while (xx_32);
@@ -1219,7 +1219,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					gdwCurrentMask = left_shift;
 				} while (yy_32);
 			LABEL_129:
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				--gpDrawMask;
 				--xx_32;
 			} while (xx_32);
@@ -1242,7 +1242,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 						--n_draw_shift;
 					} while (n_draw_shift);
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					yy_32 = 2;
@@ -1264,7 +1264,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 								--n_draw_shift;
 							} while (n_draw_shift);
 						}
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						yy_32 += 2;
 					} while (yy_32 != 32);
 					return;
@@ -1284,7 +1284,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					src += 4;
 					dst += 2;
 				}
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					yy_32 = 2;
@@ -1301,7 +1301,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 							src += 4;
 							dst += 2;
 						}
-						dst = &dst[yy_32 - 800];
+						dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 						yy_32 += 2;
 					} while (yy_32 != 32);
 					return;
@@ -1326,7 +1326,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 						--n_draw_shift;
 					} while (n_draw_shift);
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					gpDrawMask -= 16;
@@ -1344,7 +1344,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 							++dst;
 							--i;
 						} while (i);
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						--gpDrawMask;
 						--yy_32;
 					} while (yy_32);
@@ -1365,7 +1365,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					src += 4;
 					dst += 2;
 				}
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					gpDrawMask -= 16;
@@ -1384,7 +1384,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 							--i;
 						} while (i);
 						src += (unsigned char)src & 2;
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						--gpDrawMask;
 						--yy_32;
 					} while (yy_32);
@@ -1407,7 +1407,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					if (dst < gpBufEnd)
 						break;
 					asm_trans_light_mask(32, tbl, &dst, &src, *gpDrawMask);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--xx_32;
 				} while (xx_32);
@@ -1436,7 +1436,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 						gdwCurrentMask = asm_trans_light_mask(width, tbl, &dst, &src, gdwCurrentMask);
 					} while (yy_32);
 				LABEL_50:
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--xx_32;
 				} while (xx_32);
@@ -1447,7 +1447,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					dst += xx_32;
 					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						yy_32 = 2;
@@ -1457,7 +1457,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 							dst += yy_32;
 							src += (32 - (BYTE)yy_32) & 2;
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							yy_32 += 2;
 						} while (yy_32 != 32);
 						return;
@@ -1469,7 +1469,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 				while (dst >= gpBufEnd) {
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					src += (unsigned char)src & 2;
-					dst = &dst[xx_32 - 800];
+					dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						yy_32 = 2;
@@ -1478,7 +1478,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 								break;
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
 							src += (unsigned char)src & 2;
-							dst = &dst[yy_32 - 800];
+							dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 							yy_32 += 2;
 						} while (yy_32 != 32);
 						return;
@@ -1491,7 +1491,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					dst += xx_32;
 					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						gpDrawMask -= 16;
@@ -1501,7 +1501,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 								break;
 							src += (unsigned char)src & 2;
 							asm_trans_light_mask(32, tbl, &dst, &src, *gpDrawMask);
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							--gpDrawMask;
 							--yy_32;
 						} while (yy_32);
@@ -1514,7 +1514,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 				while (dst >= gpBufEnd) {
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					src += (unsigned char)src & 2;
-					dst = &dst[xx_32 - 800];
+					dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						gpDrawMask -= 16;
@@ -1524,7 +1524,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 								break;
 							asm_trans_light_mask(32, tbl, &dst, &src, *gpDrawMask);
 							src += (unsigned char)src & 2;
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							--gpDrawMask;
 							--yy_32;
 						} while (yy_32);
@@ -1560,7 +1560,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 				++dst;
 				--i;
 			} while (i);
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--gpDrawMask;
 			--xx_32;
 		} while (xx_32);
@@ -1599,7 +1599,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 				gdwCurrentMask = left_shift;
 			} while (yy_32);
 		LABEL_208:
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--gpDrawMask;
 			--xx_32;
 		} while (xx_32);
@@ -1620,7 +1620,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32) {
 				yy_32 = 2;
 				do {
@@ -1639,7 +1639,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 							--n_draw_shift;
 						} while (n_draw_shift);
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					yy_32 += 2;
 				} while (yy_32 != 32);
 				return;
@@ -1662,7 +1662,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32) {
 				yy_32 = 2;
 				do {
@@ -1680,7 +1680,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 							--n_draw_shift;
 						} while (n_draw_shift);
 					}
-					dst = &dst[yy_32 - 800];
+					dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 					yy_32 += 2;
 				} while (yy_32 != 32);
 				return;
@@ -1705,7 +1705,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32) {
 				gpDrawMask -= 16;
 				yy_32 = 16;
@@ -1721,7 +1721,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 						++dst;
 						--i;
 					} while (i);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--yy_32;
 				} while (yy_32);
@@ -1745,7 +1745,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32) {
 				gpDrawMask -= 16;
 				yy_32 = 16;
@@ -1761,7 +1761,7 @@ void drawBottomArchesUpperScreen(BYTE *pBuff, unsigned int *pMask)
 						++dst;
 						--i;
 					} while (i);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--yy_32;
 				} while (yy_32);
@@ -1828,7 +1828,7 @@ void drawUpperScreen(BYTE *pBuff)
 					dst += 4;
 					--j;
 				} while (j);
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				--i;
 			} while (i);
 			break;
@@ -1872,7 +1872,7 @@ void drawUpperScreen(BYTE *pBuff)
 					} while (n_draw_shift);
 				} while (yy_32);
 			LABEL_133:
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				--xx_32;
 			} while (xx_32);
 			break;
@@ -1894,7 +1894,7 @@ void drawUpperScreen(BYTE *pBuff)
 						--n_draw_shift;
 					} while (n_draw_shift);
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					yy_32 = 2;
@@ -1916,7 +1916,7 @@ void drawUpperScreen(BYTE *pBuff)
 								--n_draw_shift;
 							} while (n_draw_shift);
 						}
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						yy_32 += 2;
 					} while (yy_32 != 32);
 					return;
@@ -1936,7 +1936,7 @@ void drawUpperScreen(BYTE *pBuff)
 					src += 4;
 					dst += 2;
 				}
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					yy_32 = 2;
@@ -1953,7 +1953,7 @@ void drawUpperScreen(BYTE *pBuff)
 							src += 4;
 							dst += 2;
 						}
-						dst = &dst[yy_32 - 800];
+						dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 						yy_32 += 2;
 					} while (yy_32 != 32);
 					return;
@@ -1978,7 +1978,7 @@ void drawUpperScreen(BYTE *pBuff)
 						--n_draw_shift;
 					} while (n_draw_shift);
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					i = 16;
@@ -1992,7 +1992,7 @@ void drawUpperScreen(BYTE *pBuff)
 							dst += 4;
 							--j;
 						} while (j);
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						--i;
 					} while (i);
 					return;
@@ -2012,7 +2012,7 @@ void drawUpperScreen(BYTE *pBuff)
 					src += 4;
 					dst += 2;
 				}
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 				if (xx_32 < 0) {
 					i = 16;
@@ -2026,7 +2026,7 @@ void drawUpperScreen(BYTE *pBuff)
 							dst += 4;
 							--j;
 						} while (j);
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						--i;
 					} while (i);
 					return;
@@ -2048,7 +2048,7 @@ void drawUpperScreen(BYTE *pBuff)
 					if (dst < gpBufEnd)
 						break;
 					asm_cel_light_square(8, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--xx_32;
 				} while (xx_32);
 				break;
@@ -2073,7 +2073,7 @@ void drawUpperScreen(BYTE *pBuff)
 						asm_cel_light_edge(width, tbl, &dst, &src);
 					} while (yy_32);
 				LABEL_58:
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--xx_32;
 				} while (xx_32);
 				break;
@@ -2083,7 +2083,7 @@ void drawUpperScreen(BYTE *pBuff)
 					dst += xx_32;
 					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						yy_32 = 2;
@@ -2093,7 +2093,7 @@ void drawUpperScreen(BYTE *pBuff)
 							dst += yy_32;
 							src += (32 - (BYTE)yy_32) & 2;
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							yy_32 += 2;
 						} while (yy_32 != 32);
 						return;
@@ -2105,7 +2105,7 @@ void drawUpperScreen(BYTE *pBuff)
 				while (dst >= gpBufEnd) {
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					src += (unsigned char)src & 2;
-					dst = &dst[xx_32 - 800];
+					dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						yy_32 = 2;
@@ -2114,7 +2114,7 @@ void drawUpperScreen(BYTE *pBuff)
 								break;
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
 							src += (unsigned char)src & 2;
-							dst = &dst[yy_32 - 800];
+							dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 							yy_32 += 2;
 						} while (yy_32 != 32);
 						return;
@@ -2127,7 +2127,7 @@ void drawUpperScreen(BYTE *pBuff)
 					dst += xx_32;
 					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						yy_32 = 16;
@@ -2135,7 +2135,7 @@ void drawUpperScreen(BYTE *pBuff)
 							if (dst < gpBufEnd)
 								break;
 							asm_cel_light_square(8, tbl, &dst, &src);
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							--yy_32;
 						} while (yy_32);
 						return;
@@ -2147,7 +2147,7 @@ void drawUpperScreen(BYTE *pBuff)
 				while (dst >= gpBufEnd) {
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					src += (unsigned char)src & 2;
-					dst = &dst[xx_32 - 800];
+					dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 					xx_32 -= 2;
 					if (xx_32 < 0) {
 						yy_32 = 16;
@@ -2155,7 +2155,7 @@ void drawUpperScreen(BYTE *pBuff)
 							if (dst < gpBufEnd)
 								break;
 							asm_cel_light_square(8, tbl, &dst, &src);
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							--yy_32;
 						} while (yy_32);
 						return;
@@ -2187,7 +2187,7 @@ void drawUpperScreen(BYTE *pBuff)
 				dst += 4;
 				--j;
 			} while (j);
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--i;
 		} while (i);
 		break;
@@ -2230,7 +2230,7 @@ void drawUpperScreen(BYTE *pBuff)
 				} while (n_draw_shift);
 			} while (yy_32);
 		LABEL_205:
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--xx_32;
 		} while (xx_32);
 		break;
@@ -2250,7 +2250,7 @@ void drawUpperScreen(BYTE *pBuff)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32) {
 				yy_32 = 2;
 				do {
@@ -2269,7 +2269,7 @@ void drawUpperScreen(BYTE *pBuff)
 							--n_draw_shift;
 						} while (n_draw_shift);
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					yy_32 += 2;
 				} while (yy_32 != 32);
 				return;
@@ -2292,7 +2292,7 @@ void drawUpperScreen(BYTE *pBuff)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32) {
 				yy_32 = 2;
 				do {
@@ -2310,7 +2310,7 @@ void drawUpperScreen(BYTE *pBuff)
 							--n_draw_shift;
 						} while (n_draw_shift);
 					}
-					dst = &dst[yy_32 - 800];
+					dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 					yy_32 += 2;
 				} while (yy_32 != 32);
 				return;
@@ -2335,7 +2335,7 @@ void drawUpperScreen(BYTE *pBuff)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32) {
 				i = 16;
 				do {
@@ -2347,7 +2347,7 @@ void drawUpperScreen(BYTE *pBuff)
 						dst += 4;
 						--j;
 					} while (j);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--i;
 				} while (i);
 				return;
@@ -2370,7 +2370,7 @@ void drawUpperScreen(BYTE *pBuff)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!xx_32) {
 				i = 16;
 				do {
@@ -2382,7 +2382,7 @@ void drawUpperScreen(BYTE *pBuff)
 						dst += 4;
 						--j;
 					} while (j);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--i;
 				} while (i);
 				return;
@@ -2444,7 +2444,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src += 32;
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				if (dst < gpBufEnd) {
 					j = 8;
 					do {
@@ -2457,7 +2457,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src += 32;
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				--i;
 			} while (i);
 			break;
@@ -2477,7 +2477,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					if (!yy_32) {
 					LABEL_433:
 						WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						if (!--xx_32)
 							return;
 						goto LABEL_412;
@@ -2580,7 +2580,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src = &src[-xx_32 + 32];
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				if (!xx_32)
 					break;
 			}
@@ -2623,7 +2623,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src = &src[-yy_32 + 32];
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				yy_32 += 2;
 			} while (yy_32 != 32);
 			break;
@@ -2666,7 +2666,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src = &src[-xx_32 + 32];
 					dst = &dst[-xx_32 + 32];
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				if (!xx_32)
 					break;
 				dst += xx_32;
@@ -2709,7 +2709,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src = &src[-yy_32 + 32];
 					dst = &dst[-yy_32 + 32];
 				}
-				dst = &dst[yy_32 - 800];
+				dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 				yy_32 += 2;
 			} while (yy_32 != 32);
 			break;
@@ -2753,7 +2753,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src = &src[-xx_32 + 32];
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				if (!xx_32)
 					break;
 			}
@@ -2771,7 +2771,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src += 32;
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				if (dst < gpBufEnd) {
 					j = 8;
 					do {
@@ -2784,7 +2784,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src += 32;
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				--i;
 			} while (i);
 			break;
@@ -2827,7 +2827,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src = &src[-xx_32 + 32];
 					dst = &dst[-xx_32 + 32];
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				if (!xx_32)
 					break;
 				dst += xx_32;
@@ -2846,7 +2846,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src += 32;
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				if (dst < gpBufEnd) {
 					j = 8;
 					do {
@@ -2859,7 +2859,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src += 32;
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				--i;
 			} while (i);
 			break;
@@ -2880,14 +2880,14 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					src += 32;
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				if (dst < gpBufEnd) {
 					asm_trans_light_square_0_2(8, tbl, &dst, &src);
 				} else {
 					src += 32;
 					dst += 32;
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				--i;
 			} while (i);
 			break;
@@ -2921,7 +2921,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 				} while (yy_32);
 			LABEL_69:
 				WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				--xx_32;
 			} while (xx_32);
 			break;
@@ -2955,7 +2955,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 						} else {
 							asm_trans_light_cel_1_3(32 - yy_32, tbl, &dst, &src);
 						}
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						yy_32 += 2;
 					} while (yy_32 != 32);
 					return;
@@ -2976,7 +2976,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 				} else {
 					asm_trans_light_cel_1_3(32 - xx_32, tbl, &dst, &src);
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				xx_32 -= 2;
 			} while (xx_32 >= 0);
 			goto LABEL_98;
@@ -3009,7 +3009,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 							asm_trans_light_cel_1_3(32 - yy_32, tbl, &dst, &src);
 						}
 						src += (unsigned char)src & 2;
-						dst = &dst[yy_32 - 800];
+						dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 						yy_32 += 2;
 					} while (yy_32 != 32);
 					return;
@@ -3029,7 +3029,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					asm_trans_light_cel_1_3(32 - xx_32, tbl, &dst, &src);
 				}
 				src += (unsigned char)src & 2;
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 			} while (xx_32 >= 0);
 			goto LABEL_154;
@@ -3050,14 +3050,14 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 							src += 32;
 							dst += 32;
 						}
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						if (dst < gpBufEnd) {
 							asm_trans_light_square_0_2(8, tbl, &dst, &src);
 						} else {
 							src += 32;
 							dst += 32;
 						}
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						--i;
 					} while (i);
 					return;
@@ -3078,7 +3078,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 				} else {
 					asm_trans_light_cel_1_3(32 - xx_32, tbl, &dst, &src);
 				}
-				dst -= 800;
+				dst -= (SCREEN_WIDTH + 160);
 				xx_32 -= 2;
 			} while (xx_32 >= 0);
 			goto LABEL_210;
@@ -3099,14 +3099,14 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 							src += 32;
 							dst += 32;
 						}
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						if (dst < gpBufEnd) {
 							asm_trans_light_square_0_2(8, tbl, &dst, &src);
 						} else {
 							src += 32;
 							dst += 32;
 						}
-						dst -= 800;
+						dst -= (SCREEN_WIDTH + 160);
 						--i;
 					} while (i);
 					return;
@@ -3126,7 +3126,7 @@ void drawTopArchesLowerScreen(BYTE *pBuff)
 					asm_trans_light_cel_1_3(32 - xx_32, tbl, &dst, &src);
 				}
 				src += (unsigned char)src & 2;
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 			} while (xx_32 >= 0);
 			goto LABEL_249;
@@ -3153,7 +3153,7 @@ LABEL_11:
 				src += 32;
 				dst += 32;
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (dst < gpBufEnd) {
 				j = 8;
 				do {
@@ -3167,7 +3167,7 @@ LABEL_11:
 				src += 32;
 				dst += 32;
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--i;
 		} while (i);
 		break;
@@ -3247,7 +3247,7 @@ LABEL_11:
 			} while (yy_32);
 		LABEL_293:
 			WorldBoolFlag = ((BYTE)WorldBoolFlag + 1) & 1;
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			if (!--xx_32)
 				return;
 		}
@@ -3310,7 +3310,7 @@ LABEL_11:
 							} while (n_draw_shift);
 						}
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					yy_32 += 2;
 				} while (yy_32 != 32);
 				return;
@@ -3359,7 +3359,7 @@ LABEL_11:
 					} while (n_draw_shift);
 				}
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			xx_32 -= 2;
 		} while (xx_32 >= 0);
 		goto LABEL_308;
@@ -3405,7 +3405,7 @@ LABEL_11:
 						dst += 2;
 					}
 				}
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 			} while (xx_32 >= 0);
 			goto LABEL_336;
@@ -3453,7 +3453,7 @@ LABEL_11:
 					dst += 2;
 				}
 			}
-			dst = &dst[yy_32 - 800];
+			dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 			yy_32 += 2;
 		} while (yy_32 != 32);
 		break;
@@ -3481,7 +3481,7 @@ LABEL_11:
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (dst < gpBufEnd) {
 						j = 8;
 						do {
@@ -3495,7 +3495,7 @@ LABEL_11:
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--i;
 				} while (i);
 				return;
@@ -3544,7 +3544,7 @@ LABEL_11:
 					} while (n_draw_shift);
 				}
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			xx_32 -= 2;
 		} while (xx_32 >= 0);
 		goto LABEL_364;
@@ -3572,7 +3572,7 @@ LABEL_11:
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (dst < gpBufEnd) {
 						j = 8;
 						do {
@@ -3586,7 +3586,7 @@ LABEL_11:
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--i;
 				} while (i);
 				return;
@@ -3626,7 +3626,7 @@ LABEL_11:
 					dst += 2;
 				}
 			}
-			dst = &dst[xx_32 - 800];
+			dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 			xx_32 -= 2;
 		} while (xx_32 >= 0);
 		goto LABEL_389;
@@ -3677,7 +3677,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--yy_32;
 				} while (yy_32);
@@ -3719,7 +3719,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						yy_32 -= width;
 					} while (yy_32);
 				LABEL_252:
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--xx_32;
 				} while (xx_32);
@@ -3744,7 +3744,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src = &src[32 - i];
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (!i)
 						break;
 				}
@@ -3768,7 +3768,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src = &src[32 - i];
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					i += 2;
 				} while (i != 32);
 				break;
@@ -3791,7 +3791,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src = &src[32 - i];
 						dst = &dst[32 - i];
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (!i)
 						break;
 					dst += i;
@@ -3815,7 +3815,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src = &src[32 - i];
 						dst = &dst[32 - i];
 					}
-					dst = &dst[i - 800];
+					dst = &dst[i - (SCREEN_WIDTH + 160)];
 					i += 2;
 				} while (i != 32);
 				break;
@@ -3839,7 +3839,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src = &src[32 - i];
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (!i)
 						break;
 				}
@@ -3860,7 +3860,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--yy_32;
 				} while (yy_32);
@@ -3884,7 +3884,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src = &src[32 - i];
 						dst = &dst[32 - i];
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (!i)
 						break;
 					dst += i;
@@ -3906,7 +3906,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--yy_32;
 				} while (yy_32);
@@ -3928,7 +3928,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--yy_32;
 				} while (yy_32);
@@ -3960,7 +3960,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						yy_32 -= width;
 					} while (yy_32);
 				LABEL_52:
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--xx_32;
 				} while (xx_32);
@@ -3988,7 +3988,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 							src += (32 - (BYTE)yy_32) & 2;
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
 							yy_32 += 2;
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 						} while (yy_32 != 32);
 						return;
 					}
@@ -4001,7 +4001,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 					dst += xx_32;
 					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					xx_32 -= 2;
 				} while (xx_32 >= 0);
 				goto LABEL_62;
@@ -4027,7 +4027,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
 							/// BUGFIX: uncomment this line
 							// src += (unsigned char)src & 2;
-							dst = &dst[yy_32 - 800];
+							dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 							yy_32 += 2;
 						} while (yy_32 != 32);
 						return;
@@ -4040,7 +4040,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 				do {
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					src += (unsigned char)src & 2;
-					dst = &dst[xx_32 - 800];
+					dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 					xx_32 -= 2;
 				} while (xx_32 >= 0);
 				goto LABEL_80;
@@ -4061,7 +4061,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 								src += 32;
 								dst += 32;
 							}
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							--gpDrawMask;
 							--yy_32;
 						} while (yy_32);
@@ -4076,7 +4076,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 					dst += xx_32;
 					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					xx_32 -= 2;
 				} while (xx_32 >= 0);
 				goto LABEL_98;
@@ -4098,7 +4098,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 								src += 32;
 								dst += 32;
 							}
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							--gpDrawMask;
 							--yy_32;
 						} while (yy_32);
@@ -4112,7 +4112,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 				do {
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					src += (unsigned char)src & 2;
-					dst = &dst[xx_32 - 800];
+					dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 					xx_32 -= 2;
 				} while (xx_32 >= 0);
 				goto LABEL_117;
@@ -4148,7 +4148,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 				src += 32;
 				dst += 32;
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--gpDrawMask;
 			--yy_32;
 		} while (yy_32);
@@ -4190,7 +4190,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 				yy_32 -= width;
 			} while (yy_32);
 		LABEL_152:
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--gpDrawMask;
 			--xx_32;
 		} while (xx_32);
@@ -4229,7 +4229,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 							--n_draw_shift;
 						} while (n_draw_shift);
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					yy_32 += 2;
 				} while (yy_32 != 32);
 				return;
@@ -4255,7 +4255,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			xx_32 -= 2;
 		} while (xx_32 >= 0);
 		goto LABEL_162;
@@ -4281,7 +4281,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 					src += 4;
 					dst += 2;
 				}
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 			} while (xx_32 >= 0);
 			goto LABEL_180;
@@ -4310,7 +4310,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 				src += 4;
 				dst += 2;
 			}
-			dst = &dst[yy_32 - 800];
+			dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 			yy_32 += 2;
 		} while (yy_32 != 32);
 		break;
@@ -4340,7 +4340,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--yy_32;
 				} while (yy_32);
@@ -4367,7 +4367,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			xx_32 -= 2;
 		} while (xx_32 >= 0);
 		goto LABEL_198;
@@ -4398,7 +4398,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--gpDrawMask;
 					--yy_32;
 				} while (yy_32);
@@ -4420,7 +4420,7 @@ void drawBottomArchesLowerScreen(BYTE *pBuff, unsigned int *pMask)
 				src += 4;
 				dst += 2;
 			}
-			dst = &dst[xx_32 - 800];
+			dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 			xx_32 -= 2;
 		} while (xx_32 >= 0);
 		goto LABEL_217;
@@ -4485,7 +4485,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--i;
 				} while (i);
 				break;
@@ -4532,7 +4532,7 @@ void drawLowerScreen(BYTE *pBuff)
 						}
 					} while (yy_32);
 				LABEL_232:
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--xx_32;
 				} while (xx_32);
 				break;
@@ -4556,7 +4556,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src = &src[32 - i];
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (!i)
 						break;
 				}
@@ -4580,7 +4580,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src = &src[32 - i];
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					i += 2;
 				} while (i != 32);
 				break;
@@ -4603,7 +4603,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src = &src[32 - i];
 						dst = &dst[32 - i];
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (!i)
 						break;
 					dst += i;
@@ -4627,7 +4627,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src = &src[32 - i];
 						dst = &dst[32 - i];
 					}
-					dst = &dst[i - 800];
+					dst = &dst[i - (SCREEN_WIDTH + 160)];
 					i += 2;
 				} while (i != 32);
 				break;
@@ -4651,7 +4651,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src = &src[32 - i];
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (!i)
 						break;
 				}
@@ -4668,7 +4668,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--i;
 				} while (i);
 				break;
@@ -4691,7 +4691,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src = &src[32 - i];
 						dst = &dst[32 - i];
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					if (!i)
 						break;
 					dst += i;
@@ -4709,7 +4709,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--i;
 				} while (i);
 				break;
@@ -4730,7 +4730,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--xx_32;
 				} while (xx_32);
 				break;
@@ -4754,7 +4754,7 @@ void drawLowerScreen(BYTE *pBuff)
 							yy_32 -= width;
 						}
 					} while (yy_32);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--xx_32;
 				} while (xx_32);
 				break;
@@ -4781,7 +4781,7 @@ void drawLowerScreen(BYTE *pBuff)
 							src += (32 - (BYTE)yy_32) & 2;
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
 							yy_32 += 2;
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 						} while (yy_32 != 32);
 						return;
 					}
@@ -4794,7 +4794,7 @@ void drawLowerScreen(BYTE *pBuff)
 					dst += xx_32;
 					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					xx_32 -= 2;
 				} while (xx_32 >= 0);
 				goto LABEL_68;
@@ -4819,7 +4819,7 @@ void drawLowerScreen(BYTE *pBuff)
 						do {
 							asm_cel_light_edge(32 - yy_32, tbl, &dst, &src);
 							src += (unsigned char)src & 2;
-							dst = &dst[yy_32 - 800];
+							dst = &dst[yy_32 - (SCREEN_WIDTH + 160)];
 							yy_32 += 2;
 						} while (yy_32 != 32);
 						return;
@@ -4832,7 +4832,7 @@ void drawLowerScreen(BYTE *pBuff)
 				do {
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					src += (unsigned char)src & 2;
-					dst = &dst[xx_32 - 800];
+					dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 					xx_32 -= 2;
 				} while (xx_32 >= 0);
 				goto LABEL_83;
@@ -4852,7 +4852,7 @@ void drawLowerScreen(BYTE *pBuff)
 								src += 32;
 								dst += 32;
 							}
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							--i;
 						} while (i);
 						return;
@@ -4866,7 +4866,7 @@ void drawLowerScreen(BYTE *pBuff)
 					dst += xx_32;
 					src += (32 - (BYTE)xx_32) & 2;
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					xx_32 -= 2;
 				} while (xx_32 >= 0);
 				goto LABEL_100;
@@ -4886,7 +4886,7 @@ void drawLowerScreen(BYTE *pBuff)
 								src += 32;
 								dst += 32;
 							}
-							dst -= 800;
+							dst -= (SCREEN_WIDTH + 160);
 							--j;
 						} while (j);
 						return;
@@ -4899,7 +4899,7 @@ void drawLowerScreen(BYTE *pBuff)
 				do {
 					asm_cel_light_edge(32 - xx_32, tbl, &dst, &src);
 					src += (unsigned char)src & 2;
-					dst = &dst[xx_32 - 800];
+					dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 					xx_32 -= 2;
 				} while (xx_32 >= 0);
 				goto LABEL_116;
@@ -4932,7 +4932,7 @@ void drawLowerScreen(BYTE *pBuff)
 				src += 32;
 				dst += 32;
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--i;
 		} while (i);
 		break;
@@ -4981,7 +4981,7 @@ void drawLowerScreen(BYTE *pBuff)
 				}
 			} while (yy_32);
 		LABEL_143:
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			--xx_32;
 		} while (xx_32);
 		break;
@@ -5020,7 +5020,7 @@ void drawLowerScreen(BYTE *pBuff)
 						} while (n_draw_shift);
 					}
 					yy_32 += 2;
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 				} while (yy_32 < 32);
 				return;
 			}
@@ -5045,7 +5045,7 @@ void drawLowerScreen(BYTE *pBuff)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			xx_32 -= 2;
 		} while (xx_32 >= 0);
 		goto LABEL_153;
@@ -5071,7 +5071,7 @@ void drawLowerScreen(BYTE *pBuff)
 					src += 4;
 					dst += 2;
 				}
-				dst = &dst[xx_32 - 800];
+				dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 				xx_32 -= 2;
 			} while (xx_32 >= 0);
 			goto LABEL_171;
@@ -5102,7 +5102,7 @@ void drawLowerScreen(BYTE *pBuff)
 			}
 			dst += yy_32;
 			yy_32 += 2;
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 		} while (yy_32 < 32);
 		break;
 	case 12: // lower (solid), without lighting
@@ -5127,7 +5127,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--i;
 				} while (i);
 				return;
@@ -5153,7 +5153,7 @@ void drawLowerScreen(BYTE *pBuff)
 					--n_draw_shift;
 				} while (n_draw_shift);
 			}
-			dst -= 800;
+			dst -= (SCREEN_WIDTH + 160);
 			xx_32 -= 2;
 		} while (xx_32 >= 0);
 		goto LABEL_189;
@@ -5179,7 +5179,7 @@ void drawLowerScreen(BYTE *pBuff)
 						src += 32;
 						dst += 32;
 					}
-					dst -= 800;
+					dst -= (SCREEN_WIDTH + 160);
 					--i;
 				} while (i);
 				return;
@@ -5200,7 +5200,7 @@ void drawLowerScreen(BYTE *pBuff)
 				src += 4;
 				dst += 2;
 			}
-			dst = &dst[xx_32 - 800];
+			dst = &dst[xx_32 - (SCREEN_WIDTH + 160)];
 			xx_32 -= 2;
 		} while (xx_32 >= 0);
 		goto LABEL_205;

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -2214,7 +2214,7 @@ void scrollrt_draw_game_screen(BOOL draw_cursor)
 
 	if (drawpanflag == 255) {
 		drawpanflag = 0;
-		hgt = 480;
+		hgt = SCREEN_HEIGHT;
 	} else {
 		hgt = 0;
 	}
@@ -2632,7 +2632,7 @@ void DrawAndBlit()
 	}
 	if (talkflag) {
 		DrawTalkPan();
-		hgt = 480;
+		hgt = SCREEN_HEIGHT;
 	}
 	scrollrt_draw_cursor_item();
 	unlock_buf(0);


### PR DESCRIPTION
If I replace `SCREEN_WIDTH`/`SCREEN_HEIGHT` in `defs.h` with something other than 640x480 (say qHD - 960x540), I get something like this in-game:
![qhd-master](https://user-images.githubusercontent.com/221979/60622417-fe8ae600-9de8-11e9-91aa-974c0c0ff6c6.png)

This pull request turns it into this:
![qhd-pr](https://user-images.githubusercontent.com/221979/60622446-0fd3f280-9de9-11e9-9f05-364db4b12cdd.png)

The visuals are far from perfect after the pull request. And so is the code. I'm still trying to understand what its the correct way to express the remaining `160` in the code via constants. But it is definitely an improvement.