### PR TITLE
diablo: rename spszMsgTbl and spszMsgKeyTbl to NetMsgStr and NetMsgHotKey

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -56,13 +56,13 @@ int framerate;
 int framestart;
 #endif
 BOOL FriendlyMode = TRUE;
-char *spszMsgTbl[4] = {
+char *NetMsgStr[4] = {
 	"I need help! Come Here!",
 	"Follow me.",
 	"Here's something for you.",
 	"Now you DIE!"
 };
-char *spszMsgKeyTbl[4] = { "F9", "F10", "F11", "F12" };
+char *NetMsgHotKey[4] = { "F9", "F10", "F11", "F12" };
 
 void FreeGameMem()
 {
@@ -989,8 +989,8 @@ void diablo_hotkey_msg(DWORD dwMsg)
 	}
 
 	strcat(szFileName, "\\Diablo.ini");
-	/// ASSERT: assert(dwMsg < sizeof(spszMsgTbl) / sizeof(spszMsgTbl[0]));
-	GetPrivateProfileString("NetMsg", spszMsgKeyTbl[dwMsg], spszMsgTbl[dwMsg], szMsg, sizeof(szMsg), szFileName);
+	/// ASSERT: assert(dwMsg < sizeof(NetMsgStr) / sizeof(NetMsgStr[0]));
+	GetPrivateProfileString("NetMsg", NetMsgHotKey[dwMsg], NetMsgStr[dwMsg], szMsg, sizeof(szMsg), szFileName);
 	NetSendCmdString(-1, szMsg);
 }
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -56,13 +56,13 @@ int framerate;
 int framestart;
 #endif
 BOOL FriendlyMode = TRUE;
-char *NetMsgStr[4] = {
+char *spszMsgTbl[4] = {
 	"I need help! Come Here!",
 	"Follow me.",
 	"Here's something for you.",
 	"Now you DIE!"
 };
-char *NetMsgHotKey[4] = { "F9", "F10", "F11", "F12" };
+char *spszMsgHotKeyTbl[4] = { "F9", "F10", "F11", "F12" };
 
 void FreeGameMem()
 {
@@ -989,8 +989,8 @@ void diablo_hotkey_msg(DWORD dwMsg)
 	}
 
 	strcat(szFileName, "\\Diablo.ini");
-	/// ASSERT: assert(dwMsg < sizeof(NetMsgStr) / sizeof(NetMsgStr[0]));
-	GetPrivateProfileString("NetMsg", NetMsgHotKey[dwMsg], NetMsgStr[dwMsg], szMsg, sizeof(szMsg), szFileName);
+	/// ASSERT: assert(dwMsg < sizeof(spszMsgTbl) / sizeof(spszMsgTbl[0]));
+	GetPrivateProfileString("NetMsg", spszMsgHotKeyTbl[dwMsg], spszMsgTbl[dwMsg], szMsg, sizeof(szMsg), szFileName);
 	NetSendCmdString(-1, szMsg);
 }
 

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -173,7 +173,7 @@ extern int framerate;
 extern int framestart;
 #endif
 extern BOOL FriendlyMode;
-extern char *NetMsgStr[4];
-extern char *NetMsgHotKey[4];
+extern char *spszMsgTbl[4];
+extern char *spszMsgHotKeyTbl[4];
 
 #endif /* __DIABLO_H__ */

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -173,7 +173,7 @@ extern int framerate;
 extern int framestart;
 #endif
 extern BOOL FriendlyMode;
-extern char *spszMsgTbl[4];
-extern char *spszMsgKeyTbl[4];
+extern char *NetMsgStr[4];
+extern char *NetMsgHotKey[4];
 
 #endif /* __DIABLO_H__ */


### PR DESCRIPTION
Rationale described in sanctuary/notes@3cd6417cdfafba340145939c2054ec614e1bd33e
as included below:

Infer the name of `NetMsgStr` and `NetMsgHotKey` from the
PSX debug names of:

	char *PanBtnHotKey[8];
	unsigned long PanBtnStr[8];

Note, the previous use of `spsz` hungarian notation has been removed
since searching for "spsz" gave no results in the [merged output of
PSX debug info](https://github.com/diasurgical/scalpel/tree/master/psx/_dump_/_dump_merge_c_).