### PR TITLE
Clean multi_send_zero_packet right

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -531,13 +531,19 @@ void multi_process_tmsgs()
 	}
 }
 
-void multi_send_zero_packet(DWORD pnum, char identifier, void *pbSrc, DWORD dwLen)
+void multi_send_zero_packet(int pnum, BYTE bCmd, BYTE *pbSrc, DWORD dwLen)
 {
-	DWORD len, dwBody;
+	DWORD dwOffset, dwBody, dwMsg;
 	TPkt pkt;
-	int t;
-	len = 0;
-	while (dwLen) {
+	TCmdPlrInfoHdr *p;
+
+	/// ASSERT: assert(pnum != myplr);
+	/// ASSERT: assert(pbSrc);
+	/// ASSERT: assert(dwLen <= 0x0ffff);
+
+	dwOffset = 0;
+
+	while(dwLen != 0) {
 		pkt.hdr.wCheck = 'ip';
 		pkt.hdr.px = 0;
 		pkt.hdr.py = 0;
@@ -548,22 +554,45 @@ void multi_send_zero_packet(DWORD pnum, char identifier, void *pbSrc, DWORD dwLe
 		pkt.hdr.bstr = 0;
 		pkt.hdr.bmag = 0;
 		pkt.hdr.bdex = 0;
-		pkt.body[0] = identifier;
-		*(WORD *)&pkt.body[1] = len;
-		dwBody = gdwLargestMsgSize - 24;
-		if (dwLen < dwBody)
+		p = (TCmdPlrInfoHdr *)pkt.body;
+		p->bCmd = bCmd;
+		p->wOffset = dwOffset;
+		dwBody = gdwLargestMsgSize - sizeof(pkt.hdr) - sizeof(*p);
+		if(dwLen < dwBody) {
 			dwBody = dwLen;
-		*(WORD *)&pkt.body[3] = dwBody;
-		memcpy(&pkt.body[5], pbSrc, *(WORD *)&pkt.body[3]);
-		t = *(WORD *)&pkt.body[3] + 24;
-		pkt.hdr.wLen = t;
-		if (!SNetSendMessage(pnum, &pkt.hdr, t)) {
+		}
+		/// ASSERT: assert(dwBody <= 0x0ffff);
+		p->wBytes = dwBody;
+		memcpy(&pkt.body[sizeof(*p)], pbSrc, p->wBytes);
+		dwMsg = sizeof(pkt.hdr);
+		dwMsg += sizeof(*p);
+		dwMsg += p->wBytes;
+		pkt.hdr.wLen = dwMsg;
+		if(!SNetSendMessage(pnum, &pkt, dwMsg)) {
 			nthread_terminate_game("SNetSendMessage2");
 			return;
 		}
-		pbSrc = (char *)pbSrc + *(WORD *)&pkt.body[3];
-		dwLen -= *(WORD *)&pkt.body[3];
-		len += *(WORD *)&pkt.body[3];
+#if 0
+		if((DWORD)pnum >= MAX_PLRS) {
+			if(myplr != 0) {
+				debug_plr_tbl[0]++;
+			}
+			if(myplr != 1) {
+				debug_plr_tbl[1]++;
+			}
+			if(myplr != 2) {
+				debug_plr_tbl[2]++;
+			}
+			if(myplr != 3) {
+				debug_plr_tbl[3]++;
+			}
+		} else {
+			debug_plr_tbl[pnum]++;
+		}
+#endif
+		pbSrc += p->wBytes;
+		dwLen -= p->wBytes;
+		dwOffset += p->wBytes;
 	}
 }
 

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -41,7 +41,7 @@ void multi_check_drop_player();
 void multi_process_network_packets();
 void multi_handle_all_packets(int pnum, BYTE *pData, int nSize);
 void multi_process_tmsgs();
-void multi_send_zero_packet(DWORD pnum, char identifier, void *pbSrc, DWORD dwLen);
+void multi_send_zero_packet(int pnum, BYTE bCmd, BYTE *pbSrc, DWORD dwLen);
 void NetClose();
 void multi_event_handler(BOOL add);
 void __stdcall multi_handle_events(_SNETEVENT *pEvt);


### PR DESCRIPTION
This function is a good example of something that can still end up being bin exact while directly accessing struct offsets by address. It was tricky at first to figure out exactly what is going on here. Anyway, it's been cleaned up the right way and the ASM output matches the beta's logic. Asserts added and debug code added in comment, will add that later.

This should help fix network code in ports and such, since the offsets are now dynamic and properly calculated.