### PR TITLE
[hellfire] fix PlayerStruct

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -260,6 +260,9 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	ShowCursor(FALSE);
 	srand(GetTickCount());
 	InitHash();
+#ifdef HELLFIRE
+	alloc_plr();
+#endif
 	fault_get_filter();
 
 	bNoEvent = diablo_get_not_running();
@@ -1901,3 +1904,38 @@ void diablo_color_cyc_logic()
 		}
 	}
 }
+
+#ifdef HELLFIRE
+void alloc_plr()
+{
+	plr = get_plr_mem(NULL);
+
+	if(plr == NULL) {
+		app_fatal("Unable to initialize memory");
+	}
+
+	memset(plr, 0, sizeof(PlayerStruct) * MAX_PLRS);
+}
+
+PlayerStruct *get_plr_mem(PlayerStruct *p)
+{
+	void *r;
+	PlayerStruct *pPlayer;
+
+	r = malloc(rand() & 0x7FFF);
+	pPlayer = (PlayerStruct *)malloc(sizeof(PlayerStruct) * MAX_PLRS);
+
+	if(r != NULL) {
+		free(r);
+	}
+	if(pPlayer == NULL) {
+		return p;
+	}
+	if(p != NULL) {
+		memcpy(pPlayer, p, sizeof(PlayerStruct) * MAX_PLRS);
+		free(p);
+	}
+
+	return pPlayer;
+}
+#endif

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -148,6 +148,10 @@ void game_loop(BOOL bStartup);
 void game_logic();
 void timeout_cursor(BOOL bTimeout);
 void diablo_color_cyc_logic();
+#ifdef HELLFIRE
+void alloc_plr();
+PlayerStruct *get_plr_mem(PlayerStruct *p);
+#endif
 
 /* data */
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -6,7 +6,11 @@ int plr_wframe_size;
 BYTE plr_gfx_flag = 0;
 int plr_aframe_size;
 int myplr;
+#ifdef HELLFIRE
+PlayerStruct *plr;
+#else
 PlayerStruct plr[MAX_PLRS];
+#endif
 int plr_fframe_size;
 int plr_qframe_size;
 BOOL deathflag;

--- a/Source/player.h
+++ b/Source/player.h
@@ -7,7 +7,11 @@ extern int plr_wframe_size;
 extern BYTE plr_gfx_flag;
 extern int plr_aframe_size;
 extern int myplr;
+#ifdef HELLFIRE
+extern PlayerStruct *plr;
+#else
 extern PlayerStruct plr[MAX_PLRS];
+#endif
 extern int plr_fframe_size;
 extern int plr_qframe_size;
 extern BOOL deathflag;

--- a/defs.h
+++ b/defs.h
@@ -49,7 +49,11 @@
 #define VOLUME_MAX				0
 
 // todo: enums
+#ifdef HELLFIRE
+#define NUMLEVELS				25
+#else
 #define NUMLEVELS				17
+#endif
 
 // from diablo 2 beta
 #define MAXEXP					2000000000

--- a/structs.h
+++ b/structs.h
@@ -163,6 +163,9 @@ typedef struct ItemStruct {
 	BOOL _iStatFlag;
 	int IDidx;
 	int offs016C; // _oldlight or _iInvalid
+#ifdef HELLFIRE
+	int field_170;
+#endif
 } ItemStruct;
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
The PlayerStruct is dynamically allocated in Hellfire. Probably just as some cheesy hack prevention. This should fix tons of diff.

This also corrects the size of the struct, by adding the missing field in ItemStruct and changing the levels to 25.