### PR TITLE
monster: add BUGFIX for MAI_Fallen, invalid out-of-bounds check

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4206,6 +4206,7 @@ void MAI_Fallen(int i)
 			for (x = -rad; x <= rad; x++) {
 				xpos = Monst->_mx + x;
 				ypos = Monst->_my + y;
+				// BUGFIX: should check `xpos` and `ypos` for out-of-bounds, was checking `x` and `y`.
 				if (y >= 0 && y < MAXDUNY && x >= 0 && x < MAXDUNX) {
 					m = dMonster[xpos][ypos];
 					if (m > 0) {


### PR DESCRIPTION
The out-of-bounds check in MAI_Fallen checks whether the relative
offset coordinates (x, y) are out of bounds, rather than the
absoulte coordinate (xpos, ypos) which is used for array access
into dMonster.