### PR TITLE
control: rename attribute_inc_rects to ChrBtnsRect

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -152,7 +152,7 @@ char *PanBtnStr[8] = {
 	"Send Message",
 	"Player Attack"
 };
-RECT32 attribute_inc_rects[4] = {
+RECT32 ChrBtnsRect[4] = {
 	{ 137, 138, 41, 22 },
 	{ 137, 166, 41, 22 },
 	{ 137, 195, 41, 22 },
@@ -1971,10 +1971,10 @@ void CheckChrBtns()
 			default:
 				continue;
 			}
-			if (MouseX >= attribute_inc_rects[i].x
-			    && MouseX <= attribute_inc_rects[i].x + attribute_inc_rects[i].w
-			    && MouseY >= attribute_inc_rects[i].y
-			    && MouseY <= attribute_inc_rects[i].y + attribute_inc_rects[i].h) {
+			if (MouseX >= ChrBtnsRect[i].x
+			    && MouseX <= ChrBtnsRect[i].x + ChrBtnsRect[i].w
+			    && MouseY >= ChrBtnsRect[i].y
+			    && MouseY <= ChrBtnsRect[i].y + ChrBtnsRect[i].h) {
 				chrbtn[i] = 1;
 				chrbtnactive = TRUE;
 			}
@@ -1990,10 +1990,10 @@ void ReleaseChrBtns()
 	for (i = 0; i < 4; ++i) {
 		if (chrbtn[i]) {
 			chrbtn[i] = 0;
-			if (MouseX >= attribute_inc_rects[i].x
-			    && MouseX <= attribute_inc_rects[i].x + attribute_inc_rects[i].w
-			    && MouseY >= attribute_inc_rects[i].y
-			    && MouseY <= attribute_inc_rects[i].y + attribute_inc_rects[i].h) {
+			if (MouseX >= ChrBtnsRect[i].x
+			    && MouseX <= ChrBtnsRect[i].x + ChrBtnsRect[i].w
+			    && MouseY >= ChrBtnsRect[i].y
+			    && MouseY <= ChrBtnsRect[i].y + ChrBtnsRect[i].h) {
 				switch (i) {
 				case 0:
 					NetSendCmdParam1(TRUE, CMD_ADDSTR, 1);

--- a/Source/control.h
+++ b/Source/control.h
@@ -132,7 +132,7 @@ extern char SpellITbl[MAX_SPELLS];
 extern int PanBtnPos[8][5];
 extern char *PanBtnHotKey[8];
 extern char *PanBtnStr[8];
-extern RECT32 attribute_inc_rects[4];
+extern RECT32 ChrBtnsRect[4];
 extern int SpellPages[6][7];
 
 #endif /* __CONTROL_H__ */


### PR DESCRIPTION
Rationale described in sanctuary/notes@541e63f85a442cbb2293734c24c5868ccceec800
as included below:

Note, the ChrBtnsRect global doesn't have PSX debug info.
However, the functionality correspond to that of InvRect
of inv.h. Moreover, the we may infer the name from the
function CheckChrBtns, and simply combine the two names.