### PR TITLE
PackPlayer stuff

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -782,8 +782,13 @@ void multi_send_pinfo(int pnum, char cmd)
 {
 	PkPlayerStruct pkplr;
 
+#ifdef HELLFIRE
+	PackPlayer(&pkplr, myplr);
+	dthread_send_delta(pnum, cmd, &pkplr, sizeof(pkplr) + 1);
+#else
 	PackPlayer(&pkplr, myplr, TRUE);
 	dthread_send_delta(pnum, cmd, &pkplr, sizeof(pkplr));
+#endif
 }
 
 int InitLevelType(int l)

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -1,7 +1,11 @@
 #include "diablo.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
+#ifdef HELLFIRE
+void PackPlayer(PkPlayerStruct *pPack, int pnum)
+#else
 void PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield)
+#endif
 {
 	PlayerStruct *pPlayer;
 	int i;
@@ -34,8 +38,16 @@ void PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield)
 	pPack->pMaxManaBase = pPlayer->_pMaxManaBase;
 	pPack->pMemSpells = pPlayer->_pMemSpells;
 
+#ifdef HELLFIRE
+	for (i = 0; i <= 36; i++)
+		pPack->pSplLvl[i] = pPlayer->_pSplLvl[i];
+	for (i = 37; i < 47; i++)
+		//pPack->pSplLvl[i] = pPlayer->_pSplLvl[i];
+		*((BYTE *)&pPack->SpdList[6].wValue + i) = pPlayer->_pSplLvl[i];
+#else
 	for (i = 0; i < MAX_SPELLS; i++)
 		pPack->pSplLvl[i] = pPlayer->_pSplLvl[i];
+#endif
 
 	pki = pPack->InvBody;
 	pi = pPlayer->InvBody;

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -2,7 +2,11 @@
 #ifndef __PACK_H__
 #define __PACK_H__
 
+#ifdef HELLFIRE
+void PackPlayer(PkPlayerStruct *pPack, int pnum);
+#else
 void PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield);
+#endif
 void PackItem(PkItemStruct *id, ItemStruct *is);
 void VerifyGoldSeeds(PlayerStruct *pPlayer);
 void UnPackPlayer(PkPlayerStruct *pPack, int pnum, BOOL killok);

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -65,7 +65,11 @@ void pfile_write_hero()
 
 	save_num = pfile_get_save_num_from_name(plr[myplr]._pName);
 	if (pfile_open_archive(TRUE, save_num)) {
+#ifdef HELLFIRE
+		PackPlayer(&pkplr, myplr);
+#else
 		PackPlayer(&pkplr, myplr, gbMaxPlayers == 1);
+#endif
 		pfile_encode_hero(&pkplr);
 		pfile_flush(gbMaxPlayers == 1, save_num);
 	}
@@ -459,12 +463,20 @@ BOOL __stdcall pfile_ui_save_create(_uiheroinfo *heroinfo)
 	PkPlayerStruct pkplr;
 
 	save_num = pfile_get_save_num_from_name(heroinfo->name);
+#ifdef HELLFIRE
+	if (save_num >= MAX_CHARACTERS) {
+#else
 	if (save_num == MAX_CHARACTERS) {
+#endif
 		for (save_num = 0; save_num < MAX_CHARACTERS; save_num++) {
 			if (!hero_names[save_num][0])
 				break;
 		}
+#ifdef HELLFIRE
+		if (save_num >= MAX_CHARACTERS)
+#else
 		if (save_num == MAX_CHARACTERS)
+#endif
 			return FALSE;
 	}
 	if (!pfile_open_archive(FALSE, save_num))
@@ -476,7 +488,11 @@ BOOL __stdcall pfile_ui_save_create(_uiheroinfo *heroinfo)
 	CreatePlayer(0, cl);
 	strncpy(plr[0]._pName, heroinfo->name, PLR_NAME_LEN);
 	plr[0]._pName[PLR_NAME_LEN - 1] = '\0';
+#ifdef HELLFIRE
+	PackPlayer(&pkplr, 0);
+#else
 	PackPlayer(&pkplr, 0, TRUE);
+#endif
 	pfile_encode_hero(&pkplr);
 	game_2_ui_player(&plr[0], heroinfo, FALSE);
 	pfile_flush(TRUE, save_num);

--- a/structs.h
+++ b/structs.h
@@ -1460,7 +1460,7 @@ typedef struct PkPlayerStruct {
 	DWORD pDiabloKillLevel;
 	int pDifficulty;
 	int pDamAcFlags;
-	int dwReserved[5];
+	int dwReserved;
 #else
 	char pBattleNet;
 	BOOLEAN pManaShield;


### PR DESCRIPTION
bin exact:
`pfile_ui_save_create`
`pfile_write_hero`
`multi_send_pinfo`

It seems PackPlayer loses an argument,
changing	`int dwReserved[5];`
into	`int dwReserved;`
in PkPlayerStruct fixes PkPlayerStruct size in many places but something is still wrong in some places, it's off by 1 in PackPlayer and multi_send_pinfo

also no idea what's going on here
`	for (i = 37; i < 47; i++)`
`		*((BYTE *)&pPack->SpdList[6].wValue + i) = pPlayer->_pSplLvl[i];`