### PR TITLE
Fix hellfire hive/crypt

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -761,7 +761,7 @@ BOOL NetInit(BOOL bSinglePlayer, BOOL *pfExitProgram)
 	gnDifficulty = sgGameInitInfo.bDiff;
 	SetRndSeed(sgGameInitInfo.dwSeed);
 
-	for (i = 0; i < 17; i++) {
+	for (i = 0; i < NUMLEVELS; i++) {
 		glSeedTbl[i] = GetRndSeed();
 		gnLevelTypeTbl[i] = InitLevelType(i);
 	}


### PR DESCRIPTION
In Hellfire, you may now enter the Hive/Crypt. Sometimes it will throw an error on the loading screen, likely because object/missile code thats not finished.