### PR TITLE
PlrHasItem: pass by reference

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -5432,14 +5432,14 @@ void TalktoMonster(int i)
 	pnum = Monst->_menemy;
 	Monst->_mmode = MM_TALK;
 	if (Monst->_mAi == AI_SNOTSPIL || Monst->_mAi == AI_LACHDAN) {
-		if (QuestStatus(QTYPE_BOL) && quests[QTYPE_BOL]._qvar1 == 2 && PlrHasItem(pnum, IDI_BANNER, &itm)) {
+		if (QuestStatus(QTYPE_BOL) && quests[QTYPE_BOL]._qvar1 == 2 && PlrHasItem(pnum, IDI_BANNER, itm)) {
 			RemoveInvItem(pnum, itm);
 			quests[QTYPE_BOL]._qactive = 3;
 			Monst->mtalkmsg = QUEST_BANNER12;
 			Monst->_mgoal = MGOAL_INQUIRING;
 		}
 		if (QuestStatus(QTYPE_VEIL) && Monst->mtalkmsg >= QUEST_VEIL9) {
-			if (PlrHasItem(pnum, IDI_GLDNELIX, &itm)) {
+			if (PlrHasItem(pnum, IDI_GLDNELIX, itm)) {
 				RemoveInvItem(pnum, itm);
 				Monst->mtalkmsg = QUEST_VEIL11;
 				Monst->_mgoal = MGOAL_INQUIRING;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2787,7 +2787,7 @@ void OperatePedistal(int pnum, int i)
 	int iv;
 
 	if (object[i]._oVar6 != 3) {
-		if (PlrHasItem(pnum, IDI_BLDSTONE, &iv)) {
+		if (PlrHasItem(pnum, IDI_BLDSTONE, iv)) {
 			RemoveInvItem(pnum, iv);
 			object[i]._oAnimFrame++;
 			object[i]._oVar6++;

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -571,13 +571,11 @@ void ProcessTowners()
 	}
 }
 
-ItemStruct *PlrHasItem(int pnum, int item, int *inv_item_num)
+ItemStruct *PlrHasItem(int pnum, int item, int &i)
 {
-	int i;
-
-	for (i = 0, *inv_item_num = i; i < plr[pnum]._pNumInv; i = *inv_item_num + 1, *inv_item_num = i) {
-		if (plr[pnum].InvList[*inv_item_num].IDidx == item)
-			return &plr[pnum].InvList[*inv_item_num];
+	for (i = 0; i < plr[pnum]._pNumInv; i++) {
+		if (plr[pnum].InvList[i].IDidx == item)
+			return &plr[pnum].InvList[i];
 	}
 
 	return NULL;
@@ -666,7 +664,7 @@ void TalkToTowner(int p, int t)
 				InitQTextMsg(QUEST_BANNER2);
 				towner[t]._tMsgSaid = TRUE;
 			}
-			if (quests[QTYPE_BOL]._qvar2 == 1 && PlrHasItem(p, IDI_BANNER, &i) != NULL && !towner[t]._tMsgSaid) {
+			if (quests[QTYPE_BOL]._qvar2 == 1 && PlrHasItem(p, IDI_BANNER, i) != NULL && !towner[t]._tMsgSaid) {
 				quests[QTYPE_BOL]._qactive = 3;
 				quests[QTYPE_BOL]._qvar1 = 3;
 				RemoveInvItem(p, i);
@@ -730,7 +728,7 @@ void TalkToTowner(int p, int t)
 					InitQTextMsg(QUEST_INFRA5);
 					towner[t]._tMsgSaid = TRUE;
 				}
-				if (quests[QTYPE_INFRA]._qvar2 == 1 && PlrHasItem(p, IDI_ROCK, &i) != NULL && !towner[t]._tMsgSaid) {
+				if (quests[QTYPE_INFRA]._qvar2 == 1 && PlrHasItem(p, IDI_ROCK, i) != NULL && !towner[t]._tMsgSaid) {
 					quests[QTYPE_INFRA]._qactive = 3;
 					quests[QTYPE_INFRA]._qvar2 = 2;
 					quests[QTYPE_INFRA]._qvar1 = 2;
@@ -757,7 +755,7 @@ void TalkToTowner(int p, int t)
 						towner[t]._tMsgSaid = TRUE;
 					}
 				}
-				if (quests[QTYPE_ANVIL]._qvar2 == 1 && PlrHasItem(p, IDI_ANVIL, &i) != NULL) {
+				if (quests[QTYPE_ANVIL]._qvar2 == 1 && PlrHasItem(p, IDI_ANVIL, i) != NULL) {
 					if (!towner[t]._tMsgSaid) {
 						quests[QTYPE_ANVIL]._qactive = 3;
 						quests[QTYPE_ANVIL]._qvar2 = 2;
@@ -779,7 +777,7 @@ void TalkToTowner(int p, int t)
 			}
 		}
 	} else if (t == GetActiveTowner(TOWN_WITCH)) {
-		if (quests[QTYPE_BLKM]._qactive == 1 && PlrHasItem(p, IDI_FUNGALTM, &i) != NULL) {
+		if (quests[QTYPE_BLKM]._qactive == 1 && PlrHasItem(p, IDI_FUNGALTM, i) != NULL) {
 			RemoveInvItem(p, i);
 			quests[QTYPE_BLKM]._qactive = 2;
 			quests[QTYPE_BLKM]._qlog = TRUE;
@@ -790,7 +788,7 @@ void TalkToTowner(int p, int t)
 			towner[t]._tMsgSaid = TRUE;
 		} else if (quests[QTYPE_BLKM]._qactive == 2) {
 			if (quests[QTYPE_BLKM]._qvar1 >= 2 && quests[QTYPE_BLKM]._qvar1 <= 4) {
-				if (PlrHasItem(p, IDI_MUSHROOM, &i) != NULL) {
+				if (PlrHasItem(p, IDI_MUSHROOM, i) != NULL) {
 					RemoveInvItem(p, i);
 					quests[QTYPE_BLKM]._qvar1 = 5;
 					Qtalklist[TOWN_HEALER]._qblkm = QUEST_MUSH3;
@@ -808,7 +806,7 @@ void TalkToTowner(int p, int t)
 					towner[t]._tMsgSaid = TRUE;
 				}
 			} else {
-				Item = PlrHasItem(p, IDI_SPECELIX, &i);
+				Item = PlrHasItem(p, IDI_SPECELIX, i);
 				if (Item != NULL) {
 					towner[t]._tbtcnt = 150;
 					towner[t]._tVar1 = p;
@@ -816,7 +814,7 @@ void TalkToTowner(int p, int t)
 					quests[QTYPE_BLKM]._qactive = 3;
 					towner[t]._tMsgSaid = TRUE;
 					AllItemsList[Item->IDidx].iUsable = TRUE;
-				} else if (PlrHasItem(p, IDI_BRAIN, &i) != NULL && quests[QTYPE_BLKM]._qvar2 != QUEST_MUSH11) {
+				} else if (PlrHasItem(p, IDI_BRAIN, i) != NULL && quests[QTYPE_BLKM]._qvar2 != QUEST_MUSH11) {
 					towner[t]._tbtcnt = 150;
 					towner[t]._tVar1 = p;
 					quests[QTYPE_BLKM]._qvar2 = QUEST_MUSH11;
@@ -866,7 +864,7 @@ void TalkToTowner(int p, int t)
 					towner[t]._tMsgSaid = TRUE;
 				}
 			}
-			if (quests[QTYPE_BLKM]._qactive == 2 && quests[QTYPE_BLKM]._qmsg == QUEST_MUSH10 && PlrHasItem(p, IDI_BRAIN, &i) != NULL) {
+			if (quests[QTYPE_BLKM]._qactive == 2 && quests[QTYPE_BLKM]._qmsg == QUEST_MUSH10 && PlrHasItem(p, IDI_BRAIN, i) != NULL) {
 				RemoveInvItem(p, i);
 				SpawnQuestItem(IDI_SPECELIX, towner[t]._tx, towner[t]._ty + 1, 0, 0);
 				InitQTextMsg(QUEST_MUSH4);
@@ -889,7 +887,7 @@ void TalkToTowner(int p, int t)
 		}
 	} else if (t == GetActiveTowner(TOWN_STORY)) {
 		if (gbMaxPlayers == 1) {
-			if (quests[QTYPE_VB]._qactive == 1 && PlrHasItem(p, IDI_LAZSTAFF, &i) != NULL) {
+			if (quests[QTYPE_VB]._qactive == 1 && PlrHasItem(p, IDI_LAZSTAFF, i) != NULL) {
 				RemoveInvItem(p, i);
 				quests[QTYPE_VB]._qvar1 = 2;
 				towner[t]._tbtcnt = 150;

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -33,7 +33,7 @@ void TownWitch();
 void TownBarMaid();
 void TownCow();
 void ProcessTowners();
-ItemStruct *PlrHasItem(int pnum, int item, int *i);
+ItemStruct *PlrHasItem(int pnum, int item, int &i);
 void TownerTalk(int first, int t);
 void TalkToTowner(int p, int t);
 void CowSFX(int pnum);


### PR DESCRIPTION
I was experimenting with a tool from the PSX sdk to demangle symbol files. By chance I noticed about 3 or 4 functions had a reference `&` instead of pointer `*`. Sure enough, using a reference for them looks much cleaner.

This also is more proof they compiled as C++, because references aren't supported in C.