### PR TITLE
Alt+Enter fullscreen (debug)

### DIFF
--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -396,6 +396,15 @@ LRESULT __stdcall MainWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 	case WM_ACTIVATEAPP:
 		init_activate_window(hWnd, wParam);
 		break;
+#ifdef _DEBUG
+	case WM_SYSKEYUP:
+		if(wParam == VK_RETURN) {
+			fullscreen = !fullscreen;
+			dx_reinit();
+			return 0;
+		}
+		break;
+#endif
 	case WM_QUERYNEWPALETTE:
 		SDrawRealizePalette();
 		return 1;


### PR DESCRIPTION
I'm currently in the process of re-cleaning up all functions. In doing so, the function in question is compared to both the beta and debug release. Beta to make sure stack variables are right, and debug to ensure all debug code and assertions are implemented.

This feature in particular allows you to press alt+enter to switch between fullscreen and windowed mode. Keep in mind that vanilla is broken on modern computers unless you use the RGBMODE fix.