### PR TITLE
Migrate Linux builds to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,67 @@
+version: 2
+jobs:
+  diablo_109b:
+    docker:
+      - image: diasurgical/riivaaja:stable
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run: make -f MakefileVC
+  diablo_109b_diff:
+    docker:
+      - image: diasurgical/riivaaja:stable
+    environment:
+      MAKE_BUILD: pdb
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run: make -f MakefileVC
+      - run: wget https://github.com/diasurgical/devilution-comparer/releases/download/v0.4.0/devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
+      - run: tar xf devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
+      - run: mv comparer-config/diablo.toml comparer-config.toml
+      - run: ./devilution-comparer generate-full Diablo.exe --no-mem-disp --truncate-to-original
+      - run: ../status.sh
+      - run: .travis/are-we-d1-yet.sh "$(< accuracy.txt)" $DISCORD_WEBHOOK "Diablo 1.09b"
+  spawn_109b_diff:
+    docker:
+      - image: diasurgical/riivaaja:stable
+    environment:
+      MAKE_BUILD: pdb
+      SPAWN: 1
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run: make -f MakefileVC
+      - run: wget https://github.com/diasurgical/devilution-comparer/releases/download/v0.4.0/devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
+      - run: tar xf devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
+      - run: mv comparer-config/spawn.toml comparer-config.toml
+      - run: ./devilution-comparer generate-full Diablo.exe --no-mem-disp --truncate-to-original
+      - run: ../spawn-status.sh
+      - run: .travis/are-we-d1-yet.sh "$(< accuracy.txt)" $DISCORD_WEBHOOK "Spawn 1.09b"
+  hellfire_101_diff:
+    docker:
+      - image: diasurgical/riivaaja:stable
+    environment:
+      MAKE_BUILD: pdb
+      HELLFIRE: 1
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run: make -f MakefileVC
+      - run: wget https://github.com/diasurgical/devilution-comparer/releases/download/v0.4.0/devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
+      - run: tar xf devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
+      - run: dd if=/dev/zero bs=1 count=3072 of=hellfire.exe
+      - run: dd if=Diablo.exe >> hellfire.exe
+      - run: mv comparer-config/hellfire.toml comparer-config.toml
+      - run: ./devilution-comparer generate-full hellfire.exe --no-mem-disp --truncate-to-original
+      - run: ../hellfire-status.sh
+      - run: .travis/are-we-d1-yet.sh "$(< accuracy.txt)" $DISCORD_WEBHOOK "Hellfire 1.01"
+
+workflows:
+  version: 2
+  testflow:
+    jobs:
+      - diablo_109b
+      - diablo_109b_diff
+      - spawn_109b_diff
+      - hellfire_101_diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 
 os:
-  - linux
   - osx
 
 osx_image: xcode11.3
@@ -11,9 +10,6 @@ notifications:
     on_failure: change # default: always
 
 addons:
-  apt:
-    packages:
-      - mingw-w64
   homebrew:
     packages:
       - mingw-w64
@@ -26,78 +22,4 @@ script:
   - if [ $MAKE_BUILD = debug ]; then make debug; fi
 
 stages:
-  - Riivaaja
   - test
-
-jobs:
-  include:
-    - stage: Riivaaja
-      name: "Diablo 1.09b: original toolchain"
-      language: minimal
-      sudo: required
-      services:
-        - docker
-      addons: {}
-      script: docker run -v $(pwd):/root/devilution diasurgical/riivaaja:stable
-    - stage: Riivaaja
-      name: "Diablo 1.09b: Calculate binary accuracy"
-      language: minimal
-      sudo: required
-      services:
-        - docker
-      addons: {}
-      script:
-        - |
-          set -e
-          wget https://github.com/diasurgical/devilution-comparer/releases/download/v0.4.0/devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
-          tar xf devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
-          mv comparer-config/diablo.toml comparer-config.toml
-          echo '#!/bin/sh' | sudo tee /bin/wine
-          echo 'docker run -v $(pwd):/root/devilution --entrypoint "/usr/bin/wine" diasurgical/riivaaja:stable $(basename $1) $2 $3' | sudo tee --append /bin/wine
-          sudo chmod +x /bin/wine
-          docker run -v $(pwd):/root/devilution -e MAKE_BUILD=pdb diasurgical/riivaaja:stable
-          ./devilution-comparer generate-full Diablo.exe --no-mem-disp --truncate-to-original
-          docker run -v $(pwd):/root/devilution diasurgical/riivaaja:stable ../status.sh
-          .travis/are-we-d1-yet.sh "$(< accuracy.txt)" $DISCORD_WEBHOOK "Diablo 1.09b"
-    - stage: Riivaaja
-      name: "Spawn 1.09: Calculate binary accuracy"
-      language: minimal
-      sudo: required
-      services:
-        - docker
-      addons: {}
-      script:
-        - |
-          set -e
-          wget https://github.com/diasurgical/devilution-comparer/releases/download/v0.4.0/devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
-          tar xf devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
-          mv comparer-config/spawn.toml comparer-config.toml
-          echo '#!/bin/sh' | sudo tee /bin/wine
-          echo 'docker run -v $(pwd):/root/devilution --entrypoint "/usr/bin/wine" diasurgical/riivaaja:stable $(basename $1) $2 $3' | sudo tee --append /bin/wine
-          sudo chmod +x /bin/wine
-          docker run -v $(pwd):/root/devilution -e MAKE_BUILD=pdb -e SPAWN=1 diasurgical/riivaaja:stable
-          ./devilution-comparer generate-full Diablo.exe --no-mem-disp --truncate-to-original
-          docker run -v $(pwd):/root/devilution diasurgical/riivaaja:stable ../spawn-status.sh
-          .travis/are-we-d1-yet.sh "$(< accuracy.txt)" $DISCORD_WEBHOOK "Spawn 1.09b"
-    - stage: Riivaaja
-      name: "Hellfire 1.01: Calculate binary accuracy"
-      language: minimal
-      sudo: required
-      services:
-        - docker
-      addons: {}
-      script:
-        - |
-          set -e
-          wget https://github.com/diasurgical/devilution-comparer/releases/download/v0.4.0/devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
-          tar xf devilution-comparer-v0.4.0-x86_64-unknown-linux-gnu.tar.xz
-          mv comparer-config/hellfire.toml comparer-config.toml
-          echo '#!/bin/sh' | sudo tee /bin/wine
-          echo 'docker run -v $(pwd):/root/devilution --entrypoint "/usr/bin/wine" diasurgical/riivaaja:stable $(basename $1) $2 $3' | sudo tee --append /bin/wine
-          sudo chmod +x /bin/wine
-          docker run -v $(pwd):/root/devilution -e MAKE_BUILD=pdb -e HELLFIRE=1 diasurgical/riivaaja:stable
-          dd if=/dev/zero bs=1 count=3072 of=hellfire.exe
-          dd if=Diablo.exe >> hellfire.exe
-          ./devilution-comparer generate-full hellfire.exe --no-mem-disp --truncate-to-original
-          docker run -v $(pwd):/root/devilution diasurgical/riivaaja:stable ../hellfire-status.sh
-          .travis/are-we-d1-yet.sh "$(< accuracy.txt)" $DISCORD_WEBHOOK "Hellfire 1.01"


### PR DESCRIPTION
Probably this will fail to run both the compare and are-we-d1 steps as stands because of missing dependencies (bash, rust)