### PR TITLE
items: add BUGFIX for SpawnWitch

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -5316,6 +5316,12 @@ void SpawnWitch(int lvl)
 		}
 	}
 #else
+	// BUGFIX: was `random_(51, 8) + 10`, should be `random_(51, 7) + 10`. The
+	// last entry in the witchitem array must have item type ITYPE_NONE
+	// (e.g. required by SortWitch, thus there may be at most 19 items
+	// generated. 3 items are always generated(mana, full mana and town portal),
+	// leaving at most 16 items. `random_(51, 8) + 10` gives a value in range
+	// from 10 to 17, inclusive. In other words, one too many.
 	iCnt = random_(51, 8) + 10;
 #endif
 


### PR DESCRIPTION
The logic handling the list of items for sale by Adria is broken. In
particular, the logic of SortWitch requires the list to end with an
item having item type ITYPE_NONE.

From SortWitch:

```cpp
	j = 3;
	while (witchitem[j + 1]._itype != ITYPE_NONE) {
		j++;
	}
```

However, this puts a limit (19) on the maximum number of items being
generated for the witchitem array (of length 20). The problem is that
SpawnWitch may generate 20 items if `iCnt = 17`, as made possible by
the following statement.

```cpp
	iCnt = random_(51, 8) + 10;
```

Since there are 3 items that are always generated (mana, full mana
and town portal), the total number of items generated by SpawnWitch
may be 20, which exceeds the limit (19), thus causing the logic of
SortWitch to go haywire and results in a buffer overflow.