### PR TITLE
Fix OOB in dungeon lvl2 Dark Passage generation

### DIFF
--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -53,6 +53,8 @@ const ShadowStruct SPATS[37] = {
 	{      3, 13, 11, 12, 150,   0,   0 }
 	// clang-format on
 };
+
+// BUGFIX: This array should contain an additional 0 (207 elements).
 const BYTE BSTYPES[206] = {
 	0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
 	10, 11, 12, 13, 14, 15, 16, 17, 0, 0,
@@ -76,6 +78,8 @@ const BYTE BSTYPES[206] = {
 	28, 1, 2, 25, 26, 22, 22, 25, 26, 0,
 	0, 0, 0, 0, 0, 0
 };
+
+// BUGFIX: This array should contain an additional 0 (207 elements).
 const BYTE L5BTYPES[206] = {
 	0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
 	10, 11, 12, 13, 14, 15, 16, 17, 0, 0,

--- a/Source/drlg_l1.h
+++ b/Source/drlg_l1.h
@@ -20,8 +20,11 @@ void CreateL5Dungeon(DWORD rseed, int entry);
 
 /* rdata */
 extern const ShadowStruct SPATS[37];
+
+// BUGFIX: These arrays should contain an additional 0 (207 elements).
 extern const BYTE BSTYPES[206];
 extern const BYTE L5BTYPES[206];
+
 extern const BYTE STAIRSUP[];
 extern const BYTE L5STAIRSUP[];
 extern const BYTE STAIRSDOWN[];


### PR DESCRIPTION
Dark Passage entrance index is 206 but the BSTYPES and L5BTYPES array only contain 206 elements.

Refs https://github.com/diasurgical/devilutionX/pull/400