### PR TITLE
items: add BUGFIX, item get records not reset when resetting items

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -669,6 +669,8 @@ void InitItems()
 	}
 
 	uitemflag = FALSE;
+
+	// BUGFIX: item get records not reset when resetting items.
 }
 
 void CalcPlrItemVals(int p, BOOL Loadgfx)


### PR DESCRIPTION
The item get record array tracks items being recently looted in an
effort to prevent the same item from being looted more than once.
Prior to this commit, the item get record array (and corresponding
item get record array length) variables were not cleared when
creating a new game. Therefore, the item get record array of a
previous game could remain in between games and prevent an item
from being looted (if it was looted in a previous), even if it was
never looted in the current game. In practice this almost never
shows up, since each item get record is valid for a total of 6
seconds before being cleared. So, you would either have to save
a game, quickly loot an item, when load the game and try to loot
the same item before 6 seconds pass. OR, you could use the demo
replay functionality to run test cases, and speed up execution to
run e.g. 10'000'000 logic ticks per second. Both would exhibit the
bug and prevent the item from being looted.

ref: diasurgical/devilutionX#2691