### PR TITLE
items: add BUGFIX for RndItem, invalid logic for Scroll of Resurrect

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2664,6 +2664,9 @@ int RndItem(int m)
 			ril[ri] = i;
 			ri++;
 		}
+		// BUGFIX: ri decremented even for IDROP_NEVER, thus Scroll of Resurrect
+		// (IDI_RESURRECT) decrements ri, unintentionally removing gold drop in
+		// Single Player (gold drop is still valid in Multi Player).
 		if (AllItemsList[i].iSpell == SPL_RESURRECT && gbMaxPlayers == 1)
 			ri--;
 		if (AllItemsList[i].iSpell == SPL_HEALOTHER && gbMaxPlayers == 1)


### PR DESCRIPTION
Scroll of Resurrect occurs twice in the item data list, firstly at
IDI_RESURRECT with IDROP_NEVER, and secondly a regular item with
IDROP_REGULAR.

Since the ri-- logic only checks for spell ID, ri will be decremented
also for IDROP_NEVER; thus unintentionally removing the previously added
valid item ID in Single Player (which is this case is always gold).

Therefore, the chance for gold drop is higher in Multi Player than
Single Player.