### PR TITLE
Fix function order [palette.cpp]

### DIFF
--- a/Source/palette.h
+++ b/Source/palette.h
@@ -9,18 +9,13 @@ extern int gdwPalEntries;
 
 void SaveGamma();
 void palette_init();
-void LoadGamma();
-void LoadSysPal();
 void LoadPalette(char *pszFileName);
 void LoadRndLvlPal(int l);
 void ResetPal();
 void IncreaseGamma();
-void palette_update();
-void ApplyGamma(PALETTEENTRY *dst, PALETTEENTRY *src, int n);
 void DecreaseGamma();
 int UpdateGamma(int gamma);
 void BlackPalette();
-void SetFadeLevel(DWORD fadeval);
 void PaletteFadeIn(int fr);
 void PaletteFadeOut(int fr);
 void palette_update_caves();


### PR DESCRIPTION
```
PSX                    MAC                        1.09                       EXTERN
EXT LoadPalette        palette_update             SaveGamma                  Y   
EXT LoadRndLvlPal      ApplyGamma                 palette_init               Y   
EXT ResetPal           SaveGamma                  LoadGamma                      
STAT SetFadeLevel      LoadGamma                  LoadSysPal                     
EXT GetFadeState       [LoadSysPal]               LoadPalette                Y   
EXT DrawFadedScreen    palette_init               LoadRndLvlPal              Y   
EXT BlackPalette       LoadPalette                ResetPal                   Y   
EXT PaletteFadeInTask  LoadRndLvlPal              IncreaseGamma              Y   
EXT PaletteFadeIn      ResetPal                   palette_update                 
EXT PaletteFadeOutTask IncreaseGamma              ApplyGamma                     
EXT PaletteFadeOut     DecreaseGamma              DecreaseGamma              Y   
                       UpdateGamma                UpdateGamma                Y
                       SetFadeLevel               BlackPalette               Y
                       BlackPalette               SetFadeLevel               
                       PaletteFadeIn              PaletteFadeIn              Y
                       PaletteFadeOut             PaletteFadeOut             Y
                       palette_update_caves       palette_update_caves       Y
                       Lava2Water                 Lava2Water                 Y
                       palette_get_colour_cycling palette_get_colour_cycling Y
                       palette_set_color_cycling  palette_set_color_cycling  Y
```