### PR TITLE
objects: add BUGFIX for OperateBookCase

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4321,7 +4321,7 @@ void OperateBookCase(int pnum, int i, DIABOOL sendmsg)
 			    && monster[MAX_PLRS]._msquelch == UCHAR_MAX
 			    && monster[MAX_PLRS]._mhitpoints) {
 				monster[MAX_PLRS].mtalkmsg = TEXT_ZHAR2;
-				M_StartStand(0, monster[MAX_PLRS]._mdir);
+				M_StartStand(0, monster[MAX_PLRS]._mdir); // BUGFIX: first parameter in call to M_StartStand should be MAX_PLRS, not 0.
 				monster[MAX_PLRS]._mgoal = MGOAL_ATTACK2;
 				monster[MAX_PLRS]._mmode = MM_TALK;
 			}


### PR DESCRIPTION
The monster array index should refer to Zhar the Mad, not the
first Golem.