### PR TITLE
DrawSpell: Change `spl` from char to signed char

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -375,7 +375,7 @@ void SetSpellTrans(char t)
  */
 void DrawSpell()
 {
-	char spl, st;
+	signed char spl, st;
 	int tlvl;
 
 	spl = plr[myplr]._pRSpell;


### PR DESCRIPTION
SPL_INVALID is -1, best to be explicit about signedness