### PR TITLE
credits.cpp: Enum for CreateFontA iPitchAndFamily

### DIFF
--- a/DiabloUI/credits.cpp
+++ b/DiabloUI/credits.cpp
@@ -135,7 +135,7 @@ void __fastcall credits_LoadImgCreditTxt(HWND hWnd, LPARAM lParam)
 	SDlgSetBitmapI(v13, 0, 0, -1, 1, credit_back_img, (int)&Rect, v7, v8, -1);
 	credit_vertical_pos2 = v8 - 30;
 	credits_CalcPosROP3(hWnd);
-	v9 = CreateFontA(-17, 0, 0, 0, 700, 0, 0, 0, 0, 0, 0, 0, 0x12u, "Times New Roman");
+	v9 = CreateFontA(-17, 0, 0, 0, 700, 0, 0, 0, 0, 0, 0, 0, VARIABLE_PITCH | (FF_SCRIPT << 2), "Times New Roman");
 	if (!v9 || (v11 = SGdiImportFont(v9, (int)&creditsobj), DeleteObject(v9), !v11))
 		Title_KillAndFadeDlg(hWnd);
 }

--- a/DiabloUI/credits.cpp
+++ b/DiabloUI/credits.cpp
@@ -135,7 +135,7 @@ void __fastcall credits_LoadImgCreditTxt(HWND hWnd, LPARAM lParam)
 	SDlgSetBitmapI(v13, 0, 0, -1, 1, credit_back_img, (int)&Rect, v7, v8, -1);
 	credit_vertical_pos2 = v8 - 30;
 	credits_CalcPosROP3(hWnd);
-	v9 = CreateFontA(-17, 0, 0, 0, 700, 0, 0, 0, 0, 0, 0, 0, VARIABLE_PITCH | (FF_SCRIPT << 2), "Times New Roman");
+	v9 = CreateFontA(-17, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, 0, 0, 0, VARIABLE_PITCH | (FF_SCRIPT << 2), "Times New Roman");
 	if (!v9 || (v11 = SGdiImportFont(v9, (int)&creditsobj), DeleteObject(v9), !v11))
 		Title_KillAndFadeDlg(hWnd);
 }


### PR DESCRIPTION
From https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createfonta:
> The two low-order bits specify the pitch of the font
> The four high-order bits specify the font family

[[MS-WMF]: 2.1.1.8 FamilyFont Enumeration](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/9a632766-1f1c-4e2b-b1a4-f5b1a45f99ad)
[[MS-WMF]: 2.1.1.24 PitchFont Enumeration](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/22dbe377-aec4-4669-88e6-b8fdd9351d76)