### PR TITLE
themes: add BUGFIX for SpecialThemeFit

### DIFF
--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -341,7 +341,7 @@ BOOL SpecialThemeFit(int i, int t)
 		}
 		break;
 	case THEME_TREASURE:
-		rv = treasureFlag;
+		rv = treasureFlag; // BUGFIX: treasureFlag overwrites results from CheckThemeReqs, causing treasure theme to always be valid (regardless of requirements).
 		if (rv) {
 			treasureFlag = FALSE;
 		}


### PR DESCRIPTION
The treasureFlag global variable overwrites results from CheckThemeReqs in SpecialThemeFit, causing treasure theme to always be valid (regardless of requirements).