### PR TITLE
Migrate macOS CI to GitHub Actions

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -1,0 +1,23 @@
+name: macOS Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    
+
+jobs:
+  xcode:
+    runs-on: macos-11
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: brew install mingw-w64
+
+      - name: Build
+        run: make -j8
+
+      


### PR DESCRIPTION
## What is changed?
- Adds macOS GitHub Actions CI

## Related Issue
Closes #2192 

## How to test?
- Enable GitHub Actions.
- Then force start this workflow.

## Test Runs
A test run can be seen here: https://github.com/avinal/devilution/runs/3961319252?check_suite_focus=true

Signed-off-by: Avinal Kumar <avinal.xlvii@gmail.com>