### PR TITLE
missiles: add BUGFIX for flame wave light radius

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -4996,6 +4996,8 @@ void MI_Firemove(int i)
 		if (missile[i]._mix != missile[i]._miVar3 || missile[i]._miy != missile[i]._miVar4) {
 			missile[i]._miVar3 = missile[i]._mix;
 			missile[i]._miVar4 = missile[i]._miy;
+			// BUGFIX: Flame wave gets darker after reaching full height.
+			// ChangeLightXY(missile[i]._mlid, missile[i]._miVar3, missile[i]._miVar4);
 			ChangeLight(missile[i]._mlid, missile[i]._miVar3, missile[i]._miVar4, 8);
 		}
 	} else {


### PR DESCRIPTION
Flame wave gets darker after reaching full height because of the hardcoded light radius in this branch of the code.