### PR TITLE
DrawSpell: Change `spl` from `char` to `int`

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -375,8 +375,8 @@ void SetSpellTrans(char t)
  */
 void DrawSpell()
 {
-	char spl, st;
-	int tlvl;
+	char st;
+	int spl, tlvl;
 
 	spl = plr[myplr]._pRSpell;
 	st = plr[myplr]._pRSplType;


### PR DESCRIPTION
Just checking if it's binexact. `spl` is usually an `int` in the rest of the codebase.