### PR TITLE
[hellfire] DrawLifeFlask bin exact

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1016,11 +1016,25 @@ void DrawFlask(BYTE *pCelBuff, int w, int nSrcOff, BYTE *pBuff, int nDstOff, int
 
 void DrawLifeFlask()
 {
-	int filled = (double)plr[myplr]._pHitPoints / (double)plr[myplr]._pMaxHP * 80.0;
-	plr[myplr]._pHPPer = filled;
+	double p;
+	int filled;
 
+#ifdef HELLFIRE
+	if (plr[myplr]._pMaxHP <= 0) {
+		p = 0.0;
+	} else {
+		p = (double)plr[myplr]._pHitPoints / (double)plr[myplr]._pMaxHP * 80.0;
+	}
+#else
+	p = (double)plr[myplr]._pHitPoints / (double)plr[myplr]._pMaxHP * 80.0;
+#endif
+	plr[myplr]._pHPPer = p;
+	filled = plr[myplr]._pHPPer;
+
+#ifndef HELLFIRE
 	if (filled > 80)
 		filled = 80;
+#endif
 	filled = 80 - filled;
 	if (filled > 11)
 		filled = 11;


### PR DESCRIPTION
Seems a double variable is required by hellfire, I tweaked vanilla code a bit to make the hellfire ifdef as small as possible, no idea if these changes are worth moving to vanilla