### PR TITLE
Correct missile ring offset

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -4470,8 +4470,8 @@ void mi_fire_ring(int i)
 		lvl = currlevel;
 	dmg = 16 * (random_(53, 10) + random_(53, 10) + lvl + 2) >> 1;
 	for (j = CrawlTable[b]; j > 0; j--, k += 2) {
-		tx = missile[i]._miVar1 + CrawlTable[k - 1];
-		ty = missile[i]._miVar2 + CrawlTable[k];
+		tx = missile[i]._miVar1 + CrawlTable[k];
+		ty = missile[i]._miVar2 + CrawlTable[k + 1];
 		if (tx > 0 && tx < MAXDUNX && ty > 0 && ty < MAXDUNY) {
 			dp = dPiece[tx][ty];
 			if (!nSolidTable[dp] && dObject[tx][ty] == 0) {
@@ -4501,8 +4501,8 @@ void mi_light_ring(int i)
 		lvl = currlevel;
 	dmg = 16 * (random_(53, 10) + random_(53, 10) + lvl + 2) >> 1;
 	for (j = CrawlTable[b]; j > 0; j--, k += 2) {
-		tx = missile[i]._miVar1 + CrawlTable[k - 1];
-		ty = missile[i]._miVar2 + CrawlTable[k];
+		tx = missile[i]._miVar1 + CrawlTable[k];
+		ty = missile[i]._miVar2 + CrawlTable[k + 1];
 		if (tx > 0 && tx < MAXDUNX && ty > 0 && ty < MAXDUNY) {
 			dp = dPiece[tx][ty];
 			if (!nSolidTable[dp] && dObject[tx][ty] == 0) {


### PR DESCRIPTION
Without this this the relative offsets used are wrong:
Before:
![image](https://user-images.githubusercontent.com/204594/124395870-dea79900-dd06-11eb-9203-c499a1cf71c3.png)
After:
![image](https://user-images.githubusercontent.com/204594/124395879-ebc48800-dd06-11eb-9d57-c682f6e72617.png)
