### PR TITLE
Rename global pCelBuff to pSPentSpn2Cels

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -2327,7 +2327,7 @@ void DrawGoldSplit(int amount)
 	} else {
 		screen_x = 450;
 	}
-	CelDecodeOnly(screen_x, 300, pCelBuff, nGoldFrame, 12);
+	CelDecodeOnly(screen_x, 300, pSPentSpn2Cels, nGoldFrame, 12);
 	nGoldFrame = (nGoldFrame & 7) + 1;
 }
 
@@ -2434,7 +2434,7 @@ void DrawTalkPan()
 	}
 	if (msg)
 		*msg = '\0';
-	CelDecDatOnly(gpBuffer + x, pCelBuff, frame, 12);
+	CelDecDatOnly(gpBuffer + x, pSPentSpn2Cels, frame, 12);
 	talk_btn = 0;
 	frame = (frame & 7) + 1;
 	for (i = 0; i < 4; i++) {

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -697,7 +697,7 @@ void PrintQLString(int x, int y, BOOL cjustflag, char *str, int col)
 		off += k;
 	}
 	if (qline == y) {
-		CelDecodeOnly(cjustflag ? x + k + 76 : x + 76, s + 205, pCelBuff, ALLQUESTS, 12);
+		CelDecodeOnly(cjustflag ? x + k + 76 : x + 76, s + 205, pSPentSpn2Cels, ALLQUESTS, 12);
 	}
 	for (i = 0; i < len; i++) {
 		c = fontframe[gbFontTransTbl[(BYTE)str[i]]];
@@ -708,7 +708,7 @@ void PrintQLString(int x, int y, BOOL cjustflag, char *str, int col)
 		off += fontkern[c] + 1;
 	}
 	if (qline == y) {
-		CelDecodeOnly(cjustflag ? x + k + 100 : 340 - x, s + 205, pCelBuff, ALLQUESTS, 12);
+		CelDecodeOnly(cjustflag ? x + k + 100 : 340 - x, s + 205, pSPentSpn2Cels, ALLQUESTS, 12);
 	}
 }
 

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -26,7 +26,7 @@ int stextvhold;
 int stextsel;
 char stextscrldbtn;
 int gossipend;
-BYTE *pCelBuff;
+BYTE *pSPentSpn2Cels;
 int stextsval;
 int boylevel;
 ItemStruct smithitem[20];
@@ -77,7 +77,7 @@ void InitStores()
 	int i;
 
 	pSTextBoxCels = LoadFileInMem("Data\\TextBox2.CEL", NULL);
-	pCelBuff = LoadFileInMem("Data\\PentSpn2.CEL", NULL);
+	pSPentSpn2Cels = LoadFileInMem("Data\\PentSpn2.CEL", NULL);
 	pSTextSlidCels = LoadFileInMem("Data\\TextSlid.CEL", NULL);
 	ClearSText(0, 24);
 	stextflag = STORE_NONE;
@@ -124,7 +124,7 @@ void SetupTownStores()
 void FreeStoreMem()
 {
 	MemFreeDbg(pSTextBoxCels);
-	MemFreeDbg(pCelBuff);
+	MemFreeDbg(pSPentSpn2Cels);
 	MemFreeDbg(pSTextSlidCels);
 }
 
@@ -167,7 +167,7 @@ void PrintSString(int x, int y, BOOL cjustflag, char *str, char col, int val)
 		off += k;
 	}
 	if (stextsel == y) {
-		CelDecodeOnly(cjustflag ? xx + x + k - 20 : xx + x - 20, s + 205, pCelBuff, InStoreFlag, 12);
+		CelDecodeOnly(cjustflag ? xx + x + k - 20 : xx + x - 20, s + 205, pSPentSpn2Cels, InStoreFlag, 12);
 	}
 	for (i = 0; i < len; i++) {
 		c = fontframe[gbFontTransTbl[(BYTE)str[i]]];
@@ -189,7 +189,7 @@ void PrintSString(int x, int y, BOOL cjustflag, char *str, char col, int val)
 		}
 	}
 	if (stextsel == y) {
-		CelDecodeOnly(cjustflag ? xx + x + k + 4 : 660 - x, s + 205, pCelBuff, InStoreFlag, 12);
+		CelDecodeOnly(cjustflag ? xx + x + k + 4 : 660 - x, s + 205, pSPentSpn2Cels, InStoreFlag, 12);
 	}
 }
 

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -28,7 +28,7 @@ extern int stextvhold;
 extern int stextsel;
 extern char stextscrldbtn;
 extern int gossipend;
-extern BYTE *pCelBuff;
+extern BYTE *pSPentSpn2Cels;
 extern int stextsval;
 extern int boylevel;
 extern ItemStruct smithitem[20];


### PR DESCRIPTION
This is to avoid confusion, as pCelBuff is also
commonly used as a parameter name.

The naming follows the convention used by
TextBox2.CEL and TextSlid.CEL, as seen in
stores.cpp

	pSTextBoxCels = LoadFileInMem("Data\\TextBox2.CEL", NULL);
	pSPentSpn2Cels = LoadFileInMem("Data\\PentSpn2.CEL", NULL);
	pSTextSlidCels = LoadFileInMem("Data\\TextSlid.CEL", NULL);