### PR TITLE
items: rename ItemDropStrs to ItemDropNames

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -33,7 +33,7 @@ BYTE ItemCAnimTbl[169] = {
 	14, 17, 17, 17, 0, 34, 1, 0, 3, 17,
 	8, 8, 6, 1, 3, 3, 11, 3, 4
 };
-char *ItemDropStrs[35] = {
+char *ItemDropNames[35] = {
 	"Armor2",
 	"Axe",
 	"FBttle",
@@ -190,7 +190,7 @@ void InitItemGFX()
 	char arglist[64];
 
 	for (i = 0; i < 35; i++) {
-		sprintf(arglist, "Items\\%s.CEL", ItemDropStrs[i]);
+		sprintf(arglist, "Items\\%s.CEL", ItemDropNames[i]);
 		itemanims[i] = LoadFileInMem(arglist, NULL);
 	}
 	memset(UniqueItemFlag, 0, sizeof(UniqueItemFlag));

--- a/Source/items.h
+++ b/Source/items.h
@@ -129,7 +129,7 @@ void PutItemRecord(int nSeed, WORD wCI, int nIndex);
 /* data */
 
 extern BYTE ItemCAnimTbl[169];
-extern char *ItemDropStrs[35];
+extern char *ItemDropNames[35];
 extern BYTE ItemAnimLs[35];
 extern int ItemDropSnds[35];
 extern int ItemInvSnds[35];


### PR DESCRIPTION
The rationate for preferring Name over Str is that Str
suggest a string for printing and Name a file name,
also based on the following associated PSX debug info:

	char *FileName;
	unsigned char mAnimName;

ItemDropNames correspond to the base file name of

	"Items\\%s.CEL", ItemDropNames[i]