### PR TITLE
Remove global optimizations for SHA1ProcessMessageBlock()

### DIFF
--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -24,6 +24,13 @@ static void SHA1Init(SHA1Context *context)
 	context->state[4] = 0xC3D2E1F0;
 }
 
+// Global Optimizations (/Og) cause the compiler to interpret
+// `SHA1CircularShift(5, A)` as `ror edx, 0x1b`, as if A were an unsigned integer.
+// This results in save files being incompatible between vanilla and MSVC Release builds.
+#if (_MSC_VER >= 1930) && NDEBUG
+#pragma optimize("g", off)
+#endif
+
 static void SHA1ProcessMessageBlock(SHA1Context *context)
 {
 	int i, temp;
@@ -86,6 +93,10 @@ static void SHA1ProcessMessageBlock(SHA1Context *context)
 	context->state[3] += D;
 	context->state[4] += E;
 }
+
+#if (_MSC_VER >= 1930) && NDEBUG
+#pragma optimize("g", on)
+#endif
 
 static void SHA1Input(SHA1Context *context, const char *message_array, int len)
 {


### PR DESCRIPTION
I recently noticed that save files from my Debug builds in Visual Studio 2022 were incompatible with my Release builds and vice-versa. I tracked it down to the Global Optimizations flag (`/Og`) in the compiler, which is included in the list of optimizations turned on by both `/O1` and `/O2`.

My version of MSVC in VS2022 is `_MSC_VER == 1939`. I figured this was caused by a fairly recent change in MSVC so I tested in VS2019 `_MSC_VER == 1929` as well. The optimization works fine in VS2019 so in lieu of trying to install and test every version of VS2022 to narrow it down further, I just disabled the optimization for this one function for all versions of VS2022.