### PR TITLE
Fix unused monster array/MAX_LVLMTYPES

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -11,13 +11,12 @@ int nummonsters;
 BOOLEAN sgbSaveSoundOn;
 MonsterStruct monster[MAXMONSTERS];
 int totalmonsters;
+CMonster Monsters[MAX_LVLMTYPES];
 #ifdef HELLFIRE
-CMonster Monsters[24];
-int unused_6AAE30[600];
+int GraphicTable[NUMLEVELS][MAX_LVLMTYPES];
 #else
-CMonster Monsters[16];
+BYTE GraphicTable[NUMLEVELS][MAX_LVLMTYPES];
 #endif
-// int END_Monsters_17;
 int monstimgtot;
 int uniquetrans;
 int nummtypes;

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -8,13 +8,12 @@ extern int monstactive[MAXMONSTERS];
 extern int nummonsters;
 extern MonsterStruct monster[MAXMONSTERS];
 extern int totalmonsters;
+extern CMonster Monsters[MAX_LVLMTYPES];
 #ifdef HELLFIRE
-extern CMonster Monsters[24];
-extern int unused_6AAE30[600];
+extern int GraphicTable[NUMLEVELS][MAX_LVLMTYPES];
 #else
-extern CMonster Monsters[16];
+extern BYTE GraphicTable[NUMLEVELS][MAX_LVLMTYPES];
 #endif
-// int END_Monsters_17;
 extern int monstimgtot;
 extern int uniquetrans;
 extern int nummtypes;

--- a/defs.h
+++ b/defs.h
@@ -12,7 +12,11 @@
 #define MAX_PLRS				4
 
 #define MAX_CHARACTERS			10
+#ifdef HELLFIRE
+#define MAX_LVLMTYPES			24
+#else
 #define MAX_LVLMTYPES			16
+#endif
 // #define MAX_PATH				260
 #define MAX_SEND_STR_LEN		80
 #define MAX_SPELLS				37


### PR DESCRIPTION
The unused array has been figured out, it is part of an unused function in the beta/debug release to check if monster graphic is a duplicate. The array is number of levels * number of monster types. Should help data align and also be applied to vanilla.