### PR TITLE
Unify player structures

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -692,11 +692,15 @@ void SetPlrAnims(int pnum)
 void ClearPlrRVars(PlayerStruct *p)
 {
 	// TODO: Missing debug assert p != NULL
+#ifdef HELLFIRE
+	p->pManaShield = 0;
+#endif
 	p->bReserved[0] = 0;
 	p->bReserved[1] = 0;
 	p->bReserved[2] = 0;
-#ifdef HELLFIRE
-	p->bReserved[3] = 0;
+
+#ifndef HELLFIRE
+	p->wReflection = 0;
 #endif
 	p->wReserved[0] = 0;
 	p->wReserved[1] = 0;
@@ -705,18 +709,16 @@ void ClearPlrRVars(PlayerStruct *p)
 	p->wReserved[4] = 0;
 	p->wReserved[5] = 0;
 	p->wReserved[6] = 0;
+
 #ifndef HELLFIRE
-	p->wReserved[7] = 0;
+	p->pDifficulty = 0;
+	p->pDamAcFlags = 0;
 #endif
 	p->dwReserved[0] = 0;
 	p->dwReserved[1] = 0;
 	p->dwReserved[2] = 0;
 	p->dwReserved[3] = 0;
 	p->dwReserved[4] = 0;
-#ifndef HELLFIRE
-	p->dwReserved[5] = 0;
-	p->dwReserved[6] = 0;
-#endif
 }
 
 /**

--- a/structs.h
+++ b/structs.h
@@ -343,21 +343,17 @@ typedef struct PlayerStruct {
 	unsigned char pLvlLoad;
 #ifdef HELLFIRE
 	unsigned char pDungMsgs2;
-	char bReserved[4];
+#else
+	unsigned char pBattleNet;
+#endif
+	BOOLEAN pManaShield;
+	char bReserved[3];
 	short wReflection;
 	short wReserved[7];
 	DWORD pDiabloKillLevel;
 	int pDifficulty;
 	int pDamAcFlags;
 	int dwReserved[5];
-#else
-	unsigned char pBattleNet;
-	BOOLEAN pManaShield;
-	char bReserved[3];
-	short wReserved[8];
-	DWORD pDiabloKillLevel;
-	int dwReserved[7];
-#endif
 	unsigned char *_pNData;
 	unsigned char *_pWData;
 	unsigned char *_pAData;
@@ -1495,21 +1491,17 @@ typedef struct PkPlayerStruct {
 	char pLvlLoad;
 #ifdef HELLFIRE
 	unsigned char pDungMsgs2;
-	char bReserved[4];
+#else
+	char pBattleNet;
+#endif
+	BOOLEAN pManaShield;
+	char bReserved[3];
 	short wReflection;
 	short wReserved[7];
 	DWORD pDiabloKillLevel;
 	int pDifficulty;
 	int pDamAcFlags;
 	int dwReserved[5];
-#else
-	char pBattleNet;
-	BOOLEAN pManaShield;
-	char bReserved[3];
-	short wReserved[8];
-	int pDiabloKillLevel;
-	int dwReserved[7];
-#endif
 } PkPlayerStruct;
 #pragma pack(pop)
 


### PR DESCRIPTION
Since they are being usered there reserved status can be said to have
changed. Clearly naming them makes it easier to understand what meaning
they have and this doesn't affect bin exact.