### PR TITLE
engine: rename rand_increment and rand_multiplier to RndInc and RndMult

### DIFF
--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -16,8 +16,8 @@ static CCritSect sgMemCrit;
 int SeedCount;
 BOOL gbNotInView; // valid - if x/y are in bounds
 
-const int rand_increment = 1;
-const int rand_multiplier = 0x015A4E35;
+const int RndInc = 1;
+const int RndMult = 0x015A4E35;
 
 void CelDrawDatOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth)
 {
@@ -2329,7 +2329,7 @@ void SetRndSeed(int s)
 int GetRndSeed()
 {
 	SeedCount++;
-	sglGameSeed = rand_multiplier * sglGameSeed + rand_increment;
+	sglGameSeed = RndMult * sglGameSeed + RndInc;
 	return abs(sglGameSeed);
 }
 

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -64,7 +64,7 @@ void PlayInGameMovie(char *pszMovie);
 
 /* rdata */
 
-extern const int rand_increment;  // unused
-extern const int rand_multiplier; // unused
+extern const int RndInc;
+extern const int RndMult;
 
 #endif /* __ENGINE_H__ */


### PR DESCRIPTION
Rationale described in https://github.com/sanctuary/notes/commit/a479cc56b8fcb7db1a88ac487a10147c99033963
as included below:

Note, neither `rand_increment` nor `rand_multiplier` are
present in the PSX debug info. To keep the names for
these variables consistent with the naming convention
used for `sglGameSeed`, `SeedCount`, `SetRndSeed` and
`GetRndSeed` (which are part of the PSX debug info), we
rename them to `RndInc` and `RndMult`, respectively.