### PR TITLE
objects: add BUGFIX for holy shrine

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3919,6 +3919,7 @@ void OperateShrine(int pnum, int i, int sType)
 			yy = random_(159, MAXDUNY);
 			lv = dPiece[xx][yy];
 			j++;
+			// BUGFIX: should not cast phasing if still on bad tile after max amount of tries.
 			if (j > MAXDUNX * MAXDUNY)
 				break;
 		} while (nSolidTable[lv] || dObject[xx][yy] != 0 || dMonster[xx][yy] != 0);


### PR DESCRIPTION
If the random number generator ends up giving X-Y coordinate pairs
that always are on bad tiles (e.g. solid, with object or with monster)
then after a total of MAXDUNX * MAXDUNY tries, it will still cast
phasing to teleport to the bad tile.