### PR TITLE
nthread: add parameter name to nthread_handler

### DIFF
--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -173,7 +173,7 @@ void nthread_start(BOOL set_turn_upper_bit)
 	}
 }
 
-unsigned int __stdcall nthread_handler(void *)
+unsigned int __stdcall nthread_handler(void *data)
 {
 	int delta;
 	BOOL received;

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -24,7 +24,7 @@ DWORD nthread_send_and_recv_turn(DWORD cur_turn, int turn_delta);
 BOOL nthread_recv_turns(BOOL *pfSendAsync);
 void nthread_set_turn_upper_bit();
 void nthread_start(BOOL set_turn_upper_bit);
-unsigned int __stdcall nthread_handler(void *);
+unsigned int __stdcall nthread_handler(void *data);
 void nthread_cleanup();
 void nthread_ignore_mutex(BOOL bStart);
 BOOL nthread_has_500ms_passed(BOOL unused);


### PR DESCRIPTION
Fixes the following error when compiling as C with Clang:

	Source/dthread.cpp:92:46: error: parameter name omitted
	unsigned int __stdcall dthread_handler(void *)
																^

Related to #2017.