### PR TITLE
missiles: add BUGFIX for MFILE_NONE enum

### DIFF
--- a/enums.h
+++ b/enums.h
@@ -1309,7 +1309,6 @@ typedef enum missile_graphic_id {
 	MFILE_SCUBMISD,
 	MFILE_SCBSEXPD,
 	MFILE_NULL,
-	MFILE_INVALID,
 	MFILE_NONE = 0xFF, // BUGFIX: should be `MFILE_NONE = MFILE_SCBSEXPD+1`, i.e. MFILE_NULL, since there would otherwise be an out-of-bounds in SetMissAnim when accessing misfiledata for any of the missiles that have MFILE_NONE as mFileNum in missiledata.
 } missile_graphic_id;
 

--- a/enums.h
+++ b/enums.h
@@ -1310,7 +1310,7 @@ typedef enum missile_graphic_id {
 	MFILE_SCBSEXPD,
 	MFILE_NULL,
 	MFILE_INVALID,
-	MFILE_NONE = 0xFF,
+	MFILE_NONE = 0xFF, // BUGFIX: should be `MFILE_NONE = MFILE_SCBSEXPD+1`, i.e. MFILE_NULL, since there would otherwise be an out-of-bounds in SetMissAnim when accessing misfiledata for any of the missiles that have MFILE_NONE as mFileNum in missiledata.
 } missile_graphic_id;
 
 typedef enum _mai_id {


### PR DESCRIPTION
The current definition of MFILE_NONE is set to 255 (or -1 when
interpreted as a signed 8-bit integer). The definitions of missiles
without graphic animations use MFILE_NONE for the mFileNum field in
missiledata. This is problematic as it results in an out-of-bounds
access in SetMissAnim when accessing misfiledata for such a missile.
One such example is the Recharge Staff skill which does not use a
missile graphic animation and thus has _miAnimType set to MFILE_NONE.

The code path leading to out-of-bounds access after casting Recharge
is as follows: AddMissile -> SetMissDir -> SetMissAnim, which in turn
accesses misfiledata[animtype], i.e. misfiledata[255].