### PR TITLE
Fix scrollrt draw cursor back

### DIFF
--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -81,9 +81,14 @@ static void scrollrt_draw_cursor_back_buffer()
 	/// ASSERT: assert(gpBuffer);
 	src = sgSaveBack;
 	dst = &gpBuffer[SCREENXY(sgdwCursX, sgdwCursY)];
+	i = sgdwCursHgt;
 
-	for (i = sgdwCursHgt; i != 0; i--, src += sgdwCursWdt, dst += BUFFER_WIDTH) {
-		memcpy(dst, src, sgdwCursWdt);
+	if (sgdwCursHgt != 0) {
+		while (i--) {
+			memcpy(dst, src, sgdwCursWdt);
+			src += sgdwCursWdt;
+			dst += BUFFER_WIDTH;
+		}
 	}
 
 	sgdwCursXOld = sgdwCursX;


### PR DESCRIPTION
I think it's fair to say almost any cases where the iterator is being subtracted, a while loop was used rather than a for loop. Afterall, we are blizzard, must keep 1337 code style you newbs.