### PR TITLE
missiles: add BUGFIX for AddRndTeleport

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1322,6 +1322,7 @@ void AddRndTeleport(int mi, int sx, int sy, int dx, int dy, int midir, char mien
 			UseMana(id, SPL_RNDTELEPORT);
 	} else {
 		pn = dObject[dx][dy] - 1;
+		// BUGFIX: should only run magic circle check if dObject[dx][dy] is non-zero.
 		if (object[pn]._otype == OBJ_MCIRCLE1 || object[pn]._otype == OBJ_MCIRCLE2) {
 			missile[mi]._mix = dx;
 			missile[mi]._miy = dy;


### PR DESCRIPTION
If `dObject[dx][dy]` is zero, then `pn = -1`, which causes an
out-of-bounds access to `object`. If the memory at `object[-1]._otype`
is either 84 or 85, then the player is randomly teleported to the
location of the Vile Betrayer quest. This can be triggered either
by interacting with a holy shrine or by casting phasing.

	"Wherever you go, there you are"