### PR TITLE
Cast pointer to ptrdiff_t to make code less undefined for 64-bit.

### DIFF
--- a/Source/list.h
+++ b/Source/list.h
@@ -186,14 +186,14 @@ public:
 
 	T *Next()
 	{
-		if ((int)m_nextNode <= 0)
+		if ((ptrdiff_t)m_nextNode <= 0)
 			return NULL;
 		return m_nextNode;
 	}
 
 	TLink<T> *NextLink(size_t offset = -1)
 	{
-		if ((int)m_nextNode <= 0)
+		if ((ptrdiff_t)m_nextNode <= 0)
 			return (TLink<T> *)~((size_t)m_nextNode);
 
 		if ((int)offset < 0) {


### PR DESCRIPTION
We already use `size_t` in some places here, so using `prtdiff_t` in cases where sign is needed probably makes sense. Should not change code for 32-bit.