### PR TITLE
Use 'MAXBELTITEMS' in belt traversal logic.

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1575,7 +1575,7 @@ void AutoGetItem(int pnum, int ii)
 			if (w == 1 && h == 1) {
 				idx = plr[pnum].HoldItem.IDidx;
 				if (plr[pnum].HoldItem._iStatFlag && AllItemsList[idx].iUsable) {
-					for (i = 0; i < 8 && !done; i++) {
+					for (i = 0; i < MAXBELTITEMS && !done; i++) {
 						if (plr[pnum].SpdList[i]._itype == ITYPE_NONE) {
 							plr[pnum].SpdList[i] = plr[pnum].HoldItem;
 							CalcPlrScrolls(pnum);


### PR DESCRIPTION
This replaces a hardcoded `8` in inventory (belt) processing logic with the `MAXBELTITEMS` macro.

Integrating in the `devilution` repo as requested:
- https://github.com/diasurgical/devilutionX/pull/849#discussion_r497861962