### PR TITLE
towners: add BUGFIX for ProcessTowners

### DIFF
--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -701,6 +701,7 @@ void ProcessTowners()
 {
 	int i, ao;
 
+	// BUGFIX: should be `i < numtowners`, was `i < NUM_TOWNERS`.
 	for (i = 0; i < NUM_TOWNERS; i++) {
 		switch (towner[i]._ttype) {
 		case TOWN_SMITH:


### PR DESCRIPTION
Only active towners should be processed in ProcessTowners, not
the entire array. For reference logic see GetActiveTowner.