### PR TITLE
Change PCX struct to match Z-Soft Manual

### DIFF
--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -43,19 +43,19 @@ void CaptureScreen()
 BOOL CaptureHdr(HANDLE hFile, short width, short height)
 {
 	DWORD lpNumBytes;
-	PCXHeader Buffer;
+	PCXHEADER Buffer;
 
 	memset(&Buffer, 0, sizeof(Buffer));
-	Buffer.manufacturer = 10;
-	Buffer.version = 5;
-	Buffer.encoding = 1;
-	Buffer.bitsPerPixel = 8;
-	Buffer.xmax = width - 1;
-	Buffer.ymax = height - 1;
-	Buffer.horzRes = width;
-	Buffer.vertRes = height;
-	Buffer.numColorPlanes = 1;
-	Buffer.bytesPerScanLine = width;
+	Buffer.Manufacturer = 10;
+	Buffer.Version = 5;
+	Buffer.Encoding = 1;
+	Buffer.BitsPerPixel = 8;
+	Buffer.Xmax = width - 1;
+	Buffer.Ymax = height - 1;
+	Buffer.HDpi = width;
+	Buffer.VDpi = height;
+	Buffer.NPlanes = 1;
+	Buffer.BytesPerLine = width;
 
 	return WriteFile(hFile, &Buffer, sizeof(Buffer), &lpNumBytes, NULL) && lpNumBytes == sizeof(Buffer);
 }

--- a/structs.h
+++ b/structs.h
@@ -1552,22 +1552,26 @@ typedef struct _plrmsg {
 // capture
 //////////////////////////////////////////////////
 
-typedef struct PCXHeader {
-	char manufacturer;
-	char version;
-	char encoding;
-	char bitsPerPixel;
-	short xmin, ymin;
-	short xmax, ymax;
-	short horzRes, vertRes;
-	char palette[48];
-	char reserved;
-	char numColorPlanes;
-	short bytesPerScanLine;
-	short paletteType;
-	short horzSize, vertSize;
-	char padding[54];
-} PCXHeader;
+typedef struct _PcxHeader {
+	BYTE Manufacturer;
+	BYTE Version;
+	BYTE Encoding;
+	BYTE BitsPerPixel;
+	WORD Xmin;
+	WORD Ymin;
+	WORD Xmax;
+	WORD Ymax;
+	WORD HDpi;
+	WORD VDpi;
+	BYTE Colormap[48];
+	BYTE Reserved;
+	BYTE NPlanes;
+	WORD BytesPerLine;
+	WORD PaletteInfo;
+	WORD HscreenSize;
+	WORD VscreenSize;
+	BYTE Filler[54];
+} PCXHEADER;
 
 //////////////////////////////////////////////////
 // encrypt


### PR DESCRIPTION
The PCX header struct was taken from some random modern decoder. To make things more accurate, it now aligns with the official [Z-Soft PCX Reference Manual](https://github.com/qb40/dpanimkit/blob/master/PCX.TXT#L102). Which also matches up with various PCX samples released in the early 1990's. All types are unsigned (BYTE/WORD).