### PR TITLE
Fix Hellfire Structs

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -11,7 +11,12 @@ int nummonsters;
 BOOLEAN sgbSaveSoundOn;
 MonsterStruct monster[MAXMONSTERS];
 int totalmonsters;
+#ifdef HELLFIRE
+CMonster Monsters[24];
+int unused_6AAE30[600];
+#else
 CMonster Monsters[16];
+#endif
 // int END_Monsters_17;
 int monstimgtot;
 int uniquetrans;

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -8,7 +8,12 @@ extern int monstactive[MAXMONSTERS];
 extern int nummonsters;
 extern MonsterStruct monster[MAXMONSTERS];
 extern int totalmonsters;
+#ifdef HELLFIRE
+extern CMonster Monsters[24];
+extern int unused_6AAE30[600];
+#else
 extern CMonster Monsters[16];
+#endif
 // int END_Monsters_17;
 extern int monstimgtot;
 extern int uniquetrans;

--- a/structs.h
+++ b/structs.h
@@ -164,7 +164,7 @@ typedef struct ItemStruct {
 	int IDidx;
 	int offs016C; // _oldlight or _iInvalid
 #ifdef HELLFIRE
-	int field_170;
+	int _iDamAcFlags;
 #endif
 } ItemStruct;
 
@@ -335,12 +335,27 @@ typedef struct PlayerStruct {
 	unsigned char pTownWarps;
 	unsigned char pDungMsgs;
 	unsigned char pLvlLoad;
+/*
+#ifdef HELLFIRE
+	unsigned char pDungMsgs2;
+	char bReserved[4];
+	short wReflection;
+	short wReserved[7];
+	int pDiabloKillLevel;
+	int pDifficulty;
+	int pDamAcFlags;
+	int dwReserved[5];
+#else
+*/
 	unsigned char pBattleNet;
 	BOOLEAN pManaShield;
 	char bReserved[3];
 	short wReserved[8];
 	DWORD pDiabloKillLevel;
 	int dwReserved[7];
+/*
+#endif
+*/
 	unsigned char *_pNData;
 	unsigned char *_pWData;
 	unsigned char *_pAData;
@@ -522,15 +537,24 @@ typedef struct MonsterData {
 } MonsterData;
 
 typedef struct CMonster {
+#ifdef HELLFIRE
+	int mtype;
+#else
 	unsigned char mtype;
+#endif
 	// TODO: Add enum for place flags
 	unsigned char mPlaceFlags;
 	AnimStruct Anims[6];
 	TSnd *Snds[4][2];
 	int width;
 	int width2;
+#ifdef HELLFIRE
+	int mMinHP;
+	int mMaxHP;
+#else
 	unsigned char mMinHP;
 	unsigned char mMaxHP;
+#endif
 	BOOL has_special;
 	unsigned char mAFNum;
 	char mdeadval;


### PR DESCRIPTION
CMonster now has the correct size.
ItemStruct/Playerstruct have the correct field names. However, the new fields in PlayerStruct are commented out because all the code for manashield has to be removed from hellfire, since it relies on a field in the reserved fields. Hellfire added four new fields: reflection related, difficulty, damage/ac (beserk I think), and new dungeon messages.

It also expanded monster types from 16 to 24, and there is an unused array beneath it.