### PR TITLE
monster: add BUGFIX for M_FallenFear

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -5993,6 +5993,7 @@ void M_FallenFear(int x, int y)
 		    && monster[mi]._mhitpoints >> 6 > 0) {
 			monster[mi]._mgoal = MGOAL_RETREAT;
 			monster[mi]._mgoalvar1 = rundist;
+			// BUGFIX: should be `monster[mi]`, was `monster[i]`.
 			monster[mi]._mdir = GetDirection(x, y, monster[i]._mx, monster[i]._my);
 		}
 	}


### PR DESCRIPTION
The index used to access monster was incorrect for the fallen
one flee behaviour. The AI should make fallen ones flee from
the direction of the monster which got hit. Right now, it's
random as the wrong index is used.