### PR TITLE
player: add BUGFIX for CheckNewPath

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3653,6 +3653,7 @@ void CheckNewPath(int pnum)
 
 					if (x < 2 && y < 2) {
 						ClrPlrPath(pnum);
+						// BUGFIX: missing check for `destAction == ACTION_ATTACKMON` in if-statement of `TalktoMonster` branch.
 						if (monster[i].mtalkmsg && monster[i].mtalkmsg != TEXT_VILE14) {
 							TalktoMonster(i);
 						} else {


### PR DESCRIPTION
Without this BUGFIX, pathing towards and attacking a hostile
player with player index 0 (through 3) would trigger the speech
dialogue of a corresponding monster 0 (through 3), should they
have speeches activated. Given that the first 4 monster indices
are reserved for Golems, this BUG would trigger if a golem was
killed, and given the incorrect implementation of pseudo delete
of golems in DeleteMonsterList failing to reserve the golem
monster indices, and a new monster was spawned (e.g. by King
Leoric) thus taking a "golem" monster index. Given this scenario,
attacking a player could trigger a speech dialogue (well, that is
if the spawned monsters had speech dialogues activated).