### PR TITLE
Improve build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: cpp
 os:
   - linux
   - osx
+  
+osx_image: xcode10.3
 
 notifications:
   email:
@@ -15,7 +17,6 @@ addons:
   homebrew:
     packages:
       - mingw-w64
-    update: true
 
 env:
   - MAKE_BUILD=make


### PR DESCRIPTION
Most Mac images at Travis are severely outdated each build spends about 5 minutes just to update the brew package list before it is able to install any packages. Switching to a known more recent image solves this situation for now.