### PR TITLE
dthread: add parameter name to dthread_handler

### DIFF
--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -86,7 +86,7 @@ void dthread_start()
 	}
 }
 
-unsigned int __stdcall dthread_handler(void *)
+unsigned int __stdcall dthread_handler(void *data)
 {
 	char *error_buf;
 	TMegaPkt *pkt;

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -12,7 +12,7 @@ extern BOOLEAN dthread_running;
 void dthread_remove_player(int pnum);
 void dthread_send_delta(int pnum, char cmd, void *pbSrc, int dwLen);
 void dthread_start();
-unsigned int __stdcall dthread_handler(void *);
+unsigned int __stdcall dthread_handler(void *data);
 void dthread_cleanup();
 
 /* data */


### PR DESCRIPTION
This fixes a build error in dthread_handler when compiling as C.

	Source/dthread.cpp:92:46: error: parameter name omitted
	unsigned int __stdcall dthread_handler(void *)
																^