### PR TITLE
Fix unknown struct field and drawpanflag

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -532,7 +532,7 @@ void SetSpell()
 		ClearPanel();
 		plr[myplr]._pRSpell = pSpell;
 		plr[myplr]._pRSplType = pSplType;
-		drawpanflag = 255;
+		force_redraw = 255;
 	}
 }
 
@@ -576,7 +576,7 @@ void ToggleSpell(int slot)
 	if (spells & (__int64)1 << (plr[myplr]._pSplHotKey[slot] - 1)) {
 		plr[myplr]._pRSpell = plr[myplr]._pSplHotKey[slot];
 		plr[myplr]._pRSplType = plr[myplr]._pSplTHotKey[slot];
-		drawpanflag = 255;
+		force_redraw = 255;
 	}
 }
 
@@ -2379,7 +2379,7 @@ void CheckSBook()
 			}
 			plr[myplr]._pRSpell = sn;
 			plr[myplr]._pRSplType = st;
-			drawpanflag = 255;
+			force_redraw = 255;
 		}
 	}
 	if (MouseX >= RIGHT_PANEL + 7 && MouseX < RIGHT_PANEL + 313 && MouseY >= 320 && MouseY < 349) { /// BUGFIX: change `< 313` to `< 311`
@@ -2655,7 +2655,7 @@ void control_type_message()
 		talkbtndown[i] = FALSE;
 	}
 	sgbPlrTalkTbl = PANEL_HEIGHT + 16;
-	drawpanflag = 255;
+	force_redraw = 255;
 	sgbTalkSavePos = sgbNextTalkSave;
 }
 
@@ -2663,7 +2663,7 @@ void control_reset_talk()
 {
 	talkflag = FALSE;
 	sgbPlrTalkTbl = 0;
-	drawpanflag = 255;
+	force_redraw = 255;
 }
 
 BOOL control_talk_last_key(int vkey)

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -20,7 +20,7 @@ BOOL gbLoadGame;
 HINSTANCE ghInst;
 int DebugMonsters[10];
 BOOLEAN cineflag;
-int drawpanflag;
+int force_redraw;
 BOOL visiondebug;
 BOOL scrollflag; /* unused */
 BOOL light4flag;
@@ -134,10 +134,10 @@ void run_game_loop(unsigned int uMsg)
 	gbRunGame = TRUE;
 	gbProcessPlayers = TRUE;
 	gbRunGameResult = TRUE;
-	drawpanflag = 255;
+	force_redraw = 255;
 	DrawAndBlit();
 	PaletteFadeIn(8);
-	drawpanflag = 255;
+	force_redraw = 255;
 	gbGameLoopStartup = TRUE;
 	nthread_ignore_mutex(FALSE);
 
@@ -180,7 +180,7 @@ void run_game_loop(unsigned int uMsg)
 	PaletteFadeOut(8);
 	SetCursor_(0);
 	ClearScreenBuffer();
-	drawpanflag = 255;
+	force_redraw = 255;
 	scrollrt_draw_game_screen(TRUE);
 	saveProc = SetWindowProc(saveProc);
 	/// ASSERT: assert(saveProc == GM_Game);
@@ -761,7 +761,7 @@ LRESULT CALLBACK GM_Game(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		sgbMouseDown = 0;
 		ReleaseCapture();
 		ShowProgress(uMsg);
-		drawpanflag = 255;
+		force_redraw = 255;
 		DrawAndBlit();
 		if (gbRunGame)
 			PaletteFadeIn(8);
@@ -1213,7 +1213,7 @@ void diablo_pause_game()
 			FreeMonsterSnd();
 			track_repeat_walk(0);
 		}
-		drawpanflag = 255;
+		force_redraw = 255;
 	}
 }
 
@@ -1827,7 +1827,7 @@ void game_logic()
 		PauseMode = 2;
 	}
 	if (gbMaxPlayers == 1 && gmenu_exception()) {
-		drawpanflag |= 1;
+		force_redraw |= 1;
 		return;
 	}
 
@@ -1861,7 +1861,7 @@ void game_logic()
 	ClearPlrMsg();
 	CheckTriggers();
 	CheckQuests();
-	drawpanflag |= 1;
+	force_redraw |= 1;
 	pfile_update(FALSE);
 }
 
@@ -1875,14 +1875,14 @@ void timeout_cursor(BOOL bTimeout)
 			AddPanelString("-- Network timeout --", TRUE);
 			AddPanelString("-- Waiting for players --", TRUE);
 			SetCursor_(CURSOR_HOURGLASS);
-			drawpanflag = 255;
+			force_redraw = 255;
 		}
 		scrollrt_draw_game_screen(1);
 	} else if (sgnTimeoutCurs) {
 		SetCursor_(sgnTimeoutCurs);
 		sgnTimeoutCurs = 0;
 		ClearPanel();
-		drawpanflag = 255;
+		force_redraw = 255;
 	}
 }
 

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -101,7 +101,7 @@ extern BOOL gbLoadGame;
 extern HINSTANCE ghInst;
 extern int DebugMonsters[10];
 extern BOOLEAN cineflag;
-extern int drawpanflag;
+extern int force_redraw;
 extern BOOL visiondebug;
 extern BOOL scrollflag; /* unused */
 extern BOOL light4flag;

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -346,7 +346,7 @@ void dx_reinit()
 
 	dx_cleanup();
 
-	drawpanflag = 255;
+	force_redraw = 255;
 
 	dx_init(ghMainWnd);
 

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -3808,8 +3808,8 @@ void PlayInGameMovie(char *pszMovie)
 	PaletteFadeOut(8);
 	play_movie(pszMovie, 0);
 	ClearScreenBuffer();
-	drawpanflag = 255;
+	force_redraw = 255;
 	scrollrt_draw_game_screen(1);
 	PaletteFadeIn(8);
-	drawpanflag = 255;
+	force_redraw = 255;
 }

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -98,7 +98,7 @@ void gamemenu_new_game(BOOL bActivate)
 	}
 
 	deathflag = FALSE;
-	drawpanflag = 255;
+	force_redraw = 255;
 	scrollrt_draw_game_screen(TRUE);
 	gbRunGame = FALSE;
 	gamemenu_off();
@@ -116,13 +116,13 @@ void gamemenu_load_game(BOOL bActivate)
 	gamemenu_off();
 	SetCursor_(CURSOR_NONE);
 	InitDiabloMsg(EMSG_LOADING);
-	drawpanflag = 255;
+	force_redraw = 255;
 	DrawAndBlit();
 	LoadGame(FALSE);
 	ClrDiabloMsg();
 	PaletteFadeOut(8);
 	deathflag = FALSE;
-	drawpanflag = 255;
+	force_redraw = 255;
 	DrawAndBlit();
 	PaletteFadeIn(8);
 	SetCursor_(CURSOR_HAND);
@@ -145,11 +145,11 @@ void gamemenu_save_game(BOOL bActivate)
 	SetCursor_(CURSOR_NONE);
 	gamemenu_off();
 	InitDiabloMsg(EMSG_SAVING);
-	drawpanflag = 255;
+	force_redraw = 255;
 	DrawAndBlit();
 	SaveGame();
 	ClrDiabloMsg();
-	drawpanflag = 255;
+	force_redraw = 255;
 	SetCursor_(CURSOR_HAND);
 	interface_msg_pump();
 	SetWindowProc(saveProc);

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -405,7 +405,7 @@ LRESULT __stdcall MainWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 		PostQuitMessage(0);
 		break;
 	case WM_PAINT:
-		drawpanflag = 255;
+		force_redraw = 255;
 		break;
 	case WM_CLOSE:
 		return 0;
@@ -449,7 +449,7 @@ void init_activate_window(HWND hWnd, BOOL bActive)
 	SetWindowLong(hWnd, GWL_STYLE, dwNewLong);
 
 	if (gbActive) {
-		drawpanflag = 255;
+		force_redraw = 255;
 		ResetPal();
 	}
 }

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -46,7 +46,7 @@ void DrawCutscene()
 	}
 
 	unlock_buf(1);
-	drawpanflag = 255;
+	force_redraw = 255;
 	scrollrt_draw_game_screen(0);
 }
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -933,7 +933,7 @@ void CheckInvPaste(int pnum, int mx, int my)
 		if (plr[pnum].InvBody[INVLOC_HAND_LEFT]._itype == ITYPE_STAFF && plr[pnum].InvBody[INVLOC_HAND_LEFT]._iSpell != 0 && plr[pnum].InvBody[INVLOC_HAND_LEFT]._iCharges > 0) {
 			plr[pnum]._pRSpell = plr[pnum].InvBody[INVLOC_HAND_LEFT]._iSpell;
 			plr[pnum]._pRSplType = RSPLTYPE_CHARGES;
-			drawpanflag = 255;
+			force_redraw = 255;
 		}
 		break;
 	case ILOC_ARMOR:
@@ -1320,7 +1320,7 @@ void RemoveInvItem(int pnum, int iv)
 				plr[pnum]._pRSpell = SPL_INVALID;
 			}
 
-			drawpanflag = 255;
+			force_redraw = 255;
 		}
 	}
 }
@@ -1342,7 +1342,7 @@ void RemoveSpdBarItem(int pnum, int iv)
 			}
 		}
 	}
-	drawpanflag = 255;
+	force_redraw = 255;
 }
 
 void CheckInvItem()
@@ -2215,7 +2215,7 @@ int CalculateGold(int pnum)
 	for (i = 0; i < MAXBELTITEMS; i++) {
 		if (plr[pnum].SpdList[i]._itype == ITYPE_GOLD) {
 			gold += plr[pnum].SpdList[i]._ivalue;
-			drawpanflag = 255;
+			force_redraw = 255;
 		}
 	}
 	for (i = 0; i < plr[pnum]._pNumInv; i++) {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -451,7 +451,7 @@ void CalcPlrItemVals(int p, BOOL Loadgfx)
 	    && !(spl & ((unsigned __int64)1 << (plr[p]._pRSpell - 1)))) {
 		plr[p]._pRSpell = SPL_INVALID;
 		plr[p]._pRSplType = RSPLTYPE_INVALID;
-		drawpanflag = 255;
+		force_redraw = 255;
 	}
 
 	plr[p]._pISplLvlAdd = spllvladd;
@@ -625,7 +625,7 @@ void CalcPlrScrolls(int p)
 		if (!(plr[p]._pScrlSpells & 1 << (plr[p]._pRSpell - 1))) {
 			plr[p]._pRSpell = SPL_INVALID;
 			plr[p]._pRSplType = RSPLTYPE_INVALID;
-			drawpanflag = 255;
+			force_redraw = 255;
 		}
 	}
 }

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3455,7 +3455,7 @@ void OperateShrine(int pnum, int i, int sType)
 	}
 
 	CalcPlrInv(pnum, TRUE);
-	drawpanflag = 255;
+	force_redraw = 255;
 
 	if (pnum == myplr)
 		NetSendCmdParam2(FALSE, CMD_PLROPOBJ, pnum, i);
@@ -3577,7 +3577,7 @@ void OperateGoatShrine(int pnum, int i, int sType)
 	object[i]._oVar1 = FindValidShrine(i);
 	OperateShrine(pnum, i, sType);
 	object[i]._oAnimDelay = 2;
-	drawpanflag = 255;
+	force_redraw = 255;
 }
 
 void OperateCauldron(int pnum, int i, int sType)
@@ -3587,7 +3587,7 @@ void OperateCauldron(int pnum, int i, int sType)
 	OperateShrine(pnum, i, sType);
 	object[i]._oAnimFlag = 0;
 	object[i]._oAnimFrame = 3;
-	drawpanflag = 255;
+	force_redraw = 255;
 }
 
 BOOL OperateFountains(int pnum, int i)
@@ -3705,7 +3705,7 @@ BOOL OperateFountains(int pnum, int i)
 			NetSendCmdParam1(FALSE, CMD_OPERATEOBJ, i);
 		break;
 	}
-	drawpanflag = 255;
+	force_redraw = 255;
 	return applied;
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1874,7 +1874,7 @@ void DropHalfPlayersGold(int pnum)
 			}
 		}
 	}
-	drawpanflag = 255;
+	force_redraw = 255;
 	if (hGold > 0) {
 		for (i = 0; i < plr[pnum]._pNumInv && hGold > 0; i++) {
 			if (plr[pnum].InvList[i]._itype == ITYPE_GOLD && plr[pnum].InvList[i]._ivalue != GOLD_MAX_LIMIT) {
@@ -2840,7 +2840,7 @@ BOOL PM_DoSpell(int pnum)
 				        & (unsigned __int64)1 << (plr[pnum]._pRSpell - 1))) {
 					plr[pnum]._pRSpell = SPL_INVALID;
 					plr[pnum]._pRSplType = RSPLTYPE_INVALID;
-					drawpanflag = 255;
+					force_redraw = 255;
 				}
 			}
 
@@ -2849,7 +2849,7 @@ BOOL PM_DoSpell(int pnum)
 				        & (unsigned __int64)1 << (plr[pnum]._pRSpell - 1))) {
 					plr[pnum]._pRSpell = SPL_INVALID;
 					plr[pnum]._pRSplType = RSPLTYPE_INVALID;
-					drawpanflag = 255;
+					force_redraw = 255;
 				}
 			}
 		}

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -2801,8 +2801,8 @@ void scrollrt_draw_game_screen(BOOL draw_cursor)
 {
 	int hgt;
 
-	if (drawpanflag == 255) {
-		drawpanflag = 0;
+	if (force_redraw == 255) {
+		force_redraw = 0;
 		hgt = SCREEN_HEIGHT;
 	} else {
 		hgt = 0;
@@ -2835,7 +2835,7 @@ void DrawAndBlit()
 		return;
 	}
 
-	if (drawpanflag == 255) {
+	if (force_redraw == 255) {
 		drawhpflag = TRUE;
 		drawmanaflag = TRUE;
 		drawbtnflag = TRUE;
@@ -2843,7 +2843,7 @@ void DrawAndBlit()
 		ddsdesc = FALSE;
 		ctrlPan = TRUE;
 		hgt = SCREEN_HEIGHT;
-	} else if (drawpanflag == 1) {
+	} else if (force_redraw == 1) {
 		ddsdesc = TRUE;
 		ctrlPan = FALSE;
 		hgt = VIEWPORT_HEIGHT;
@@ -2851,7 +2851,7 @@ void DrawAndBlit()
 		return;
 	}
 
-	drawpanflag = 0;
+	force_redraw = 0;
 
 	lock_buf(0);
 	if (leveltype != DTYPE_TOWN) {

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1847,7 +1847,7 @@ void TakePlrsMoney(int cost)
 			}
 		}
 	}
-	drawpanflag = 255;
+	force_redraw = 255;
 	if (cost > 0) {
 		for (i = 0; i < plr[myplr]._pNumInv && cost > 0; i++) {
 			if (plr[myplr].InvList[i]._itype == ITYPE_GOLD && plr[myplr].InvList[i]._ivalue != GOLD_MAX_LIMIT) {

--- a/structs.h
+++ b/structs.h
@@ -102,7 +102,7 @@ typedef struct ItemStruct {
 	int _iAnimFrame;
 	int _iAnimWidth;
 	int _iAnimWidth2; // width 2?
-	int _isin;        // set when item is flagged for deletion, deprecated in 1.02
+	BOOL _iDelFlag; // set when item is flagged for deletion, deprecated in 1.02
 	char _iSelFlag;
 	BOOL _iPostDraw;
 	BOOL _iIdentified;


### PR DESCRIPTION
At one point in time `drawpanflag` was named correct but I changed it. It's now been changed back to the correct name from the PSX symbol `force_redraw`.

Also the unused field in `ItemStruct` was given away in an assertion in a newly discovered PSX build. It is called `_iDelFlag` consistent with other structs.