### PR TITLE
msg: add BUGFIX for delta_kill_monster

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -461,6 +461,7 @@ void delta_kill_monster(int mi, BYTE x, BYTE y, BYTE bLevel)
 	DMonsterStr *pD = &sgLevels[bLevel].monster[mi];
 	pD->_mx = x;
 	pD->_my = y;
+	// BUGFIX: should only sync monster direction if bLevel is same as currlevel.
 	pD->_mdir = monster[mi]._mdir;
 	pD->_mhitpoints = 0;
 }


### PR DESCRIPTION
The monster direction is synced even if the receiving player is not
on the same dungeon level as the player killing the monster.

Note, this happens, even if one player is in town, and the other
kills a monster at e.g. dlvl=1. Then the code will check the
monster at index mi even for the player in town, so it will just
read garbage data from memory.