### PR TITLE
[hellfire] fix drlg_l4 functions

### DIFF
--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -384,15 +384,16 @@ void DRLG_L4SetSPRoom(int rx1, int ry1)
 
 static void L4makeDmt()
 {
-	int i, j, val, dmtx, dmty;
+	int i, j, idx, val, dmtx, dmty;
 
 	for (j = 0, dmty = 1; dmty <= 77; j++, dmty += 2) {
 		for (i = 0, dmtx = 1; dmtx <= 77; i++, dmtx += 2) {
-			val = L4dungeon[dmtx + 1][dmty + 1];
-			val = 2 * val + L4dungeon[dmtx][dmty + 1];
-			val = 2 * val + L4dungeon[dmtx + 1][dmty];
-			val = 2 * val + L4dungeon[dmtx][dmty];
-			dungeon[i][j] = L4ConvTbl[val];
+			val = 8 * L4dungeon[dmtx + 1][dmty + 1]
+			+ 4 * L4dungeon[dmtx][dmty + 1]
+			+ 2 * L4dungeon[dmtx + 1][dmty]
+			+ L4dungeon[dmtx][dmty];
+			idx = L4ConvTbl[val];
+			dungeon[i][j] = idx;
 		}
 	}
 }
@@ -1049,8 +1050,10 @@ static void DRLG_L4Subs()
 
 	for (y = 0; y < DMAXY; y++) {
 		for (x = 0; x < DMAXX; x++) {
-			if (random(0, 3) == 0) {
-				c = L4BTYPES[dungeon[x][y]];
+			rv = random(0, 3);
+			if (rv == 0) {
+				c = dungeon[x][y];
+				c = L4BTYPES[c];
 				if (c != 0 && dflags[x][y] == 0) {
 					rv = random(0, 16);
 					i = -1;
@@ -1070,8 +1073,10 @@ static void DRLG_L4Subs()
 	}
 	for (y = 0; y < DMAXY; y++) {
 		for (x = 0; x < DMAXX; x++) {
-			if (random(0, 10) == 0) {
-				if (L4BTYPES[dungeon[x][y]] == 6 && dflags[x][y] == 0) {
+			rv = random(0, 10);
+			if (rv == 0) {
+				c = dungeon[x][y];
+				if (L4BTYPES[c] == 6 && dflags[x][y] == 0) {
 					dungeon[x][y] = random(0, 3) + 95;
 				}
 			}
@@ -1314,7 +1319,7 @@ static void L4roomGen(int x, int y, int w, int h, int dir)
 
 static void L4firstRoom()
 {
-	int x, y, w, h, rndx, rndy, xmin, xmax, ymin, ymax;
+	int x, y, w, h, rndx, rndy, xmin, xmax, ymin, ymax, tx, ty;
 
 	if (currlevel != 16) {
 		if (currlevel == quests[QTYPE_WARLRD]._qlevel && quests[QTYPE_WARLRD]._qactive) {
@@ -1337,7 +1342,8 @@ static void L4firstRoom()
 	xmax = 19 - w;
 	rndx = random(0, xmax - xmin + 1) + xmin;
 	if (rndx + w > 19) {
-		x = 19 - w + 1;
+		tx = w + rndx - 19;
+		x = rndx - tx + 1;
 	} else {
 		x = rndx;
 	}
@@ -1345,7 +1351,8 @@ static void L4firstRoom()
 	ymax = 19 - h;
 	rndy = random(0, ymax - ymin + 1) + ymin;
 	if (rndy + h > 19) {
-		y = 19 - h + 1;
+		ty = h + rndy - 19;
+		y = rndy - ty + 1;
 	} else {
 		y = rndy;
 	}
@@ -1374,17 +1381,16 @@ void L4SaveQuads()
 {
 	int i, j, x, y;
 
-	y = 0;
+	x = l4holdx;
+	y = l4holdy;
+
 	for (j = 0; j < 14; j++) {
-		x = 0;
 		for (i = 0; i < 14; i++) {
-			dflags[i + l4holdx][j + l4holdy] = 1;
-			dflags[DMAXX - 1 - x - l4holdx][j + l4holdy] = 1;
-			dflags[i + l4holdx][DMAXY - 1 - y - l4holdy] = 1;
-			dflags[DMAXX - 1 - x - l4holdx][DMAXY - 1 - y - l4holdy] = 1;
-			x++;
+			dflags[i + x][j + y] = 1;
+			dflags[DMAXX - 1 - i - x][j + y] = 1;
+			dflags[i + x][DMAXY - 1 - j - y] = 1;
+			dflags[DMAXX - 1 - i - x][DMAXY - 1 - j - y] = 1;
 		}
-		y++;
 	}
 }
 


### PR DESCRIPTION
The remaining functions in this file are bin exact in hellfire, should also be applied to vanilla.

`L4SaveQuads` and `L4firstRoom` were very tricky functions. The former makes sense yet is so simple, but such a thing gets optimized in a weird way. The latter would be close to impossible to get if it weren't for an unoptimized patch.