### PR TITLE
items: add BUGFIX for GetItemRecord when handling quest items

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -5998,6 +5998,7 @@ BOOL GetItemRecord(int nSeed, WORD wCI, int nIndex)
 
 	for (i = 0; i < gnNumGetRecords; i++) {
 		if (dwTicks - itemrecord[i].dwTimestamp > 6000) {
+			// BUGFIX: loot actions for multiple quest items with same seed (e.g. blood stone) performed within less then 6 seconds will be ignored.
 			NextItemRecord(i);
 			i--;
 		} else if (nSeed == itemrecord[i].nSeed && wCI == itemrecord[i].wCI && nIndex == itemrecord[i].nIndex) {


### PR DESCRIPTION
When spawing quest items (e.g. blood stone), no unique seed is set
for the item. Therefor two quest items may share the same seed, this
happens deterministically for the Valor quest, since three blood stones
are spawned, each with item seed 0x00000000.

For this reason, if two or more such quest items with identical seed are
looted within less than 6 seconds, the 2nd, 3rd, etc loot actions are
ignored.