### PR TITLE
inv: add BUGFIX for CheckInvCut

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1634,6 +1634,7 @@ void CheckInvCut(int pnum, int mx, int my)
 		if (pnum == myplr) {
 			PlaySFX(IS_IGRAB);
 			SetCursor_(plr[pnum].HoldItem._iCurs + CURSOR_FIRSTITEM);
+			// BUGFIX: should be `my - (cursH >> 1)`, was `MouseY - (cursH >> 1)`.
 			SetCursorPos(mx - (cursW >> 1), MouseY - (cursH >> 1));
 		}
 	}


### PR DESCRIPTION
For consistency, use (mx, my) parameters in call to SetCursorPos. As all callers of CheckInvCut pass (MouseX, MouseY) as arguments, this BUGFIX is only for consistency, there is no functional change.