### PR TITLE
Fix AddCbolt conditional

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2283,12 +2283,16 @@ void AddFlamec(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, 
 
 void AddCbolt(int mi, int sx, int sy, int dx, int dy, int midir, char micaster, int id, int dam)
 {
+	/// ASSERT: assert((DWORD)mi < MAXMISSILES);
+
 	if (micaster == 0) {
-		if (id != -1)
+		if (id == myplr) {
 			missile[mi]._mirnd = random(63, 15) + 1;
-		else
+			missile[mi]._midam = random(68, plr[id]._pMagic >> 2) + 1;
+		} else {
 			missile[mi]._mirnd = random(63, 15) + 1;
-		missile[mi]._midam = random(68, plr[id]._pMagic >> 2) + 1;
+			missile[mi]._midam = random(68, plr[id]._pMagic >> 2) + 1;
+		}
 	} else {
 		missile[mi]._mirnd = random(63, 15) + 1;
 		missile[mi]._midam = 15;


### PR DESCRIPTION
So this technically doesn't fix anything, since the code generated is already bin exact. However if you look at the debug release, you can see the ASM of the removed conditional, which compares `id` with `myplr`. But `eax` is then overwritten by the call to random. So if compiled with visual c++ 4.20, the ASM will now match the debug release.
![Capture](https://user-images.githubusercontent.com/15209402/61166789-19e8a600-a4f9-11e9-954e-13f47baf7a3b.PNG)
