### PR TITLE
monster: add BUGFIX comment for monstkills

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4,6 +4,7 @@
 // Tracks which missile files are already loaded
 int MissileFileFlag;
 
+// BUGFIX: replace monstkills[MAXMONSTERS] with monstkills[NUM_MTYPES].
 int monstkills[MAXMONSTERS];
 int monstactive[MAXMONSTERS];
 int nummonsters;


### PR DESCRIPTION
The size of the monstkills array is unnecessarily large,
as it maps from monster type to number of kills, and the
monster type enum goes from 0 to NUM_MTYPES-1.