### PR TITLE
missiles: add BUGFIX for MI_Element and MI_Bonespirit

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -5797,6 +5797,7 @@ void MI_Element(int i)
 		if (missile[i]._miVar3 == 1) {
 			missile[i]._miVar3 = 2;
 			missile[i]._mirange = 255;
+			// BUGFIX: should be `mid >= 0`, was `mid > 0`; FindClosest returns -1 if no monster is found.
 			mid = FindClosest(cx, cy, 19);
 			if (mid > 0) {
 				sd = GetDirection8(cx, cy, monster[mid]._mx, monster[mid]._my);
@@ -5849,6 +5850,7 @@ void MI_Bonespirit(int i)
 		if (missile[i]._miVar3 == 1) {
 			missile[i]._miVar3 = 2;
 			missile[i]._mirange = 255;
+			// BUGFIX: should be `mid >= 0`, was `mid > 0`; FindClosest returns -1 if no monster is found.
 			mid = FindClosest(cx, cy, 19);
 			if (mid > 0) {
 				missile[i]._midam = monster[mid]._mhitpoints >> 7;


### PR DESCRIPTION
The Elemental and Bone Spirit spells tries to locate the closest monster at each logic tick, to update the direction of the spell. This is done using the FindClosest function, which returns the monster array index of the closest monster; or -1 if no monster is located.

The callee of FindClosest checks if `mid > 0`, and as such does not handle the monster array index 0 case. Since this case is known to be the Golem of player 1, perhaps this is intentional. If so, the FindClosest function should instead be updated to find the closest monster that is NOT a Golem; as the current code will simply fail to find other monsters if there is a Golem of player 1 closer. It will also handle Golems of other players differently than player 1 (regardless of PvP settings).