### PR TITLE
monster: add BUGFIX for ClrAllMonsters

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -656,6 +656,7 @@ void ClrAllMonsters()
 		Monst->_mFlags = 0;
 		Monst->_mDelFlag = FALSE;
 		Monst->_menemy = random_(89, gbActivePlayers);
+		// BUGFIX: `Monst->_menemy` may be referencing a player who already left the game, thus reading garbage data from `plr[Monst->_menemy]._pfutx`.
 		Monst->_menemyx = plr[Monst->_menemy]._pfutx;
 		Monst->_menemyy = plr[Monst->_menemy]._pfuty;
 	}


### PR DESCRIPTION
I believe monsters should all update their targets within a couple seconds because `UpdateEnemy()` is called at the end of a monster's idle animation so perhaps the value it's initialized to here doesn't actually matter. In that case, maybe just setting them to zero would be better.