### PR TITLE
Nice huge commit

### DIFF
--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -1410,7 +1410,7 @@ void SetTownMicros()
 				lv--;
 				pPiece = (WORD *)&pLevelPieces[32 * lv];
 				for (i = 0; i < 16; i++) {
-					pMap->mt[i] = pPiece[(i & 1) + 14 - (i & 0xE)];
+					pMap->mt[i] = pPiece[(i & 1) + 16 - 2 - (i & 0xE)];
 				}
 			} else {
 				for (i = 0; i < 16; i++) {


### PR DESCRIPTION
In the dungeon version of this function, you can see that `2` is being subtracted from the total micro length. Town uses all 16 micros, thus the `14` comes from `16 - 2`:
```c
for (i = 0; i < blocks; i++)
	pMap->mt[i] = pPiece[(i & 1) + blocks - 2 - (i & 0xE)];
```