### PR TITLE
effects: rename monster_action_sounds to MonstSndChar

### DIFF
--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -6,7 +6,7 @@ int sfxdnum;
 HANDLE sfx_stream;
 TSFX *sfx_data_cur;
 
-const char monster_action_sounds[] = { 'a', 'h', 'd', 's' };
+const char MonstSndChar[] = { 'a', 'h', 'd', 's' };
 
 /* data */
 
@@ -909,9 +909,9 @@ void InitMonsterSND(int monst)
 
 	mtype = Monsters[monst].mtype;
 	for (i = 0; i < 4; i++) {
-		if (monster_action_sounds[i] != 's' || monsterdata[mtype].snd_special) {
+		if (MonstSndChar[i] != 's' || monsterdata[mtype].snd_special) {
 			for (j = 0; j < 2; j++) {
-				sprintf(name, monsterdata[mtype].sndfile, monster_action_sounds[i], j + 1);
+				sprintf(name, monsterdata[mtype].sndfile, MonstSndChar[i], j + 1);
 				path = (char *)DiabloAllocPtr(strlen(name) + 1);
 				strcpy(path, name);
 				pSnd = sound_file_load(path);

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -30,7 +30,7 @@ void __stdcall effects_play_sound(char *snd_file);
 
 /* rdata */
 
-extern const char monster_action_sounds[];
+extern const char MonstSndChar[];
 
 /* data */
 


### PR DESCRIPTION
Rationale described in https://github.com/sanctuary/notes/commit/f609ea371d0768a6927d5e8ef931d23243d73387:
as included below:

Note, the PSX sym file does not seem to include the
original name for `monster_action_sounds`. However, it
does include the names for very similar global
variables used for players rather than monsters, so
from these we may infer a similar name for
`monster_action_sounds`.

In particular, `ArmourChar`, `WepChar` and `CharChar` are
used for player graphics. So, following the same naming
convention we arrive at `MonstSndChar`.