### PR TITLE
drlg_l1: add BUGFIX for DRLG_PlaceMiniSet

### DIFF
--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -972,6 +972,7 @@ static int DRLG_PlaceMiniSet(const BYTE *miniset, int tmin, int tmax, int cx, in
 	sw = miniset[0];
 	sh = miniset[1];
 
+	// BUGFIX: should be `numt = tmin`, was `numt = 1`.
 	if (tmax - tmin == 0)
 		numt = 1;
 	else


### PR DESCRIPTION
Prior to this commit, invoking DRLG_PlaceMiniSet with say min=5, max=5 would result in just 1 miniset being generated, not 5 as expected.