### PR TITLE
Fix function order [dx.cpp]

### DIFF
--- a/Source/dx.h
+++ b/Source/dx.h
@@ -12,13 +12,8 @@ extern char gbEmulate;
 extern HMODULE ghDiabMod;
 
 void dx_init(HWND hWnd);
-void dx_create_back_buffer();
-void dx_create_primary_surface();
-HRESULT dx_DirectDrawCreate(LPGUID guid, LPDIRECTDRAW *lplpDD, LPUNKNOWN pUnkOuter);
 void lock_buf(BYTE idx);
-void lock_buf_priv();
 void unlock_buf(BYTE idx);
-void unlock_buf_priv();
 void dx_cleanup();
 void dx_reinit();
 void j_dx_reinit();

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -2493,7 +2493,7 @@ static void DrawMain(int dwHgt, BOOL draw_desc, BOOL draw_hp, BOOL draw_mana, BO
 					break;
 				}
 				retry = FALSE;
-				dx_reinit();
+				j_dx_reinit();
 				ysize = SCREEN_HEIGHT;
 				dwTicks = GetTickCount();
 			}


### PR DESCRIPTION
This one was a bit trickier as it relied on limited info from the mac release and line numbers from assertions. If you check the table below:
```
                          Debug      1.09
dx_init                   134 - 197 [149 183]
dx_create_back_buffer     50 - 92   [59 96]
dx_create_primary_surface 105       [109]
dx_DirectDrawCreate       118 - 123 [122 127]
lock_buf                  
lock_buf_priv             222 - 224 [235]
unlock_buf                
unlock_buf_priv           250 - 260 [273]
dx_cleanup                295 - 296
dx_reinit                 334
j_dx_reinit               
```
You can see line numbers are in order except for `dx_init`, which should fall after `dx_DirectDrawCreate       `. Additionally the mac release shows that the private locking functions come before the non private:
```
dx_init
lock_buf_priv
lock_buf
unlock_buf_priv
unlock_buf
dx_cleanup
```