### PR TITLE
codec: fix build error of codec.cpp when compiling as C

### DIFF
--- a/Source/codec.cpp
+++ b/Source/codec.cpp
@@ -5,12 +5,12 @@
  */
 #include "all.h"
 
-struct CodecSignature {
+typedef struct CodecSignature {
 	DWORD checksum;
 	BYTE error;
 	BYTE last_chunk_size;
 	WORD unused;
-};
+} CodecSignature;
 
 int codec_decode(BYTE *pbSrcDst, DWORD size, char *pszPassword)
 {


### PR DESCRIPTION
Prior to this commit, the following error was encountered when compiling
as C using Clang:

	Source/codec.cpp:20:2: error: must use 'struct' tag to refer to type 'CodecSignature'
			  CodecSignature *sig;
			  ^
			  struct