### PR TITLE
diablo: add BUGFIX for LoadGameLevel

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1971,6 +1971,13 @@ void LoadGameLevel(BOOL firstflag, int lvldir)
 		LoadSetMap();
 		IncProgress();
 		GetLevelMTypes();
+
+		// BUGFIX: must invoke FillSolidBlockTbls prior to invoking InitMonsters,
+		// as placement of unique monsters in set levels require initialization
+		// of nSolidTable. In particular, InitMonsters -> PlaceQuestMonsters ->
+		// PlaceUniqueMonst -> MonstPlace -> SolidLoc, which requires nSolidTable
+		// to be initialized.
+
 		InitMonsters();
 		InitMissileGFX();
 		InitDead();


### PR DESCRIPTION
An incorrect placement of unique monsters was used in set levels when entering through Town Portal from Tristram (or entering from a dungeon level with different dungeon type).

To reproduce, use a Town Portal to enter any set level containing unique monsters (e.g. Skeleton King's Lair or Archbishop Lazarus' Lair).

As LoadGameLevel invokes InitMonsters without first invoking FillSolidBlockTbls for set levels, the nSolidTable will contain garbage data (the collision mapping for mini tiles of the _previous_ dungeon type, NOT the current dungeon type).