### PR TITLE
Add bugfix for dupe bug

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1521,7 +1521,7 @@ void AutoGetItem(int pnum, int ii)
 	}
 
 	item[ii]._iCreateInfo &= 0x7FFF;
-	plr[pnum].HoldItem = item[ii];
+	plr[pnum].HoldItem = item[ii]; /// BUGFIX: overwrites cursor item, allowing for belt dupe bug
 	CheckQuestItem(pnum);
 	CheckBookLevel(pnum);
 	CheckItemStats(pnum);


### PR DESCRIPTION
This one is based on Dr. Zed's notes from The Dark mod. Basically a hacky fix is to backup `plr[pnum].HoldItem` to a temporary buffer and then restore it at the end of this function, to prevent picking up a potion and it being overwritten. An actual proper fix would involve rewriting all of diablo's crappy code that uses the cursor item as a temporary buffer, similar to the [Eldritch Shrine bug that overwrites your cursor item with a rejuv potion](https://github.com/diasurgical/devilution/issues/64#issuecomment-434897325).

Also, the dupe bug does *not exist* prior to patch 1.02. 1.02 introduced dupe detection and ironically created the dupe bug somehow, but I'm still trying to figure out what code change it was.