### PR TITLE
lighting: add BUGFIX for MakeLightTable

### DIFF
--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -1003,6 +1003,9 @@ void MakeLightTable()
 					fs = (BYTE)sqrt((8 * l - j) * (8 * l - j) + (8 * k - i) * (8 * k - i));
 					fs += fs < 0 ? -0.5 : 0.5;
 
+					// BUGFIX: This error causes a "jittery" effect when a light source moves.
+					// Swap the addition and multiplication operators to fix the lookup table.
+					// lightblock[j + 8 * i][k][l] = fs;
 					lightblock[j * 8 + i][k][l] = fs;
 				}
 			}


### PR DESCRIPTION
The i/j/k/l variables obfuscate the fact that the distance formula used for generating data in lightblock is using the x offset with the y component of the tile coordinate and vice-versa.

Mixing x and y this way causes light to move horizontally within a tile when the light source is moving vertically and vice-versa.

---

To verify, if you check the places where `lightblock` is used, the code looks something like this.
`lightblock[xoff + 8*yoff][y][x]`

Compared to that, the addition and multiplication operators are swapped in `lightblock[j * 8 + i][k][l]`, therefore it suggests the following relationships.
* `i = xoff`
* `j = yoff`
* `k = y`
* `l = x`

Subtituting these into the distance formula just a few lines up, we get:
`sqrt((8 * x - yoff) * (8 * x - yoff) + (8 * y - xoff) * (8 * y - xoff))`

In this formula, you can clearly see that the x and y terms are being mixed up, and swapping `i` and `j` in the equation above would swap the `xoff` and `yoff` terms in the formula. Swapping the addition and multiplication operators gives the same result, but it also matches the code in the places where `lightblock` is used.

See:

https://github.com/diasurgical/devilution/blob/6b7135cec37e9cf0f6740d7e1a1ec880f89e73ff/Source/lighting.cpp#L571