### PR TITLE
drlg_l1: add BUGFIX for DRLG_L5

### DIFF
--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -2728,11 +2728,13 @@ static void DRLG_L5(int entry)
 			}
 #else
 		} else if (entry == ENTRY_MAIN) {
+			// BUGFIX: missing doneflag check before call to DRLG_PlaceMiniSet. PoC: triggered by (dlvl=2, seed=0x0000007B, quest=Poisoned Water Supply).
 			if (DRLG_PlaceMiniSet(L5STAIRSUP, 1, 1, 0, 0, TRUE, -1, 0) < 0)
 				doneflag = FALSE;
 			else if (DRLG_PlaceMiniSet(STAIRSDOWN, 1, 1, 0, 0, FALSE, -1, 1) < 0)
 				doneflag = FALSE;
 		} else {
+			// BUGFIX: missing doneflag check before call to DRLG_PlaceMiniSet.
 			if (DRLG_PlaceMiniSet(L5STAIRSUP, 1, 1, 0, 0, FALSE, -1, 0) < 0)
 				doneflag = FALSE;
 			else if (DRLG_PlaceMiniSet(STAIRSDOWN, 1, 1, 0, 0, TRUE, -1, 1) < 0)


### PR DESCRIPTION
When generating dlvl=2 dungeons containing a
staircase down to the Poisoned Water Supply,
a check is missing to ensure that doneflag
is not set to FALSE by the first call to
DRLG_PlaceMiniSet(PWATERIN, ...).

If that was the case, then a second call to
DRLG_PlaceMiniSet may be made, to place
L5STAIRSUP even though doneflag may have been
set to FALSE.

For the correct logic, cross reference against
the drlg_l2 code for placing staircases using
DRLG_L2PlaceMiniSet.

For a PoC triggering the incorrect behaviour,
see dlvl=2, seed=0x0000007B with
quest=Poisoned Water Supply active.