### PR TITLE
Fix missing assert for FindGetItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ That's a tricky question. Under the DMCA, reverse-engineering has exceptions for
 - [BWAPI Team](https://github.com/bwapi) - providing library API to work with Storm
 - [Ladislav Zezula](https://github.com/ladislav-zezula) - reversing PKWARE library, further documenting Storm
 - [fearedbliss](https://github.com/fearedbliss) - being awe-inspiring
+- Diablodin - providing additional info about the PSX release
 - Climax Studios & Sony - secretly helping with their undercover QA :P
 - Blizzard North - wait, this was a typo!
 - Depression - reason to waste four months of my life doing this ;)

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1686,13 +1686,15 @@ void SyncGetItem(int x, int y, int idx, WORD ci, int iseed)
 			if (itemactive[i] == ii) {
 				DeleteItem(itemactive[i], i);
 				FindGetItem(idx, ci, iseed);
-				FindGetItem(idx, ci, iseed); /* check idx */
+				/// ASSERT: assert(FindGetItem(idx,ci,iseed) == -1);
+				FindGetItem(idx, ci, iseed); /* todo: replace with above */
 				i = 0;
 			} else {
 				i++;
 			}
 		}
-		FindGetItem(idx, ci, iseed);
+		/// ASSERT: assert(FindGetItem(idx, ci, iseed) == -1);
+		FindGetItem(idx, ci, iseed); /* todo: replace with above */
 	}
 }
 


### PR DESCRIPTION
I always had a suspicion about the useless calls in SyncGetItem being something debug related, but wasn't too sure. After some digging in a special PSX release, the last two calls were found to be assertions. Curiously the MAC build is also missing these calls, implying they fixed the assert macro there.

Oh, and the guy who made this possible by giving these psx builds is now credited.