### PR TITLE
Fix function order [spells+pack.cpp]

### DIFF
--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -1,6 +1,36 @@
 #include "diablo.h"
 #include "../3rdParty/Storm/Source/storm.h"
 
+static void PackItem(PkItemStruct *id, ItemStruct *is)
+{
+	if (is->_itype == -1) {
+		id->idx = 0xFFFF;
+	} else {
+		id->idx = is->IDidx;
+		if (is->IDidx == IDI_EAR) {
+			id->iCreateInfo = is->_iName[8] | (is->_iName[7] << 8);
+			id->iSeed = is->_iName[12] | ((is->_iName[11] | ((is->_iName[10] | (is->_iName[9] << 8)) << 8)) << 8);
+			id->bId = is->_iName[13];
+			id->bDur = is->_iName[14];
+			id->bMDur = is->_iName[15];
+			id->bCh = is->_iName[16];
+			id->bMCh = is->_iName[17];
+			id->wValue = is->_ivalue | (is->_iName[18] << 8) | ((is->_iCurs - 19) << 6);
+			id->dwBuff = is->_iName[22] | ((is->_iName[21] | ((is->_iName[20] | (is->_iName[19] << 8)) << 8)) << 8);
+		} else {
+			id->iSeed = is->_iSeed;
+			id->iCreateInfo = is->_iCreateInfo;
+			id->bId = is->_iIdentified + 2 * is->_iMagical;
+			id->bDur = is->_iDurability;
+			id->bMDur = is->_iMaxDur;
+			id->bCh = is->_iCharges;
+			id->bMCh = is->_iMaxCharges;
+			if (!is->IDidx)
+				id->wValue = is->_ivalue;
+		}
+	}
+}
+
 void PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield)
 {
 	PlayerStruct *pPlayer;
@@ -76,33 +106,35 @@ void PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield)
 		pPack->pManaShield = FALSE;
 }
 
-void PackItem(PkItemStruct *id, ItemStruct *is)
+// Note: last slot of item[MAXITEMS+1] used as temporary buffer
+// find real name reference below, possibly [sizeof(item[])/sizeof(ItemStruct)]
+static void UnPackItem(PkItemStruct *is, ItemStruct *id)
 {
-	if (is->_itype == -1) {
-		id->idx = 0xFFFF;
+	if (is->idx == 0xFFFF) {
+		id->_itype = -1;
 	} else {
-		id->idx = is->IDidx;
-		if (is->IDidx == IDI_EAR) {
-			id->iCreateInfo = is->_iName[8] | (is->_iName[7] << 8);
-			id->iSeed = is->_iName[12] | ((is->_iName[11] | ((is->_iName[10] | (is->_iName[9] << 8)) << 8)) << 8);
-			id->bId = is->_iName[13];
-			id->bDur = is->_iName[14];
-			id->bMDur = is->_iName[15];
-			id->bCh = is->_iName[16];
-			id->bMCh = is->_iName[17];
-			id->wValue = is->_ivalue | (is->_iName[18] << 8) | ((is->_iCurs - 19) << 6);
-			id->dwBuff = is->_iName[22] | ((is->_iName[21] | ((is->_iName[20] | (is->_iName[19] << 8)) << 8)) << 8);
+		if (is->idx == IDI_EAR) {
+			RecreateEar(
+			    MAXITEMS,
+			    is->iCreateInfo,
+			    is->iSeed,
+			    is->bId,
+			    is->bDur,
+			    is->bMDur,
+			    is->bCh,
+			    is->bMCh,
+			    is->wValue,
+			    is->dwBuff);
 		} else {
-			id->iSeed = is->_iSeed;
-			id->iCreateInfo = is->_iCreateInfo;
-			id->bId = is->_iIdentified + 2 * is->_iMagical;
-			id->bDur = is->_iDurability;
-			id->bMDur = is->_iMaxDur;
-			id->bCh = is->_iCharges;
-			id->bMCh = is->_iMaxCharges;
-			if (!is->IDidx)
-				id->wValue = is->_ivalue;
+			RecreateItem(MAXITEMS, is->idx, is->iCreateInfo, is->iSeed, is->wValue);
+			item[MAXITEMS]._iMagical = is->bId >> 1;
+			item[MAXITEMS]._iIdentified = is->bId & 1;
+			item[MAXITEMS]._iDurability = is->bDur;
+			item[MAXITEMS]._iMaxDur = is->bMDur;
+			item[MAXITEMS]._iCharges = is->bCh;
+			item[MAXITEMS]._iMaxCharges = is->bMCh;
 		}
+		*id = item[MAXITEMS];
 	}
 }
 
@@ -215,36 +247,4 @@ void UnPackPlayer(PkPlayerStruct *pPack, int pnum, BOOL killok)
 	pPlayer->pDiabloKillLevel = pPack->pDiabloKillLevel;
 	pPlayer->pBattleNet = pPack->pBattleNet;
 	pPlayer->pManaShield = pPack->pManaShield;
-}
-
-// Note: last slot of item[MAXITEMS+1] used as temporary buffer
-// find real name reference below, possibly [sizeof(item[])/sizeof(ItemStruct)]
-void UnPackItem(PkItemStruct *is, ItemStruct *id)
-{
-	if (is->idx == 0xFFFF) {
-		id->_itype = -1;
-	} else {
-		if (is->idx == IDI_EAR) {
-			RecreateEar(
-			    MAXITEMS,
-			    is->iCreateInfo,
-			    is->iSeed,
-			    is->bId,
-			    is->bDur,
-			    is->bMDur,
-			    is->bCh,
-			    is->bMCh,
-			    is->wValue,
-			    is->dwBuff);
-		} else {
-			RecreateItem(MAXITEMS, is->idx, is->iCreateInfo, is->iSeed, is->wValue);
-			item[MAXITEMS]._iMagical = is->bId >> 1;
-			item[MAXITEMS]._iIdentified = is->bId & 1;
-			item[MAXITEMS]._iDurability = is->bDur;
-			item[MAXITEMS]._iMaxDur = is->bMDur;
-			item[MAXITEMS]._iCharges = is->bCh;
-			item[MAXITEMS]._iMaxCharges = is->bMCh;
-		}
-		*id = item[MAXITEMS];
-	}
 }

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -3,10 +3,8 @@
 #define __PACK_H__
 
 void PackPlayer(PkPlayerStruct *pPack, int pnum, BOOL manashield);
-void PackItem(PkItemStruct *id, ItemStruct *is);
 void VerifyGoldSeeds(PlayerStruct *pPlayer);
 void UnPackPlayer(PkPlayerStruct *pPack, int pnum, BOOL killok);
-void UnPackItem(PkItemStruct *is, ItemStruct *id);
 
 /* rdata */
 

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -143,6 +143,52 @@ void CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int caster, int 
 	}
 }
 
+static void PlacePlayer(int pnum)
+{
+	int nx, ny, max, min, x, y;
+	DWORD i;
+	BOOL done;
+
+	if (plr[pnum].plrlevel == currlevel) {
+		for (i = 0; i < 8; i++) {
+			nx = plr[pnum].WorldX + plrxoff2[i];
+			ny = plr[pnum].WorldY + plryoff2[i];
+
+			if (PosOkPlayer(pnum, nx, ny)) {
+				break;
+			}
+		}
+
+		if (!PosOkPlayer(pnum, nx, ny)) {
+			done = FALSE;
+
+			for (max = 1, min = -1; min > -50 && !done; max++, min--) {
+				for (y = min; y <= max && !done; y++) {
+					ny = plr[pnum].WorldY + y;
+
+					for (x = min; x <= max && !done; x++) {
+						nx = plr[pnum].WorldX + x;
+
+						if (PosOkPlayer(pnum, nx, ny)) {
+							done = TRUE;
+						}
+					}
+				}
+			}
+		}
+
+		plr[pnum].WorldX = nx;
+		plr[pnum].WorldY = ny;
+
+		dPlayer[nx][ny] = pnum + 1;
+
+		if (pnum == myplr) {
+			ViewX = nx;
+			ViewY = ny;
+		}
+	}
+}
+
 /**
  * @param pnum player index
  * @param rid target player index
@@ -188,52 +234,6 @@ void DoResurrect(int pnum, int rid)
 			StartStand(rid, plr[rid]._pdir);
 		} else {
 			plr[rid]._pmode = PM_STAND;
-		}
-	}
-}
-
-void PlacePlayer(int pnum)
-{
-	int nx, ny, max, min, x, y;
-	DWORD i;
-	BOOL done;
-
-	if (plr[pnum].plrlevel == currlevel) {
-		for (i = 0; i < 8; i++) {
-			nx = plr[pnum].WorldX + plrxoff2[i];
-			ny = plr[pnum].WorldY + plryoff2[i];
-
-			if (PosOkPlayer(pnum, nx, ny)) {
-				break;
-			}
-		}
-
-		if (!PosOkPlayer(pnum, nx, ny)) {
-			done = FALSE;
-
-			for (max = 1, min = -1; min > -50 && !done; max++, min--) {
-				for (y = min; y <= max && !done; y++) {
-					ny = plr[pnum].WorldY + y;
-
-					for (x = min; x <= max && !done; x++) {
-						nx = plr[pnum].WorldX + x;
-
-						if (PosOkPlayer(pnum, nx, ny)) {
-							done = TRUE;
-						}
-					}
-				}
-			}
-		}
-
-		plr[pnum].WorldX = nx;
-		plr[pnum].WorldY = ny;
-
-		dPlayer[nx][ny] = pnum + 1;
-
-		if (pnum == myplr) {
-			ViewX = nx;
-			ViewY = ny;
 		}
 	}
 }

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -7,7 +7,6 @@ void UseMana(int id, int sn);
 BOOL CheckSpell(int id, int sn, char st, BOOL manaonly);
 void CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int caster, int spllvl);
 void DoResurrect(int pnum, int rid);
-void PlacePlayer(int pnum);
 void DoHealOther(int pnum, int rid);
 
 #endif /* __SPELLS_H__ */


### PR DESCRIPTION
As per usual:
```
PSX                      MAC              1.09
STAT PackItem            PackItem         PackPlayer          
EXT  PackPlayer          PackPlayer       PackItem            
STAT UnPackItem          UnPackItem       VerifyGoldSeeds     
EXT  VerifyGoldSeeds     VerifyGoldSeeds  UnPackPlayer        
EXT  UnPackPlayer        UnPackPlayer     UnPackItem          
```
```
PSX                    MAC                   1.09
EXT GetManaAmount      GetManaAmount         GetManaAmount  
EXT UseMana            UseMana               UseMana            
EXT CheckSpell         CheckSpell            CheckSpell     
EXT CastSpell          CastSpell             CastSpell      
                       PlacePlayer           DoResurrect        
EXT DoResurrect        DoResurrect           PlacePlayer        
EXT DoHealOther        DoHealOther           DoHealOther        
```