### PR TITLE
Implement CelGetFrame (CEL decoder helper)

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -726,14 +726,12 @@ void CPrintString(int nOffset, int nCel, char col)
 	labret:
 	}
 #else
-	int i;
+	int i, nDataSize;
 	BYTE width, pix;
 	BYTE *src, *dst, *end;
-	DWORD *pFrameTable;
 
-	pFrameTable = (DWORD *)&pPanelText[4 * nCel];
-	src = &pPanelText[pFrameTable[0]];
-	end = &src[pFrameTable[1] - pFrameTable[0]];
+	src = CelGetFrame(pPanelText, nCel, &nDataSize);
+	end = &src[nDataSize];
 	dst = &gpBuffer[nOffset];
 
 	switch (col) {

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -11,6 +11,8 @@ extern int orgseed;
 extern int SeedCount;
 extern BOOL gbNotInView; // valid - if x/y are in bounds
 
+__FINLINE BYTE *CelGetFrame(BYTE *pCelBuff, int nCel, int *nDataSize);
+
 void CelDrawDatOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
 void CelDecodeOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
 void CelDecDatOnly(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth);

--- a/defs.h
+++ b/defs.h
@@ -173,3 +173,15 @@ typedef void (*_PVFV)(void);
 #else
 #define ALIGN_BY_1
 #endif
+
+#if (_MSC_VER == 1200)
+#define __FINLINE __forceinline
+#else
+#define __FINLINE
+#endif
+
+#ifndef _BIG_ENDIAN_
+#define SwapLE32
+#else
+#define SwapLE32(value) (value << 24 | (value & 0xFF00) << 8 | (value & 0xFF0000) >> 8 | value >> 24);
+#endif


### PR DESCRIPTION
This implements the first of the inlined CEL decoder helper functions
that are still visable in the Mac port code.

Functions are still bin exact