### PR TITLE
engine: add BUGFIX comment for Cl2BlitOutlineSafe

### DIFF
--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -3811,6 +3811,7 @@ void Cl2BlitOutlineSafe(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWi
 							dst[-1] = col;
 							dst[1] = col;
 							dst[-BUFFER_WIDTH] = col;
+							// BUGFIX: only set `if (dst+BUFFER_WIDTH < gpBufEnd)`
 							dst[BUFFER_WIDTH] = col;
 						}
 						dst++;


### PR DESCRIPTION
When hovering over a monster at the bottom part of the screen, the
outline may be off-by-one, thus overwriting the top pixel of the panel.