### PR TITLE
[hellfire] workaround no more game/crypt crash

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1786,7 +1786,7 @@ void DrawInfoBox()
 		if (pcursitem != -1)
 			GetItemStr(pcursitem);
 		if (pcursobj != -1)
-			GetObjectStr(pcursobj);
+			;//GetObjectStr(pcursobj);
 		if (pcursmonst != -1) {
 			if (leveltype != DTYPE_TOWN) {
 				infoclr = COL_WHITE;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1100,10 +1100,14 @@ void RightMouseDown()
 		} else if (stextflag == STORE_NONE) {
 			if (spselflag) {
 				SetSpell();
+#ifdef HELLFIRE
+			} else if ((!sbookflag || MouseX <= 320) && (MouseY >= PANEL_TOP || (!TryIconCurs() && (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem))))) {
+#else
 			} else if (MouseY >= SPANEL_HEIGHT
 			    || (!sbookflag || MouseX <= RIGHT_PANEL)
 			        && !TryIconCurs()
 			        && (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem))) {
+#endif
 				if (pcurs == CURSOR_HAND) {
 					if (pcursinvitem == -1 || !UseInvItem(myplr, pcursinvitem))
 						CheckPlrSpell();

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -39,7 +39,7 @@ void LoadGame(BOOL firstflag)
 	_nummonsters = WLoad();
 	_numitems = WLoad();
 	_nummissiles = WLoad();
-	_nobjects = WLoad();
+	//_nobjects = WLoad();
 
 	for (i = 0; i < NUMLEVELS; i++) {
 		glSeedTbl[i] = ILoad();
@@ -67,7 +67,7 @@ void LoadGame(BOOL firstflag)
 	nummonsters = _nummonsters;
 	numitems = _numitems;
 	nummissiles = _nummissiles;
-	nobjects = _nobjects;
+	//nobjects = _nobjects;
 
 	for (i = 0; i < MAXMONSTERS; i++)
 		monstkills[i] = ILoad();
@@ -83,14 +83,14 @@ void LoadGame(BOOL firstflag)
 			missileavail[i] = BLoad();
 		for (i = 0; i < nummissiles; i++)
 			LoadMissile(missileactive[i]);
-		for (i = 0; i < MAXOBJECTS; i++)
+		/*for (i = 0; i < MAXOBJECTS; i++)
 			objectactive[i] = BLoad();
 		for (i = 0; i < MAXOBJECTS; i++)
 			objectavail[i] = BLoad();
 		for (i = 0; i < nobjects; i++)
 			LoadObject(objectactive[i]);
 		for (i = 0; i < nobjects; i++)
-			SyncObjectAnim(objectactive[i]);
+			SyncObjectAnim(objectactive[i]);*/
 
 		numlights = WLoad();
 
@@ -311,7 +311,7 @@ void SaveGame()
 	WSave(nummonsters);
 	WSave(numitems);
 	WSave(nummissiles);
-	WSave(nobjects);
+	//WSave(nobjects);
 
 	for (i = 0; i < NUMLEVELS; i++) {
 		ISave(glSeedTbl[i]);
@@ -341,12 +341,12 @@ void SaveGame()
 			BSave(missileavail[i]);
 		for (i = 0; i < nummissiles; i++)
 			SaveMissile(missileactive[i]);
-		for (i = 0; i < MAXOBJECTS; i++)
+		/*for (i = 0; i < MAXOBJECTS; i++)
 			BSave(objectactive[i]);
 		for (i = 0; i < MAXOBJECTS; i++)
 			BSave(objectavail[i]);
 		for (i = 0; i < nobjects; i++)
-			SaveObject(objectactive[i]);
+			SaveObject(objectactive[i]);*/
 
 		WSave(numlights);
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2252,14 +2252,33 @@ void AddLightball(int mi, int sx, int sy, int dx, int dy, int midir, char mienem
 void AddFirewall(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam)
 {
 	int i;
+#ifdef HELLFIRE
+	BYTE lvl;
 
-	missile[mi]._midam = 16 * (random_(53, 10) + random_(53, 10) + plr[id]._pLevel + 2) >> 1;
+	if (random(53, 10) + random(53, 10) + (id > 0) + 2 != 0)
+		lvl = plr[id]._pLevel;
+	else
+		lvl = currlevel;
+	missile[mi]._midam = lvl << 4;
+#else
+	/// ASSERT: assert((DWORD)mi < MAXMISSILES);
+	missile[mi]._midam = 16 * (random(53, 10) + random(53, 10) + plr[id]._pLevel + 2);
+#endif
+	missile[mi]._midam >>= 1;
 	GetMissileVel(mi, sx, sy, dx, dy, 16);
+#ifdef HELLFIRE
+	missile[mi]._mirange = 10 * (missile[mi]._mispllvl + 1);
+	if (mienemy || id < 0)
+		missile[mi]._mirange += currlevel;
+	else
+#else
 	missile[mi]._mirange = 10;
-	i = missile[mi]._mispllvl;
-	if (i > 0)
-		missile[mi]._mirange = 10 * (i + 1);
-	missile[mi]._mirange = ((missile[mi]._mirange * plr[id]._pISplDur >> 3) & 0xFFFFFFF0) + 16 * missile[mi]._mirange;
+	for (i = missile[mi]._mispllvl; i > 0; i--) {
+		missile[mi]._mirange += 10;
+	}
+#endif
+	missile[mi]._mirange += (missile[mi]._mirange * plr[id]._pISplDur) >> 7;
+	missile[mi]._mirange <<= 4;
 	missile[mi]._miVar1 = missile[mi]._mirange - missile[mi]._miAnimLen;
 	missile[mi]._miVar2 = 0;
 }

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2251,7 +2251,6 @@ void AddLightball(int mi, int sx, int sy, int dx, int dy, int midir, char mienem
 
 void AddFirewall(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy, int id, int dam)
 {
-	int i;
 #ifdef HELLFIRE
 	BYTE lvl;
 
@@ -2261,6 +2260,8 @@ void AddFirewall(int mi, int sx, int sy, int dx, int dy, int midir, char mienemy
 		lvl = currlevel;
 	missile[mi]._midam = lvl << 4;
 #else
+	int i;
+
 	/// ASSERT: assert((DWORD)mi < MAXMISSILES);
 	missile[mi]._midam = 16 * (random(53, 10) + random(53, 10) + plr[id]._pLevel + 2);
 #endif


### PR DESCRIPTION
Without this workaround the game is currently not playable.
The problem seems to be related to missing descriptions for objects like levers, spell books etc.
Especially in the crypt. Without this hack the game is crashing over and over again.
Now the game can be played, but Na-Krul is missing.