### PR TITLE
Add Diablo Version 1.08-Specific Behavior with Preprocessor Directives

### DIFF
--- a/MakefileVC
+++ b/MakefileVC
@@ -51,16 +51,16 @@ endif
 CFLAGS=/nologo /c /GX /W3 /O1 /I $(VC_INC_DIR) /FD /Gr /MT /D "NDEBUG" /D "WIN32" /D "_WINDOWS" /Fp"Diablo.pch" /YX /G5 /Zi /FAs
 LINKFLAGS=/nologo /subsystem:windows /machine:I386 /incremental:no
 
+VERSION := 109
+
+CFLAGS += /D "VERSION=$(VERSION)"
+
 ifeq ($(HELLFIRE),1)
 	CFLAGS += /D "HELLFIRE"
 endif
 
 ifeq ($(SPAWN),1)
 	CFLAGS += /D "SPAWN"
-endif
-
-ifeq ($(V108),1)
-	CFLAGS += /D "V108"
 endif
 
 ifeq ($(MAKE_BUILD),pdb)

--- a/MakefileVC
+++ b/MakefileVC
@@ -61,6 +61,7 @@ endif
 
 ifeq ($(V108),1)
 	CFLAGS += /D "V108"
+endif
 
 ifeq ($(MAKE_BUILD),pdb)
 ifeq ($(HELLFIRE),1)

--- a/MakefileVC
+++ b/MakefileVC
@@ -59,6 +59,9 @@ ifeq ($(SPAWN),1)
 	CFLAGS += /D "SPAWN"
 endif
 
+ifeq ($(V108),1)
+	CFLAGS += /D "V108"
+
 ifeq ($(MAKE_BUILD),pdb)
 ifeq ($(HELLFIRE),1)
 	VC_LINK = $(VC5_LINK)

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -102,7 +102,7 @@ int path_get_h_cost(int sx, int sy, int dx, int dy)
 	int max = delta_x > delta_y ? delta_x : delta_y;
 
 	// see path_check_equal for why this is times 2
-#ifdef V108
+#if VERSION == 108
 	return min + (2 * max);
 #else
 	return 2 * (min + max);

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -102,7 +102,11 @@ int path_get_h_cost(int sx, int sy, int dx, int dy)
 	int max = delta_x > delta_y ? delta_x : delta_y;
 
 	// see path_check_equal for why this is times 2
+#ifdef v108
+	return min + (2 * max);
+#else
 	return 2 * (min + max);
+#endif
 }
 
 /**

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -102,7 +102,7 @@ int path_get_h_cost(int sx, int sy, int dx, int dy)
 	int max = delta_x > delta_y ? delta_x : delta_y;
 
 	// see path_check_equal for why this is times 2
-#ifdef v108
+#ifdef V108
 	return min + (2 * max);
 #else
 	return 2 * (min + max);


### PR DESCRIPTION
Build for version 1.08 binary. The difference between v1.09b and v1.08 is weighting in pathfinding, and fixing sound issues, however nothing in the original source had been changed between v1.09 and v1.09b, but rather using a different version of the directsound API

v1.08 `path_get_h_cost()` is found at 0x44A911
v1.09/v1.09b `path_get_h_cost()` is found at 0x4494D3

```
  1. CHANGES FROM 1.09 TO 1.09b
     (download only, not an automatic battle.net update)

        A. Fixed sound problem with Windows NT 4.

  2. CHANGES FROM 1.08 TO 1.09

        A. Fixed some Battle.net issues.
 
 Medium bugs (affecting gameplay)
        B. Reverted a change made in 1.08 that, while correctly calculated
           distance, caused unintended gameplay issues.
           ```