### PR TITLE
mpqapi_add_file cleanup

### DIFF
--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -266,17 +266,12 @@ _BLOCKENTRY *mpqapi_add_file(const char *pszName, _BLOCKENTRY *pBlk, int block_i
 	h3 = Hash(pszName, 2);
 	if (mpqapi_get_hash_index(h1, h2, h3, 0) != -1)
 		app_fatal("Hash collision between \"%s\" and existing file\n", pszName);
-	i = 2048;
 	hIdx = h1 & 0x7FF;
-	while (1) {
-		i--;
+	i = 2048;
+	while (i--) {
 		if (sgpHashTbl[hIdx].block == -1 || sgpHashTbl[hIdx].block == -2)
 			break;
 		hIdx = (hIdx + 1) & 0x7FF;
-		if (!i) {
-			i = -1;
-			break;
-		}
 	}
 	if (i < 0)
 		app_fatal("Out of hash space");


### PR DESCRIPTION
bin exact in vanilla and hellfire

and about our coding style, 
`while (i--) {`
can't be changed into `while(i){i--;` - it breaks bin exact ;)