### PR TITLE
gamemenu: rename sgFooMenu to FooMenu

### DIFF
--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -1,6 +1,6 @@
 #include "diablo.h"
 
-TMenuItem spSingleMenu[6] = {
+TMenuItem sgSingleMenu[6] = {
 	// clang-format off
 	//   dwFlags, pszStr,        fnMenu
 	{ GMENU_ENABLED, "Save Game",   &gamemenu_save_game },
@@ -11,7 +11,7 @@ TMenuItem spSingleMenu[6] = {
 	{ GMENU_ENABLED, NULL, NULL }
 	// clang-format on
 };
-TMenuItem spMultiMenu[5] = {
+TMenuItem sgMultiMenu[5] = {
 	// clang-format off
 	//   dwFlags, pszStr,            fnMenu
 	{ GMENU_ENABLED, "Options",         &gamemenu_options      },
@@ -21,7 +21,7 @@ TMenuItem spMultiMenu[5] = {
 	{ GMENU_ENABLED, NULL,              NULL                   }
 	// clang-format on
 };
-TMenuItem spOptionsMenu[6] = {
+TMenuItem sgOptionsMenu[6] = {
 	// clang-format off
 	//                     dwFlags, pszStr,          fnMenu
 	{ GMENU_ENABLED | GMENU_SLIDER, NULL,            &gamemenu_music_volume  },
@@ -43,10 +43,10 @@ void gamemenu_previous()
 
 	if (gbMaxPlayers == 1) {
 		proc = gamemenu_enable_single;
-		item = spSingleMenu;
+		item = sgSingleMenu;
 	} else {
 		proc = gamemenu_enable_multi;
-		item = spMultiMenu;
+		item = sgMultiMenu;
 	}
 	gmenu_call_proc(item, proc);
 	PressEscKey();
@@ -56,18 +56,18 @@ void gamemenu_enable_single(TMenuItem *pMenuItems)
 {
 	BOOL enable;
 
-	gmenu_enable(&spSingleMenu[3], gbValidSaveFile);
+	gmenu_enable(&sgSingleMenu[3], gbValidSaveFile);
 
 	enable = FALSE;
 	if (plr[myplr]._pmode != PM_DEATH && !deathflag)
 		enable = TRUE;
 
-	gmenu_enable(spSingleMenu, enable);
+	gmenu_enable(sgSingleMenu, enable);
 }
 
 void gamemenu_enable_multi(TMenuItem *pMenuItems)
 {
-	gmenu_enable(&spMultiMenu[2], deathflag);
+	gmenu_enable(&sgMultiMenu[2], deathflag);
 }
 
 void gamemenu_off()
@@ -166,12 +166,12 @@ void gamemenu_options(BOOL bActivate)
 	gamemenu_get_sound();
 	gamemenu_get_gamma();
 	gamemenu_get_color_cycling();
-	gmenu_call_proc(spOptionsMenu, NULL);
+	gmenu_call_proc(sgOptionsMenu, NULL);
 }
 
 void gamemenu_get_music()
 {
-	gamemenu_sound_music_toggle(music_toggle_names, spOptionsMenu, sound_get_or_set_music_volume(1));
+	gamemenu_sound_music_toggle(music_toggle_names, sgOptionsMenu, sound_get_or_set_music_volume(1));
 }
 
 void gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int volume)
@@ -190,18 +190,18 @@ void gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int volume)
 
 void gamemenu_get_sound()
 {
-	gamemenu_sound_music_toggle(sound_toggle_names, &spOptionsMenu[1], sound_get_or_set_sound_volume(1));
+	gamemenu_sound_music_toggle(sound_toggle_names, &sgOptionsMenu[1], sound_get_or_set_sound_volume(1));
 }
 
 void gamemenu_get_color_cycling()
 {
-	spOptionsMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];
+	sgOptionsMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];
 }
 
 void gamemenu_get_gamma()
 {
-	gmenu_slider_steps(&spOptionsMenu[2], 15);
-	gmenu_slider_set(&spOptionsMenu[2], 30, 100, UpdateGamma(0));
+	gmenu_slider_steps(&sgOptionsMenu[2], 15);
+	gmenu_slider_set(&sgOptionsMenu[2], 30, 100, UpdateGamma(0));
 }
 
 void gamemenu_music_volume(BOOL bActivate)
@@ -222,7 +222,7 @@ void gamemenu_music_volume(BOOL bActivate)
 		return;
 	}
 
-	volume = gamemenu_slider_music_sound(spOptionsMenu);
+	volume = gamemenu_slider_music_sound(sgOptionsMenu);
 	sound_get_or_set_music_volume(volume);
 
 	if (volume == VOLUME_MIN) {
@@ -264,7 +264,7 @@ void gamemenu_sound_volume(BOOL bActivate)
 			sound_get_or_set_sound_volume(VOLUME_MAX);
 		}
 	} else {
-		volume = gamemenu_slider_music_sound(&spOptionsMenu[1]);
+		volume = gamemenu_slider_music_sound(&sgOptionsMenu[1]);
 		sound_get_or_set_sound_volume(volume);
 		if (volume == VOLUME_MIN) {
 			if (gbSoundOn) {
@@ -297,7 +297,7 @@ void gamemenu_gamma(BOOL bActivate)
 
 int gamemenu_slider_gamma()
 {
-	return gmenu_slider_get(&spOptionsMenu[2], 30, 100);
+	return gmenu_slider_get(&sgOptionsMenu[2], 30, 100);
 }
 
 void gamemenu_color_cycling(BOOL bActivate)
@@ -305,5 +305,5 @@ void gamemenu_color_cycling(BOOL bActivate)
 	BOOL color_cycling;
 
 	color_cycling = palette_set_color_cycling(palette_get_colour_cycling() == 0);
-	spOptionsMenu[3].pszStr = color_cycling_toggle_names[color_cycling & 1];
+	sgOptionsMenu[3].pszStr = color_cycling_toggle_names[color_cycling & 1];
 }

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -1,6 +1,6 @@
 #include "diablo.h"
 
-TMenuItem SingleMenu[6] = {
+TMenuItem spSingleMenu[6] = {
 	// clang-format off
 	//   dwFlags, pszStr,        fnMenu
 	{ GMENU_ENABLED, "Save Game",   &gamemenu_save_game },
@@ -11,7 +11,7 @@ TMenuItem SingleMenu[6] = {
 	{ GMENU_ENABLED, NULL, NULL }
 	// clang-format on
 };
-TMenuItem MultiMenu[5] = {
+TMenuItem spMultiMenu[5] = {
 	// clang-format off
 	//   dwFlags, pszStr,            fnMenu
 	{ GMENU_ENABLED, "Options",         &gamemenu_options      },
@@ -21,7 +21,7 @@ TMenuItem MultiMenu[5] = {
 	{ GMENU_ENABLED, NULL,              NULL                   }
 	// clang-format on
 };
-TMenuItem OptionsMenu[6] = {
+TMenuItem spOptionsMenu[6] = {
 	// clang-format off
 	//                     dwFlags, pszStr,          fnMenu
 	{ GMENU_ENABLED | GMENU_SLIDER, NULL,            &gamemenu_music_volume  },
@@ -43,10 +43,10 @@ void gamemenu_previous()
 
 	if (gbMaxPlayers == 1) {
 		proc = gamemenu_enable_single;
-		item = SingleMenu;
+		item = spSingleMenu;
 	} else {
 		proc = gamemenu_enable_multi;
-		item = MultiMenu;
+		item = spMultiMenu;
 	}
 	gmenu_call_proc(item, proc);
 	PressEscKey();
@@ -56,18 +56,18 @@ void gamemenu_enable_single(TMenuItem *pMenuItems)
 {
 	BOOL enable;
 
-	gmenu_enable(&SingleMenu[3], gbValidSaveFile);
+	gmenu_enable(&spSingleMenu[3], gbValidSaveFile);
 
 	enable = FALSE;
 	if (plr[myplr]._pmode != PM_DEATH && !deathflag)
 		enable = TRUE;
 
-	gmenu_enable(SingleMenu, enable);
+	gmenu_enable(spSingleMenu, enable);
 }
 
 void gamemenu_enable_multi(TMenuItem *pMenuItems)
 {
-	gmenu_enable(&MultiMenu[2], deathflag);
+	gmenu_enable(&spMultiMenu[2], deathflag);
 }
 
 void gamemenu_off()
@@ -166,12 +166,12 @@ void gamemenu_options(BOOL bActivate)
 	gamemenu_get_sound();
 	gamemenu_get_gamma();
 	gamemenu_get_color_cycling();
-	gmenu_call_proc(OptionsMenu, NULL);
+	gmenu_call_proc(spOptionsMenu, NULL);
 }
 
 void gamemenu_get_music()
 {
-	gamemenu_sound_music_toggle(music_toggle_names, OptionsMenu, sound_get_or_set_music_volume(1));
+	gamemenu_sound_music_toggle(music_toggle_names, spOptionsMenu, sound_get_or_set_music_volume(1));
 }
 
 void gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int volume)
@@ -190,18 +190,18 @@ void gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int volume)
 
 void gamemenu_get_sound()
 {
-	gamemenu_sound_music_toggle(sound_toggle_names, &OptionsMenu[1], sound_get_or_set_sound_volume(1));
+	gamemenu_sound_music_toggle(sound_toggle_names, &spOptionsMenu[1], sound_get_or_set_sound_volume(1));
 }
 
 void gamemenu_get_color_cycling()
 {
-	OptionsMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];
+	spOptionsMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];
 }
 
 void gamemenu_get_gamma()
 {
-	gmenu_slider_steps(&OptionsMenu[2], 15);
-	gmenu_slider_set(&OptionsMenu[2], 30, 100, UpdateGamma(0));
+	gmenu_slider_steps(&spOptionsMenu[2], 15);
+	gmenu_slider_set(&spOptionsMenu[2], 30, 100, UpdateGamma(0));
 }
 
 void gamemenu_music_volume(BOOL bActivate)
@@ -222,7 +222,7 @@ void gamemenu_music_volume(BOOL bActivate)
 		return;
 	}
 
-	volume = gamemenu_slider_music_sound(OptionsMenu);
+	volume = gamemenu_slider_music_sound(spOptionsMenu);
 	sound_get_or_set_music_volume(volume);
 
 	if (volume == VOLUME_MIN) {
@@ -264,7 +264,7 @@ void gamemenu_sound_volume(BOOL bActivate)
 			sound_get_or_set_sound_volume(VOLUME_MAX);
 		}
 	} else {
-		volume = gamemenu_slider_music_sound(&OptionsMenu[1]);
+		volume = gamemenu_slider_music_sound(&spOptionsMenu[1]);
 		sound_get_or_set_sound_volume(volume);
 		if (volume == VOLUME_MIN) {
 			if (gbSoundOn) {
@@ -297,7 +297,7 @@ void gamemenu_gamma(BOOL bActivate)
 
 int gamemenu_slider_gamma()
 {
-	return gmenu_slider_get(&OptionsMenu[2], 30, 100);
+	return gmenu_slider_get(&spOptionsMenu[2], 30, 100);
 }
 
 void gamemenu_color_cycling(BOOL bActivate)
@@ -305,5 +305,5 @@ void gamemenu_color_cycling(BOOL bActivate)
 	BOOL color_cycling;
 
 	color_cycling = palette_set_color_cycling(palette_get_colour_cycling() == 0);
-	OptionsMenu[3].pszStr = color_cycling_toggle_names[color_cycling & 1];
+	spOptionsMenu[3].pszStr = color_cycling_toggle_names[color_cycling & 1];
 }

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -21,7 +21,7 @@ TMenuItem MultiMenu[5] = {
 	{ GMENU_ENABLED, NULL,              NULL                   }
 	// clang-format on
 };
-TMenuItem OptionMenu[6] = {
+TMenuItem OptionsMenu[6] = {
 	// clang-format off
 	//                     dwFlags, pszStr,          fnMenu
 	{ GMENU_ENABLED | GMENU_SLIDER, NULL,            &gamemenu_music_volume  },
@@ -166,12 +166,12 @@ void gamemenu_options(BOOL bActivate)
 	gamemenu_get_sound();
 	gamemenu_get_gamma();
 	gamemenu_get_color_cycling();
-	gmenu_call_proc(OptionMenu, NULL);
+	gmenu_call_proc(OptionsMenu, NULL);
 }
 
 void gamemenu_get_music()
 {
-	gamemenu_sound_music_toggle(music_toggle_names, OptionMenu, sound_get_or_set_music_volume(1));
+	gamemenu_sound_music_toggle(music_toggle_names, OptionsMenu, sound_get_or_set_music_volume(1));
 }
 
 void gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int volume)
@@ -190,18 +190,18 @@ void gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int volume)
 
 void gamemenu_get_sound()
 {
-	gamemenu_sound_music_toggle(sound_toggle_names, &OptionMenu[1], sound_get_or_set_sound_volume(1));
+	gamemenu_sound_music_toggle(sound_toggle_names, &OptionsMenu[1], sound_get_or_set_sound_volume(1));
 }
 
 void gamemenu_get_color_cycling()
 {
-	OptionMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];
+	OptionsMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];
 }
 
 void gamemenu_get_gamma()
 {
-	gmenu_slider_steps(&OptionMenu[2], 15);
-	gmenu_slider_set(&OptionMenu[2], 30, 100, UpdateGamma(0));
+	gmenu_slider_steps(&OptionsMenu[2], 15);
+	gmenu_slider_set(&OptionsMenu[2], 30, 100, UpdateGamma(0));
 }
 
 void gamemenu_music_volume(BOOL bActivate)
@@ -222,7 +222,7 @@ void gamemenu_music_volume(BOOL bActivate)
 		return;
 	}
 
-	volume = gamemenu_slider_music_sound(OptionMenu);
+	volume = gamemenu_slider_music_sound(OptionsMenu);
 	sound_get_or_set_music_volume(volume);
 
 	if (volume == VOLUME_MIN) {
@@ -264,7 +264,7 @@ void gamemenu_sound_volume(BOOL bActivate)
 			sound_get_or_set_sound_volume(VOLUME_MAX);
 		}
 	} else {
-		volume = gamemenu_slider_music_sound(&OptionMenu[1]);
+		volume = gamemenu_slider_music_sound(&OptionsMenu[1]);
 		sound_get_or_set_sound_volume(volume);
 		if (volume == VOLUME_MIN) {
 			if (gbSoundOn) {
@@ -297,7 +297,7 @@ void gamemenu_gamma(BOOL bActivate)
 
 int gamemenu_slider_gamma()
 {
-	return gmenu_slider_get(&OptionMenu[2], 30, 100);
+	return gmenu_slider_get(&OptionsMenu[2], 30, 100);
 }
 
 void gamemenu_color_cycling(BOOL bActivate)
@@ -305,5 +305,5 @@ void gamemenu_color_cycling(BOOL bActivate)
 	BOOL color_cycling;
 
 	color_cycling = palette_set_color_cycling(palette_get_colour_cycling() == 0);
-	OptionMenu[3].pszStr = color_cycling_toggle_names[color_cycling & 1];
+	OptionsMenu[3].pszStr = color_cycling_toggle_names[color_cycling & 1];
 }

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -1,6 +1,6 @@
 #include "diablo.h"
 
-TMenuItem sgSingleMenu[6] = {
+TMenuItem SingleMenu[6] = {
 	// clang-format off
 	//   dwFlags, pszStr,        fnMenu
 	{ GMENU_ENABLED, "Save Game",   &gamemenu_save_game },
@@ -11,7 +11,7 @@ TMenuItem sgSingleMenu[6] = {
 	{ GMENU_ENABLED, NULL, NULL }
 	// clang-format on
 };
-TMenuItem sgMultiMenu[5] = {
+TMenuItem MultiMenu[5] = {
 	// clang-format off
 	//   dwFlags, pszStr,            fnMenu
 	{ GMENU_ENABLED, "Options",         &gamemenu_options      },
@@ -21,7 +21,7 @@ TMenuItem sgMultiMenu[5] = {
 	{ GMENU_ENABLED, NULL,              NULL                   }
 	// clang-format on
 };
-TMenuItem sgOptionMenu[6] = {
+TMenuItem OptionMenu[6] = {
 	// clang-format off
 	//                     dwFlags, pszStr,          fnMenu
 	{ GMENU_ENABLED | GMENU_SLIDER, NULL,            &gamemenu_music_volume  },
@@ -43,10 +43,10 @@ void gamemenu_previous()
 
 	if (gbMaxPlayers == 1) {
 		proc = gamemenu_enable_single;
-		item = sgSingleMenu;
+		item = SingleMenu;
 	} else {
 		proc = gamemenu_enable_multi;
-		item = sgMultiMenu;
+		item = MultiMenu;
 	}
 	gmenu_call_proc(item, proc);
 	PressEscKey();
@@ -56,18 +56,18 @@ void gamemenu_enable_single(TMenuItem *pMenuItems)
 {
 	BOOL enable;
 
-	gmenu_enable(&sgSingleMenu[3], gbValidSaveFile);
+	gmenu_enable(&SingleMenu[3], gbValidSaveFile);
 
 	enable = FALSE;
 	if (plr[myplr]._pmode != PM_DEATH && !deathflag)
 		enable = TRUE;
 
-	gmenu_enable(sgSingleMenu, enable);
+	gmenu_enable(SingleMenu, enable);
 }
 
 void gamemenu_enable_multi(TMenuItem *pMenuItems)
 {
-	gmenu_enable(&sgMultiMenu[2], deathflag);
+	gmenu_enable(&MultiMenu[2], deathflag);
 }
 
 void gamemenu_off()
@@ -166,12 +166,12 @@ void gamemenu_options(BOOL bActivate)
 	gamemenu_get_sound();
 	gamemenu_get_gamma();
 	gamemenu_get_color_cycling();
-	gmenu_call_proc(sgOptionMenu, NULL);
+	gmenu_call_proc(OptionMenu, NULL);
 }
 
 void gamemenu_get_music()
 {
-	gamemenu_sound_music_toggle(music_toggle_names, sgOptionMenu, sound_get_or_set_music_volume(1));
+	gamemenu_sound_music_toggle(music_toggle_names, OptionMenu, sound_get_or_set_music_volume(1));
 }
 
 void gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int volume)
@@ -190,18 +190,18 @@ void gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int volume)
 
 void gamemenu_get_sound()
 {
-	gamemenu_sound_music_toggle(sound_toggle_names, &sgOptionMenu[1], sound_get_or_set_sound_volume(1));
+	gamemenu_sound_music_toggle(sound_toggle_names, &OptionMenu[1], sound_get_or_set_sound_volume(1));
 }
 
 void gamemenu_get_color_cycling()
 {
-	sgOptionMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];
+	OptionMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling() & 1];
 }
 
 void gamemenu_get_gamma()
 {
-	gmenu_slider_steps(&sgOptionMenu[2], 15);
-	gmenu_slider_set(&sgOptionMenu[2], 30, 100, UpdateGamma(0));
+	gmenu_slider_steps(&OptionMenu[2], 15);
+	gmenu_slider_set(&OptionMenu[2], 30, 100, UpdateGamma(0));
 }
 
 void gamemenu_music_volume(BOOL bActivate)
@@ -222,7 +222,7 @@ void gamemenu_music_volume(BOOL bActivate)
 		return;
 	}
 
-	volume = gamemenu_slider_music_sound(sgOptionMenu);
+	volume = gamemenu_slider_music_sound(OptionMenu);
 	sound_get_or_set_music_volume(volume);
 
 	if (volume == VOLUME_MIN) {
@@ -264,7 +264,7 @@ void gamemenu_sound_volume(BOOL bActivate)
 			sound_get_or_set_sound_volume(VOLUME_MAX);
 		}
 	} else {
-		volume = gamemenu_slider_music_sound(&sgOptionMenu[1]);
+		volume = gamemenu_slider_music_sound(&OptionMenu[1]);
 		sound_get_or_set_sound_volume(volume);
 		if (volume == VOLUME_MIN) {
 			if (gbSoundOn) {
@@ -297,7 +297,7 @@ void gamemenu_gamma(BOOL bActivate)
 
 int gamemenu_slider_gamma()
 {
-	return gmenu_slider_get(&sgOptionMenu[2], 30, 100);
+	return gmenu_slider_get(&OptionMenu[2], 30, 100);
 }
 
 void gamemenu_color_cycling(BOOL bActivate)
@@ -305,5 +305,5 @@ void gamemenu_color_cycling(BOOL bActivate)
 	BOOL color_cycling;
 
 	color_cycling = palette_set_color_cycling(palette_get_colour_cycling() == 0);
-	sgOptionMenu[3].pszStr = color_cycling_toggle_names[color_cycling & 1];
+	OptionMenu[3].pszStr = color_cycling_toggle_names[color_cycling & 1];
 }


### PR DESCRIPTION
Rationale described in sanctuary/notes@1c69e098fe4f22c2e40de2872bbc20892ad7bb45
as included below:

Use names from assert for sgSingleMenu and sgMultiMenu (no change).

Infer name of `spOptionsMenu` from PSX debug data:

	struct OMENUITEM MemcardLoadOptionsMenu[4]
	struct OMENUITEM MemcardSaveOptionsMenu[4]

Use "sp" prefix for spOptionsMenu to conform with assert
information.