### PR TITLE
Fix logic in themes.cpp

### DIFF
--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -455,13 +455,15 @@ void InitThemes()
 void HoldThemeRooms()
 {
 	int i, x, y;
+	char v;
 
 	if (currlevel != 16) {
 		if (leveltype == DTYPE_CATHEDRAL) {
 			for (i = 0; i < numthemes; i++) {
+				v = themes[i].ttval;
 				for (y = 0; y < MAXDUNY; y++) {
 					for (x = 0; x < MAXDUNX; x++) {
-						if (dTransVal[x][y] == (char)themes[i].ttval) {
+						if (dTransVal[x][y] == v) {
 							dFlags[x][y] |= BFLAG_POPULATED;
 						}
 					}
@@ -517,8 +519,11 @@ void Theme_Barrel(int t)
 		for (xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && !nSolidTable[dPiece[xp][yp]]) {
 				if (random(0, barrnd[leveltype - 1]) == 0) {
-					r = random(0, barrnd[leveltype - 1]) != 0;
-					r += OBJ_BARREL;
+					if (random(0, barrnd[leveltype - 1]) == 0) {
+						r = OBJ_BARREL;
+					} else {
+						r = OBJ_BARRELEX;
+					}
 					AddObject(r, xp, yp);
 				}
 			}


### PR DESCRIPTION
`HoldThemeRooms` has a missing variable, as seen in the beta's assembly.

`Theme_Barrel`. No way they wrote the code like that. It now looks the same as the beta.