### PR TITLE
Bugfix: MaxGold shouldn't depend on auricGold.

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -22,7 +22,7 @@ CornerStoneStruct CornerStone;
 BYTE *itemanims[ITEMTYPES];
 BOOL UniqueItemFlag[128];
 #ifdef HELLFIRE
-int auricGold = 10000;
+int auricGold = GOLD_MAX_LIMIT * 2;
 #endif
 int numitems;
 int gnNumGetRecords;


### PR DESCRIPTION
MaxGold is set to GOLD_MAX_LIMIT in line 59, but the reassignment to auricGold / 2 in line 1149 always overrides this.

This patch makes auricGold depend on GOLD_MAX_LIMIT, instead of the other way around.
The change doesn't affect the behavior of the software, but clears up the intention of the code.
Also, less importantly, a private change to GOLD_MAX_LIMIT will lead to unexpected behavior with the current code.

The change is a compile time constant that evaluates to the same value that is hard coded now. It should not affect the binary.