### PR TITLE
[hellfire] NetSendCmdGItem2 binexact

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1084,10 +1084,10 @@ BOOL NetSendCmdReq2(BYTE bCmd, BYTE mast, BYTE pnum, TCmdGItem *p)
 	int ticks;
 	TCmdGItem cmd;
 
-#ifndef HELLFIRE
-	memcpy(&cmd, p, sizeof(cmd));
-#else
+#ifdef HELLFIRE
 	cmd = *p;
+#else
+	memcpy(&cmd, p, sizeof(cmd));
 #endif
 	cmd.bCmd = bCmd;
 	cmd.bPnum = pnum;

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1084,7 +1084,11 @@ BOOL NetSendCmdReq2(BYTE bCmd, BYTE mast, BYTE pnum, TCmdGItem *p)
 	int ticks;
 	TCmdGItem cmd;
 
+#ifndef HELLFIRE
 	memcpy(&cmd, p, sizeof(cmd));
+#else
+	cmd = *p;
+#endif
 	cmd.bCmd = bCmd;
 	cmd.bPnum = pnum;
 	cmd.bMaster = mast;


### PR DESCRIPTION
so the product devs were weird.

What is by all accounts a memcyp is not. Apparently he changed this memcpy to a pointer .` cmd = *p;`

Anyway I know you have strict style guides. please check and let me know if this is ok. 

Thanks
 