### PR TITLE
objects: add BUGFIX for InitObjects

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1091,6 +1091,7 @@ void InitObjects()
 				quests[Q_BLIND]._qmsg = sp_id;
 				AddBookLever(0, 0, MAXDUNX, MAXDUNY, setpc_x, setpc_y, setpc_w + setpc_x + 1, setpc_h + setpc_y + 1, sp_id);
 				mem = LoadFileInMem("Levels\\L2Data\\Blind2.DUN", NULL);
+				// BUGFIX: should not invoke LoadMapObjs for Blind2.DUN, as Blind2.DUN is missing an objects layer.
 				LoadMapObjs(mem, 2 * setpc_x, 2 * setpc_y);
 				mem_free_dbg(mem);
 			}


### PR DESCRIPTION
Don't load objects from Blind2.DUN, as Blind2.DUN is missing an objects layer. This may results in an out-of-bounds read.