### PR TITLE
Fix function order [capture.cpp]

### DIFF
--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -1,5 +1,142 @@
 #include "diablo.h"
 
+static BOOL CaptureHdr(HANDLE hFile, short width, short height)
+{
+	DWORD lpNumBytes;
+	PCXHEADER Buffer;
+
+	memset(&Buffer, 0, sizeof(Buffer));
+	Buffer.Manufacturer = 10;
+	Buffer.Version = 5;
+	Buffer.Encoding = 1;
+	Buffer.BitsPerPixel = 8;
+	Buffer.Xmax = width - 1;
+	Buffer.Ymax = height - 1;
+	Buffer.HDpi = width;
+	Buffer.VDpi = height;
+	Buffer.NPlanes = 1;
+	Buffer.BytesPerLine = width;
+
+	return WriteFile(hFile, &Buffer, sizeof(Buffer), &lpNumBytes, NULL) && lpNumBytes == sizeof(Buffer);
+}
+
+static BOOL CapturePal(HANDLE hFile, PALETTEENTRY *palette)
+{
+	DWORD NumberOfBytesWritten;
+	BYTE pcx_palette[769];
+	int i;
+
+	pcx_palette[0] = 12;
+	for (i = 0; i < 256; i++) {
+		pcx_palette[1 + 3 * i + 0] = palette[i].peRed;
+		pcx_palette[1 + 3 * i + 1] = palette[i].peGreen;
+		pcx_palette[1 + 3 * i + 2] = palette[i].peBlue;
+	}
+
+	return WriteFile(hFile, pcx_palette, 769, &NumberOfBytesWritten, 0) && NumberOfBytesWritten == 769;
+}
+
+static BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
+{
+	int rleLength;
+
+	do {
+		BYTE rlePixel = *src;
+		*src++;
+		rleLength = 1;
+
+		width--;
+
+		while (rlePixel == *src) {
+			if (rleLength >= 63)
+				break;
+			if (!width)
+				break;
+			rleLength++;
+
+			width--;
+			src++;
+		}
+
+		if (rleLength > 1 || rlePixel > 0xBF) {
+			*dst = rleLength | 0xC0;
+			*dst++;
+		}
+
+		*dst = rlePixel;
+		*dst++;
+	} while (width);
+
+	return dst;
+}
+
+static BOOL CapturePix(HANDLE hFile, WORD width, WORD height, WORD stride, BYTE *pixels)
+{
+	int writeSize;
+	DWORD lpNumBytes;
+	BYTE *pBuffer, *pBufferEnd;
+
+	pBuffer = (BYTE *)DiabloAllocPtr(2 * width);
+	while (height != 0) {
+		height--;
+		pBufferEnd = CaptureEnc(pixels, pBuffer, width);
+		pixels += stride;
+		writeSize = pBufferEnd - pBuffer;
+		if (!(WriteFile(hFile, pBuffer, writeSize, &lpNumBytes, 0) && lpNumBytes == writeSize)) {
+			return FALSE;
+		}
+	}
+	mem_free_dbg(pBuffer);
+	return TRUE;
+}
+
+static HANDLE CaptureFile(char *dst_path)
+{
+	BOOLEAN num_used[100];
+	int free_num, hFind;
+	struct _finddata_t finder;
+
+	memset(num_used, FALSE, sizeof(num_used));
+	hFind = _findfirst("screen??.PCX", &finder);
+	if (hFind != -1) {
+		do {
+			if (isdigit(finder.name[6]) && isdigit(finder.name[7])) {
+				free_num = 10 * (finder.name[6] - '0');
+				free_num += (finder.name[7] - '0');
+				num_used[free_num] = TRUE;
+			}
+		} while (_findnext(hFind, &finder) == 0);
+	}
+
+	for (free_num = 0; free_num < 100; free_num++) {
+		if (!num_used[free_num]) {
+			sprintf(dst_path, "screen%02d.PCX", free_num);
+			return CreateFile(dst_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+		}
+	}
+
+	return INVALID_HANDLE_VALUE;
+}
+
+static void RedPalette(PALETTEENTRY *pal)
+{
+	PALETTEENTRY red[256];
+	int i;
+
+	for (i = 0; i < 256; i++) {
+		red[i].peRed = pal[i].peRed;
+		red[i].peGreen = 0;
+		red[i].peBlue = 0;
+		red[i].peFlags = 0;
+	}
+
+#ifdef __cplusplus
+	lpDDPalette->SetEntries(0, 0, 256, red);
+#else
+	lpDDPalette->lpVtbl->SetEntries(lpDDPalette, 0, 0, 256, red);
+#endif
+}
+
 void CaptureScreen()
 {
 	HANDLE hObject;
@@ -38,141 +175,4 @@ void CaptureScreen()
 		lpDDPalette->lpVtbl->SetEntries(lpDDPalette, 0, 0, 256, palette);
 #endif
 	}
-}
-
-BOOL CaptureHdr(HANDLE hFile, short width, short height)
-{
-	DWORD lpNumBytes;
-	PCXHEADER Buffer;
-
-	memset(&Buffer, 0, sizeof(Buffer));
-	Buffer.Manufacturer = 10;
-	Buffer.Version = 5;
-	Buffer.Encoding = 1;
-	Buffer.BitsPerPixel = 8;
-	Buffer.Xmax = width - 1;
-	Buffer.Ymax = height - 1;
-	Buffer.HDpi = width;
-	Buffer.VDpi = height;
-	Buffer.NPlanes = 1;
-	Buffer.BytesPerLine = width;
-
-	return WriteFile(hFile, &Buffer, sizeof(Buffer), &lpNumBytes, NULL) && lpNumBytes == sizeof(Buffer);
-}
-
-BOOL CapturePal(HANDLE hFile, PALETTEENTRY *palette)
-{
-	DWORD NumberOfBytesWritten;
-	BYTE pcx_palette[769];
-	int i;
-
-	pcx_palette[0] = 12;
-	for (i = 0; i < 256; i++) {
-		pcx_palette[1 + 3 * i + 0] = palette[i].peRed;
-		pcx_palette[1 + 3 * i + 1] = palette[i].peGreen;
-		pcx_palette[1 + 3 * i + 2] = palette[i].peBlue;
-	}
-
-	return WriteFile(hFile, pcx_palette, 769, &NumberOfBytesWritten, 0) && NumberOfBytesWritten == 769;
-}
-
-BOOL CapturePix(HANDLE hFile, WORD width, WORD height, WORD stride, BYTE *pixels)
-{
-	int writeSize;
-	DWORD lpNumBytes;
-	BYTE *pBuffer, *pBufferEnd;
-
-	pBuffer = (BYTE *)DiabloAllocPtr(2 * width);
-	while (height != 0) {
-		height--;
-		pBufferEnd = CaptureEnc(pixels, pBuffer, width);
-		pixels += stride;
-		writeSize = pBufferEnd - pBuffer;
-		if (!(WriteFile(hFile, pBuffer, writeSize, &lpNumBytes, 0) && lpNumBytes == writeSize)) {
-			return FALSE;
-		}
-	}
-	mem_free_dbg(pBuffer);
-	return TRUE;
-}
-
-BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width)
-{
-	int rleLength;
-
-	do {
-		BYTE rlePixel = *src;
-		*src++;
-		rleLength = 1;
-
-		width--;
-
-		while (rlePixel == *src) {
-			if (rleLength >= 63)
-				break;
-			if (!width)
-				break;
-			rleLength++;
-
-			width--;
-			src++;
-		}
-
-		if (rleLength > 1 || rlePixel > 0xBF) {
-			*dst = rleLength | 0xC0;
-			*dst++;
-		}
-
-		*dst = rlePixel;
-		*dst++;
-	} while (width);
-
-	return dst;
-}
-
-HANDLE CaptureFile(char *dst_path)
-{
-	BOOLEAN num_used[100];
-	int free_num, hFind;
-	struct _finddata_t finder;
-
-	memset(num_used, FALSE, sizeof(num_used));
-	hFind = _findfirst("screen??.PCX", &finder);
-	if (hFind != -1) {
-		do {
-			if (isdigit(finder.name[6]) && isdigit(finder.name[7])) {
-				free_num = 10 * (finder.name[6] - '0');
-				free_num += (finder.name[7] - '0');
-				num_used[free_num] = TRUE;
-			}
-		} while (_findnext(hFind, &finder) == 0);
-	}
-
-	for (free_num = 0; free_num < 100; free_num++) {
-		if (!num_used[free_num]) {
-			sprintf(dst_path, "screen%02d.PCX", free_num);
-			return CreateFile(dst_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-		}
-	}
-
-	return INVALID_HANDLE_VALUE;
-}
-
-void RedPalette(PALETTEENTRY *pal)
-{
-	PALETTEENTRY red[256];
-	int i;
-
-	for (i = 0; i < 256; i++) {
-		red[i].peRed = pal[i].peRed;
-		red[i].peGreen = 0;
-		red[i].peBlue = 0;
-		red[i].peFlags = 0;
-	}
-
-#ifdef __cplusplus
-	lpDDPalette->SetEntries(0, 0, 256, red);
-#else
-	lpDDPalette->lpVtbl->SetEntries(lpDDPalette, 0, 0, 256, red);
-#endif
 }

--- a/Source/capture.h
+++ b/Source/capture.h
@@ -3,11 +3,5 @@
 #define __CAPTURE_H__
 
 void CaptureScreen();
-BOOL CaptureHdr(HANDLE hFile, short width, short height);
-BOOL CapturePal(HANDLE hFile, PALETTEENTRY *palette);
-BOOL CapturePix(HANDLE hFile, WORD width, WORD height, WORD stride, BYTE *pixels);
-BYTE *CaptureEnc(BYTE *src, BYTE *dst, int width);
-HANDLE CaptureFile(char *dst_path);
-void RedPalette(PALETTEENTRY *pal);
 
 #endif /* __CAPTURE_H__ */


### PR DESCRIPTION
This file doesn't exist in the PSX or MAC, but we do have two assertions showing that `CaptureScreen` came after `CapturePix`, and given the new order the right number of lines fits between them.
```
Fixed           1.09             Assertion lines
CaptureHdr      CaptureScreen    250
CapturePal      CaptureHdr       
CaptureEnc      CapturePal       
CapturePix      CapturePix       169-179
CaptureFile     CaptureEnc       
RedPalette      CaptureFile      
CaptureScreen   RedPalette       
```