### PR TITLE
Bugfix for CheckCursMove

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -189,7 +189,7 @@ void CheckCursMove()
 	sy = MouseY;
 
 	if (chrflag || questlog) {
-		if (sx >= SCREEN_WIDTH / 4) {
+		if (sx >= SCREEN_WIDTH / 4) { /// BUGFIX: (sx >= SCREEN_WIDTH / 4)
 			sx -= SCREEN_WIDTH / 4;
 		} else {
 			sx = 0;

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -189,7 +189,8 @@ void CheckCursMove()
 	sy = MouseY;
 
 	if (chrflag || questlog) {
-		if (sx >= SCREEN_WIDTH / 4) { /// BUGFIX: (sx >= SCREEN_WIDTH / 4)
+		if (sx >= SCREEN_WIDTH / 4) { /// BUGFIX: (sx >= SCREEN_WIDTH / 2)
+
 			sx -= SCREEN_WIDTH / 4;
 		} else {
 			sx = 0;


### PR DESCRIPTION
The check for the cursor position being outside the char/quest panel is incorrect.