### PR TITLE
Add Select Hero enum

### DIFF
--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -35,7 +35,7 @@ int __stdcall mainmenu_select_hero_dialog(
     BOOL *multi)
 {
 	BOOL hero_is_created = TRUE;
-	int dlgresult = NEW_GAME;
+	int dlgresult = 0;
 	if (gbMaxPlayers == 1) {
 		if (!UiSelHeroSingDialog(
 		        pfile_ui_set_hero_infos,
@@ -47,7 +47,7 @@ int __stdcall mainmenu_select_hero_dialog(
 		        &gnDifficulty))
 			app_fatal("Unable to display SelHeroSing");
 
-		if (dlgresult == LOAD_GAME)
+		if (dlgresult == SELHERO_CONTINUE)
 			gbLoadGame = TRUE;
 		else
 			gbLoadGame = FALSE;
@@ -62,7 +62,7 @@ int __stdcall mainmenu_select_hero_dialog(
 	               gszHero)) {
 		app_fatal("Can't load multiplayer dialog");
 	}
-	if (dlgresult == EXIT_MENU) {
+	if (dlgresult == SELHERO_PREVIOUS) {
 		SErrSetLastError(1223);
 		return 0;
 	}
@@ -122,19 +122,19 @@ void mainmenu_loop()
 BOOL mainmenu_single_player()
 {
 	gbMaxPlayers = 1;
-	return mainmenu_init_menu(1);
+	return mainmenu_init_menu(SELHERO_NEW_DUNGEON);
 }
 
 BOOL mainmenu_init_menu(int type)
 {
 	BOOL success;
 
-	if (type == 4)
+	if (type == SELHERO_PREVIOUS)
 		return TRUE;
 
 	music_stop();
 
-	success = StartGame(type != 2, type != 3);
+	success = StartGame(type != SELHERO_CONTINUE, type != SELHERO_CONNECT);
 	if (success)
 		mainmenu_refresh_music();
 
@@ -144,7 +144,7 @@ BOOL mainmenu_init_menu(int type)
 BOOL mainmenu_multi_player()
 {
 	gbMaxPlayers = MAX_PLRS;
-	return mainmenu_init_menu(3);
+	return mainmenu_init_menu(SELHERO_CONNECT);
 }
 
 void mainmenu_play_intro()

--- a/enums.h
+++ b/enums.h
@@ -2266,12 +2266,12 @@ typedef enum _mainmenu_selections {
 	MAINMENU_ATTRACT_MODE  = 6,
 } _mainmenu_selections;
 
-typedef enum dlgresults
-{
-	NEW_GAME = 0,
-	LOAD_GAME = 2,
-	EXIT_MENU = 4,
-} dlgresults;
+typedef enum _selhero_selections {
+	SELHERO_NEW_DUNGEON = 1,
+	SELHERO_CONTINUE = 2,
+	SELHERO_CONNECT = 3,
+	SELHERO_PREVIOUS = 4
+} _selhero_selections;
 
 typedef enum panel_button_id {
 	PANBTN_CHARINFO  = 0,


### PR DESCRIPTION
This enum comes from the PSX symbol, pretty sure this is correct usage here. Given that the same style applies to the `MAINMENU_X` enum as well. There is no value `0` for the enum as that is just initializing the value. In older patches you can see that the result of `UiSelectHero` gets passed directly to the function `mainmenu_init_menu`, but when it was updated to work with newer Storm library those values became unused.

Discovered this stuff because I'm rewriting the UI and also working on reversing the SNP/Storm module.