### PR TITLE
Fix bug in InitItems

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -251,6 +251,7 @@ void AddInitItems()
 void InitItems()
 {
 	int i;
+	long s;
 
 	GetItemAttrs(0, IDI_GOLD, 1);
 	golditem = item[0];
@@ -261,7 +262,7 @@ void InitItems()
 		item[i]._itype = ITYPE_MISC;
 		item[i]._ix = 0;
 		item[i]._iy = 0;
-		item[i]._isin = 0;
+		item[i]._iAnimFlag = 0;
 		item[i]._iSelFlag = 0;
 		item[i]._iIdentified = FALSE;
 		item[i]._iPostDraw = FALSE;
@@ -273,7 +274,7 @@ void InitItems()
 	}
 
 	if (!setlevel) {
-		GetRndSeed();
+		s = GetRndSeed(); /* unused */
 		if (QuestStatus(QTYPE_INFRA))
 			SpawnRock();
 		if (QuestStatus(QTYPE_ANVIL))

--- a/enums.h
+++ b/enums.h
@@ -90,6 +90,8 @@ typedef enum item_effect_type {
 	IPL_LIGHTRES         = 0x9,
 	IPL_MAGICRES         = 0xA,
 	IPL_ALLRES           = 0xB,
+	IPL_SPLCOST          = 0xC, /* only used in beta */
+	IPL_SPLDUR           = 0xD, /* only used in beta */
 	IPL_SPLLVLADD        = 0xE,
 	IPL_CHARGES          = 0xF,
 	IPL_FIREDAM          = 0x10,


### PR DESCRIPTION
I found this while cleaning up items.cpp. Went through and compared all functions I cleaned to what someone else has and found this bug. This field is actually set to zero in the beta, but regardless it's fixed now.

Also added enum for unused item flags, before I forget.