### PR TITLE
add hellfire lightning wall rune dmg calc

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -75,6 +75,9 @@ void GetDamageAmt(int i, int *mind, int *maxd)
 		*mind = -1;
 		*maxd = -1;
 		break;
+#ifdef HELLFIRE
+	case SPL_RUNELIGHT:
+#endif
 	case SPL_LIGHTNING:
 		*mind = 2;
 		*maxd = plr[myplr]._pLevel + 2;


### PR DESCRIPTION
This change doesn't affect asm and it's more likely it was in the code - the actual problem with no dmg lightning wall rune was that the rune never read these values.