### PR TITLE
Get scrollrt_draw_dungeon to min diff

### DIFF
--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1696,7 +1696,10 @@ void scrollrt_draw_dungeon(BYTE *pBuff, int sx, int sy, int capChunks, int CelCa
 		}
 	}
 	if (bFlag & BFLAG_DEAD_PLAYER) {
-		DrawDeadPlayer(sx, sy, dx, dy, 0, CelCap, 0);
+		if (light_table_index)
+			DrawDeadPlayer(sx, sy, dx, dy, 0, CelCap, 0);
+		else
+			DrawDeadPlayer(sx, sy, dx, dy, 0, CelCap, 0);
 	}
 	if (bPlr > 0) {
 		p = bPlr - 1;


### PR DESCRIPTION
Credit goes to @Predelnik for figuring this one out. Adding it in preparation for doing a 0.9.9 release this weekend.

![image](https://user-images.githubusercontent.com/204594/61569038-cab8ed00-aa85-11e9-9fea-349c44d8ed33.png)

This means that all functions are now the correct size so most jumps should now be correct.

Update:
Diff before: 2% change, 2668 insertions(+), 2766 deletions(-)
Diff after: 1% change, 2543 insertions(+), 2635 deletions(-)