### PR TITLE
interfac: rename progress_bar_colours and progress_bar_screen_pos to BarColor and BarPos

### DIFF
--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -5,8 +5,8 @@ void *sgpBackCel;
 int sgdwProgress;
 int progress_id;
 
-const BYTE progress_bar_colours[3] = { 138, 43, 254 };
-const int progress_bar_screen_pos[3][2] = { { 53, 37 }, { 53, 421 }, { 53, 37 } };
+const BYTE BarColor[3] = { 138, 43, 254 };
+const int BarPos[3][2] = { { 53, 37 }, { 53, 421 }, { 53, 37 } };
 
 void interface_msg_pump()
 {
@@ -40,8 +40,8 @@ void DrawCutscene()
 
 	for (i = 0; i < sgdwProgress; i++) {
 		DrawProgress(
-		    progress_bar_screen_pos[progress_id][0] + i + SCREEN_X,
-		    progress_bar_screen_pos[progress_id][1] + SCREEN_Y,
+		    BarPos[progress_id][0] + i + SCREEN_X,
+		    BarPos[progress_id][1] + SCREEN_Y,
 		    progress_id);
 	}
 
@@ -57,7 +57,7 @@ void DrawProgress(int screen_x, int screen_y, int progress_id)
 
 	dst = &gpBuffer[screen_x + PitchTbl[screen_y]];
 	for (i = 0; i < 22; i++) {
-		*dst = progress_bar_colours[progress_id];
+		*dst = BarColor[progress_id];
 		dst += BUFFER_WIDTH;
 	}
 }

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -14,7 +14,7 @@ void InitCutscene(unsigned int uMsg);
 
 /* rdata */
 
-extern const BYTE progress_bar_colours[3];
-extern const int progress_bar_screen_pos[3][2];
+extern const BYTE BarColor[3];
+extern const int BarPos[3][2];
 
 #endif /* __INTERFAC_H__ */


### PR DESCRIPTION
Rationale described in sanctuary/notes@cb8812d1a605b363a90707a375ed4de999b13665
as included below:

Note, the BarColor and BarPos globals don't have
PSX debug info. However, the progress bar is
referred to as "barfoo" in other parts of the
PSX debug info, e.g.

	// register: 21
	register unsigned char barr;
	// register: 16
	register unsigned char barg;

Thus, we apply a similar naming convention for BarColor
and BarPos, using CamelCase as is conventional for global
variables in Diablo 1.