### PR TITLE
Fix returning in MonsterTrapHit

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -512,7 +512,7 @@ BOOL MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, BOOLEAN shif
 		return ret;
 	}
 #ifdef _DEBUG
-	else if (hit < hper || debug_mode_dollar_sign || debug_mode_key_inverted_v || monster[m]._mmode = MM_STONE) {
+	else if (hit < hper || debug_mode_dollar_sign || debug_mode_key_inverted_v || monster[m]._mmode == MM_STONE) {
 #else
 	else if (hit < hper || monster[m]._mmode == MM_STONE) {
 #endif

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -474,97 +474,82 @@ void MoveMissilePos(int i)
 BOOL MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, BOOLEAN shift)
 {
 	int hit, hper, dam, mor, mir;
-	BOOL resist, ret, rv;
+	BOOL resist, ret;
 
 	resist = FALSE;
 	if (monster[m].mtalkmsg) {
-		ret = FALSE;
-	} else if (monster[m]._mhitpoints >> 6 <= 0) {
-		ret = FALSE;
-	} else if (monster[m].MType->mtype == MT_ILLWEAV && monster[m]._mgoal == MGOAL_RETREAT)
-		ret = FALSE;
-	else if (monster[m]._mmode == MM_CHARGE)
-		ret = FALSE;
-
-	else {
-		mir = missiledata[t].mResist;
-		mor = monster[m].mMagicRes;
-		if (mor & IMUNE_MAGIC && mir == MISR_MAGIC) {
-			ret = FALSE;
-		}
-
-		else if (mor & IMUNE_FIRE && mir == MISR_FIRE) {
-			ret = FALSE;
-		}
-
-		else if (mor & IMUNE_LIGHTNING && mir == MISR_LIGHTNING) {
-			ret = FALSE;
-		}
-
-		//else if (mor & IMUNE_ACID && mir == MISR_ACID) {
-		//ret = FALSE;
-		//}
-		else {
-
-			if ((mor & RESIST_MAGIC && mir == MISR_MAGIC) || (mor & RESIST_FIRE && mir == MISR_FIRE) || (mor & RESIST_LIGHTNING && mir == MISR_LIGHTNING)) {
-				resist = TRUE;
-			}
-
-			hit = random(68, 100);
-			hper = 90 - (BYTE)monster[m].mArmorClass - dist;
-			if (hper < 5)
-				hper = 5;
-			if (hper > 95)
-				hper = 95;
-			if (CheckMonsterHit(m, &rv)) {
-				ret = rv;
-			} else {
-#ifdef _DEBUG
-				if (hit >= hper && !debug_mode_dollar_sign && !debug_mode_key_inverted_v && monster[m]._mmode != MM_STONE) {
-					ret = FALSE;
-				}
-#else
-				if (hit >= hper && monster[m]._mmode != MM_STONE) {
-					ret = FALSE;
-				}
-#endif
-				else {
-					dam = mindam + random(68, maxdam - mindam + 1);
-					if (!shift)
-						dam <<= 6;
-					if (resist)
-						monster[m]._mhitpoints -= dam >> 2;
-					else
-						monster[m]._mhitpoints -= dam;
-#ifdef _DEBUG
-					if (debug_mode_dollar_sign || debug_mode_key_inverted_v)
-						monster[m]._mhitpoints = 0;
-#endif
-					if (monster[m]._mhitpoints >> 6 <= 0) {
-						if (monster[m]._mmode == MM_STONE) {
-							M_StartKill(m, -1);
-							monster[m]._mmode = MM_STONE;
-						} else {
-							M_StartKill(m, -1);
-						}
-					} else {
-						if (resist) {
-							PlayEffect(m, 1);
-						} else if (monster[m]._mmode == MM_STONE) {
-							if (m > 3)
-								M_StartHit(m, -1, dam);
-							monster[m]._mmode = MM_STONE;
-						} else {
-							if (m > 3)
-								M_StartHit(m, -1, dam);
-						}
-					}
-					ret = TRUE;
-				}
-			}
-		}
+		return FALSE;
 	}
-	return ret;
+	if (monster[m]._mhitpoints >> 6 <= 0) {
+		return FALSE;
+	}
+	if (monster[m].MType->mtype == MT_ILLWEAV && monster[m]._mgoal == MGOAL_RETREAT)
+		return FALSE;
+	if (monster[m]._mmode == MM_CHARGE)
+		return FALSE;
+
+	mir = missiledata[t].mResist;
+	mor = monster[m].mMagicRes;
+	if (mor & IMUNE_MAGIC && mir == MISR_MAGIC
+	|| mor & IMUNE_FIRE && mir == MISR_FIRE
+	|| mor & IMUNE_LIGHTNING && mir == MISR_LIGHTNING) {
+		return FALSE;
+	}
+
+	if ((mor & RESIST_MAGIC && mir == MISR_MAGIC)
+	|| (mor & RESIST_FIRE && mir == MISR_FIRE)
+	|| (mor & RESIST_LIGHTNING && mir == MISR_LIGHTNING)) {
+		resist = TRUE;
+	}
+
+	hit = random(68, 100);
+	hper = 90 - (BYTE)monster[m].mArmorClass - dist;
+	if (hper < 5)
+		hper = 5;
+	if (hper > 95)
+		hper = 95;
+	if (CheckMonsterHit(m, &ret)) {
+		return ret;
+	}
+#ifdef _DEBUG
+	else if (hit < hper || debug_mode_dollar_sign || debug_mode_key_inverted_v || monster[m]._mmode = MM_STONE) {
+#else
+	else if (hit < hper || monster[m]._mmode == MM_STONE) {
+#endif
+		dam = mindam + random(68, maxdam - mindam + 1);
+		if (!shift)
+			dam <<= 6;
+		if (resist)
+			monster[m]._mhitpoints -= dam >> 2;
+		else
+			monster[m]._mhitpoints -= dam;
+#ifdef _DEBUG
+		if (debug_mode_dollar_sign || debug_mode_key_inverted_v)
+			monster[m]._mhitpoints = 0;
+#endif
+		if (monster[m]._mhitpoints >> 6 <= 0) {
+			if (monster[m]._mmode == MM_STONE) {
+				M_StartKill(m, -1);
+				monster[m]._mmode = MM_STONE;
+			} else {
+				M_StartKill(m, -1);
+			}
+		} else {
+			if (resist) {
+				PlayEffect(m, 1);
+			} else if (monster[m]._mmode == MM_STONE) {
+				if (m > 3)
+					M_StartHit(m, -1, dam);
+				monster[m]._mmode = MM_STONE;
+			} else {
+				if (m > 3)
+					M_StartHit(m, -1, dam);
+			}
+		}
+		return TRUE;
+	} else {
+		return FALSE;
+	}
 }
 
 BOOL MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, BOOLEAN shift)


### PR DESCRIPTION
This fixes a case where a temp variable is used for return, thus everything nests outward each time. If you look at the code in the beta, you can see when an if/else return is used there are TWO jumps in the ASM, the second one being unused. Basically:
```c
if ( x ) 
  return TRUE;
else if ( y ) 
  return FALSE;
```
Generates the unused jump. But this code does not:
```c
if ( x ) 
  return TRUE;
if ( y ) 
  return FALSE;
```