### PR TITLE
Missing blood boil+FreeMissGFX

### DIFF
--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -46,7 +46,7 @@ MissileData missiledata[] = {
 	{  MIS_IDENTIFY,      &AddIdentify,      &MI_Dummy,         FALSE,     1, 0,              MFILE_NONE,     -1,          -1          },
 	{  MIS_WAVE,          &AddWave,          &MI_Wave,          TRUE,      1, MISR_FIRE,      MFILE_FIREWAL,  LS_FLAMWAVE, -1          },
 	{  MIS_NOVA,          &AddNova,          &MI_Nova,          TRUE,      1, MISR_LIGHTNING, MFILE_LGHNING,  LS_NOVA,     -1          },
-	{  MIS_BLODBOIL,      &miss_null_1F,     &MI_Blodboil,      TRUE,      1, 0,              MFILE_NONE,     -1,          LS_BLODBOIL },
+	{  MIS_BLODBOIL,      &AddBlodboil,      &MI_Blodboil,      TRUE,      1, 0,              MFILE_NONE,     -1,          LS_BLODBOIL },
 	{  MIS_APOCA,         &AddApoca,         &MI_Apoca,         TRUE,      1, MISR_MAGIC,     MFILE_NEWEXP,   LS_APOC,     -1          },
 	{  MIS_REPAIR,        &AddRepair,        &MI_Dummy,         FALSE,     2, 0,              MFILE_NONE,     -1,          -1          },
 	{  MIS_RECHARGE,      &AddRecharge,      &MI_Dummy,         FALSE,     2, 0,              MFILE_NONE,     -1,          -1          },

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1123,12 +1123,13 @@ void InitMissileGFX()
 void FreeMissileGFX(int mi)
 {
 	int i;
-	DWORD *pFrameTable;
+	DWORD *p;
 
 	if (misfiledata[mi].mFlags & MFLAG_ALLOW_SPECIAL) {
 		if (misfiledata[mi].mAnimData[0]) {
-			pFrameTable = (DWORD *)misfiledata[mi].mAnimData[0];
-			mem_free_dbg(&pFrameTable[-misfiledata[mi].mAnimFAmt]); // TODO find a cleaner way to access the offeset
+			p = (DWORD *)misfiledata[mi].mAnimData[0];
+			p -= misfiledata[mi].mAnimFAmt;
+			MemFreeDbg(p);
 			misfiledata[mi].mAnimData[0] = NULL;
 		}
 		return;
@@ -1136,9 +1137,7 @@ void FreeMissileGFX(int mi)
 
 	for (i = 0; i < misfiledata[mi].mAnimFAmt; i++) {
 		if (misfiledata[mi].mAnimData[i]) {
-			pFrameTable = (DWORD *)misfiledata[mi].mAnimData[i];
-			misfiledata[mi].mAnimData[i] = NULL;
-			mem_free_dbg(pFrameTable);
+			MemFreeDbg(misfiledata[mi].mAnimData[i]);
 		}
 	}
 }
@@ -2173,6 +2172,11 @@ void AddNova(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, in
 		missile[mi]._midam = ((DWORD)currlevel >> 1) + random_(66, 3) + random_(66, 3) + random_(66, 3);
 	}
 	missile[mi]._mirange = 1;
+}
+
+void AddBlodboil(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam)
+{
+	missile[mi]._miDelFlag = 1;
 }
 
 void AddRepair(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam)
@@ -3459,17 +3463,18 @@ void MI_Stone(int i)
 	}
 	if (monster[m]._mmode != MM_STONE) {
 		missile[i]._miDelFlag = TRUE;
-	} else {
-		if (!missile[i]._mirange) {
-			missile[i]._miDelFlag = TRUE;
-			if (monster[m]._mhitpoints > 0)
-				monster[m]._mmode = missile[i]._miVar1;
-			else
-				AddDead(monster[m]._mx, monster[m]._my, stonendx, (direction)monster[m]._mdir);
-		}
-		if (missile[i]._miAnimType == MFILE_SHATTER1)
-			PutMissile(i);
+		return;
 	}
+
+	if (!missile[i]._mirange) {
+		missile[i]._miDelFlag = TRUE;
+		if (monster[m]._mhitpoints > 0)
+			monster[m]._mmode = missile[i]._miVar1;
+		else
+			AddDead(monster[m]._mx, monster[m]._my, stonendx, (direction)monster[m]._mdir);
+	}
+	if (missile[i]._miAnimType == MFILE_SHATTER1)
+		PutMissile(i);
 }
 
 void MI_Boom(int i)

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -81,6 +81,7 @@ void AddFirewallC(int mi, int sx, int sy, int dx, int dy, int midir, char mienem
 void AddInfra(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam);
 void AddWave(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam);
 void AddNova(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam);
+void AddBlodboil(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam);
 void AddRepair(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam);
 void AddRecharge(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam);
 void AddDisarm(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam);


### PR DESCRIPTION
Adds the missing blood boil function that gets merged with a duplicate, as you can see it exists in older patches and the mac version. Also cleaned up FreeMissileGFX so it properly uses macros that will produce file/line numbers, as seen in the debug release.