### PR TITLE
Wave.cpp bin exact

### DIFF
--- a/Source/wave.cpp
+++ b/Source/wave.cpp
@@ -38,8 +38,13 @@ BOOL WOpenFile(const char *FileName, HANDLE *phsFile, BOOL mayNotExist)
 	while (1) {
 		if (SFileOpenFile(FileName, phsFile))
 			return TRUE;
+#ifdef HELLFIRE
+		if (mayNotExist && GetLastError() == ERROR_FILE_NOT_FOUND)
+			break;
+#else
 		if (mayNotExist && SErrGetLastError() == ERROR_FILE_NOT_FOUND)
 			break;
+#endif
 		WGetFileArchive(NULL, &retry, FileName);
 	}
 	return FALSE;


### PR DESCRIPTION
They just had to rely so much on storm. This is actually a change between 1.04 and 1.07, and not specific to hellfire.